### PR TITLE
Fixing trajectory storage to work for all possible generators' parent particles

### DIFF
--- a/include/remolltypes.hh
+++ b/include/remolltypes.hh
@@ -49,6 +49,7 @@ struct remollEventParticle_t {
   double sx, sy, sz;
   double th, ph, p;
   double tpx, tpy, tpz;
+  int trid;
   std::vector<double> tjx, tjy, tjz; //Trajectory information
 };
 

--- a/macros/runexample_envelope.mac
+++ b/macros/runexample_envelope.mac
@@ -3,7 +3,7 @@
 /remoll/setgeofile geometry/mollerMother_merged.gdml
 # This must be explicitly called
 /run/initialize
-/remoll/tracking/set 3
+/remoll/tracking/set 0
 /tracking/storeTrajectory 1
 /remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
 /remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
@@ -20,5 +20,5 @@
 /process/list
 # Specify random number seed - DO NOT USE THE SAME SEED OVER AND OVER AGAIN
 #/remoll/seed 123456
-/remoll/filename remoll_moller_envelope_1M.root
+/remoll/filename remoll_moller_envelope_10M.root
 /run/beamOn 1000000

--- a/src/remollEvent.cc
+++ b/src/remollEvent.cc
@@ -57,15 +57,22 @@ std::vector<remollEventParticle_t> remollEvent::GetEventParticleIO() const {
     part.tpx = fPartMom[idx].x();
     part.tpy = fPartMom[idx].y();
     part.tpz = fPartMom[idx].z();
+    part.trid = 0;
 
 //The following code stores the trajectories of primary particles    
     G4TrajectoryContainer* trajectoryContainer = 
 	G4RunManager::GetRunManager()->GetCurrentEvent()->GetTrajectoryContainer();
-    if(trajectoryContainer==0){}
-    
+
+
+    if(trajectoryContainer==0){
+    }
     else for(G4int i = 0; i < trajectoryContainer->entries(); i++){
 	//Only store trajectories of primary particles
-	if((*trajectoryContainer)[i]->GetTrackID() < 2){
+	//if((*trajectoryContainer)[i]->GetTrackID() < 2){
+	if(((*trajectoryContainer)[i]->GetParentID() == 0) && abs(((*trajectoryContainer)[i]->GetInitialMomentum().mag()-part.p))<0.001){
+    //G4cout<<"Trajectory container["<<i<<"]->GetInitialMomentum()->mag() = "<<(*trajectoryContainer)[i]->GetInitialMomentum().mag()<<" ==? part.p = "<<part.p<<G4endl;
+        //G4cout<<"Yes"<<G4endl;
+        part.trid = ((*trajectoryContainer)[i]->GetTrackID());
 		//Store each point in the container in the remollEventParticle_t structure
 		for(int j = 0; j<(*trajectoryContainer)[i]->GetPointEntries(); j++){
 			G4TrajectoryPoint* point = (G4TrajectoryPoint*)((*trajectoryContainer)[i]->GetPoint(j));

--- a/src/remollEvent.cc
+++ b/src/remollEvent.cc
@@ -76,6 +76,7 @@ std::vector<remollEventParticle_t> remollEvent::GetEventParticleIO() const {
           part.tjy.push_back(point->GetPosition()[1]);
           part.tjz.push_back(point->GetPosition()[2]);
         }
+        break;
       }
     }
     parts.push_back(part);

--- a/src/remollEvent.cc
+++ b/src/remollEvent.cc
@@ -57,7 +57,7 @@ std::vector<remollEventParticle_t> remollEvent::GetEventParticleIO() const {
     part.tpx = fPartMom[idx].x();
     part.tpy = fPartMom[idx].y();
     part.tpz = fPartMom[idx].z();
-    part.trid = 0;
+    part.trid = idx+1;
 
 //The following code stores the trajectories of primary particles    
     G4TrajectoryContainer* trajectoryContainer = 
@@ -67,20 +67,16 @@ std::vector<remollEventParticle_t> remollEvent::GetEventParticleIO() const {
     if(trajectoryContainer==0){
     }
     else for(G4int i = 0; i < trajectoryContainer->entries(); i++){
-	//Only store trajectories of primary particles
-	//if((*trajectoryContainer)[i]->GetTrackID() < 2){
-	if(((*trajectoryContainer)[i]->GetParentID() == 0) && abs(((*trajectoryContainer)[i]->GetInitialMomentum().mag()-part.p))<0.001){
-    //G4cout<<"Trajectory container["<<i<<"]->GetInitialMomentum()->mag() = "<<(*trajectoryContainer)[i]->GetInitialMomentum().mag()<<" ==? part.p = "<<part.p<<G4endl;
-        //G4cout<<"Yes"<<G4endl;
-        part.trid = ((*trajectoryContainer)[i]->GetTrackID());
-		//Store each point in the container in the remollEventParticle_t structure
-		for(int j = 0; j<(*trajectoryContainer)[i]->GetPointEntries(); j++){
-			G4TrajectoryPoint* point = (G4TrajectoryPoint*)((*trajectoryContainer)[i]->GetPoint(j));
-			part.tjx.push_back(point->GetPosition()[0]);
-			part.tjy.push_back(point->GetPosition()[1]);
-			part.tjz.push_back(point->GetPosition()[2]);
-		}
-	}
+      //Only store trajectories of primary particles
+      if(((*trajectoryContainer)[i]->GetParentID() == 0) && ((*trajectoryContainer)[i]->GetTrackID() == idx)){
+        //Store each point in the container in the remollEventParticle_t structure
+        for(int j = 0; j<(*trajectoryContainer)[i]->GetPointEntries(); j++){
+          G4TrajectoryPoint* point = (G4TrajectoryPoint*)((*trajectoryContainer)[i]->GetPoint(j));
+          part.tjx.push_back(point->GetPosition()[0]);
+          part.tjy.push_back(point->GetPosition()[1]);
+          part.tjz.push_back(point->GetPosition()[2]);
+        }
+      }
     }
     parts.push_back(part);
   }

--- a/variables.txt
+++ b/variables.txt
@@ -28,6 +28,7 @@ part.th		Particle initial polar angle [rad]
 part.ph		Particle initial azimuthal angle [rad]
 part.tp[xyz]	Particle "true" momentum (if no multiple scattering effects)
 part.tj[xyz]  Particle trajectories [mm]
+part.trid	Geant4 track ID number (1 = first particle created, stored per tj[xyz] entry)
 
 beam data - single variable:
 bm.[xyz]	Beam interaction vertex, lab frame [mm]


### PR DESCRIPTION
Trajectory storage was looking for trackID < 2 (was intended to be <= 2, for moller generator purposes) and was then storing all trajectoryContainer[i]->getPoint().x/y/z information into a part branch leaf. We have changed it to check whether the trajectoryContainer[i]'s initial momentum magnitude is == part.p variable (within 0.001 MeV) and then assign a new part.trid variable to this. There is no change in functionality, but now one can define some hypothetical generator with an arbitrary number of mother particles, all of which will get their own unique trajectories successfully stored.

Potential RAM or hard disk storage changes:
- New part.trid variable
- Properly segment part.tj[xyz] information into the correct part branch positions so no data is duplicated
- A few new conditional checks that could take a bit of time frequently