### PR TITLE
Use correct units in remollGenExternal

### DIFF
--- a/src/remollGenExternal.cc
+++ b/src/remollGenExternal.cc
@@ -101,10 +101,10 @@ void remollGenExternal::SamplePhysics(remollVertex *vert, remollEvent *evt)
     }
 
     // Weighting completely handled by event file
-    evt->SetEffCrossSection(fEvent->xs);
+    evt->SetEffCrossSection(fEvent->xs*microbarn);
     evt->SetQ2(fEvent->Q2);
     evt->SetW2(fEvent->W2);
-    evt->SetAsymmetry(fEvent->A);
+    evt->SetAsymmetry(fEvent->A*ppb);
 
     // Loop over all hits in this event
     for (size_t i = 0; i < fHit->size(); i++) {


### PR DESCRIPTION
Bugfix, will cause fewer travis errors (I realize now).