### PR TITLE
Avoid using geometry_sculpt in test macros and other examples.

### DIFF
--- a/macros/checkoverlap.mac
+++ b/macros/checkoverlap.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/pionwall/moller_lead_wall_100mm.in
+++ b/macros/pionwall/moller_lead_wall_100mm.in
@@ -4,7 +4,7 @@
 #/tracking/storeTrajectory 1
 
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/pionwall/pion_lead_wall_100mm.in
+++ b/macros/pionwall/pion_lead_wall_100mm.in
@@ -4,7 +4,7 @@
 #/tracking/storeTrajectory 1
 
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/printgeometry.mac
+++ b/macros/printgeometry.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/sim_dump_backscatter.mac
+++ b/macros/sim_dump_backscatter.mac
@@ -1,7 +1,7 @@
 #  Example file
 
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/sim_moller.mac
+++ b/macros/sim_moller.mac
@@ -8,7 +8,7 @@
 #/tracking/storeTrajectory 1
 
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/sim_pion.mac
+++ b/macros/sim_pion.mac
@@ -8,7 +8,7 @@
 #/tracking/storeTrajectory 1
 
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/tests/commit/test_beam.mac
+++ b/macros/tests/commit/test_beam.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/tests/commit/test_elastic.mac
+++ b/macros/tests/commit/test_elastic.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/tests/commit/test_elasticAl.mac
+++ b/macros/tests/commit/test_elasticAl.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/tests/commit/test_elasticAl_DS.mac
+++ b/macros/tests/commit/test_elasticAl_DS.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/tests/commit/test_elasticAl_US.mac
+++ b/macros/tests/commit/test_elasticAl_US.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/tests/commit/test_inelastic.mac
+++ b/macros/tests/commit/test_inelastic.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/tests/commit/test_inelasticAl.mac
+++ b/macros/tests/commit/test_inelasticAl.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/tests/commit/test_moller.mac
+++ b/macros/tests/commit/test_moller.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/tests/commit/test_pion.mac
+++ b/macros/tests/commit/test_pion.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/tests/commit/test_raster.mac
+++ b/macros/tests/commit/test_raster.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/tests/release/test_moller.mac
+++ b/macros/tests/release/test_moller.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize

--- a/macros/tests/unit/test_overlap.mac
+++ b/macros/tests/unit/test_overlap.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/geometry/setfile geometry_sculpt/mollerMother.gdml
+/remoll/geometry/setfile geometry/mollerMother.gdml
 
 # Read geometry silently
 /remoll/geometry/verbose 0

--- a/macros/tests/valgrind/test_moller.mac
+++ b/macros/tests/valgrind/test_moller.mac
@@ -1,5 +1,5 @@
 # This must be called before initialize
-/remoll/setgeofile geometry_sculpt/mollerMother.gdml
+/remoll/setgeofile geometry/mollerMother.gdml
 
 # This must be explicitly called
 /run/initialize


### PR DESCRIPTION
The 'proper' geometry is now in the `geometry` folder. There are
differences in the distributions at the scattering plane.

Will become next bugfix release.