### PR TITLE
Geometry fixed hall center

### DIFF
--- a/geometry/mollerMother_dump.gdml
+++ b/geometry/mollerMother_dump.gdml
@@ -2,7 +2,7 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
   <define> 
-    <position name="hallCenter" x="0" y="0" z="4000"/>
+    <position name="hallCenter" x="0" y="0" z="6087."/>
     <position name="targetCenter" x="0" y="0" z="0"/>
     <position name="upstreamCenter" x="0" y="0" z="7000."/>
     <position name="trackingCenter" x="0" y="0" z="26635."/>

--- a/geometry/mollerMother_merged.gdml
+++ b/geometry/mollerMother_merged.gdml
@@ -2,7 +2,7 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
 <define> 
-  <position name="hallCenter" x="0" y="0" z="4000."/>
+  <position name="hallCenter" x="0" y="0" z="6087."/>
   <position name="targetCenter" x="0" y="0" z="0"/>
   <position name="targetCenter_Clamshell" x="0" y="200./2" z="0"/>
   <position name="upstreamCenter" x="0" y="0" z="7000."/>

--- a/geometry/mollerMother_noShlds.gdml
+++ b/geometry/mollerMother_noShlds.gdml
@@ -2,7 +2,7 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
 <define> 
-  <position name="hallCenter" x="0" y="0" z="4000"/>
+  <position name="hallCenter" x="0" y="0" z="6087."/>
   <position name="targetCenter" x="0" y="0" z="0"/>
   <position name="upstreamCenter" x="0" y="0" z="7000."/>
   <position name="hybridCenter" x="0" y="0" z="13366.57"/>

--- a/geometry/mollerMother_parametrized.gdml
+++ b/geometry/mollerMother_parametrized.gdml
@@ -2,7 +2,7 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
 <define> 
-  <position name="hallCenter" x="0" y="0" z="4000"/>
+  <position name="hallCenter" x="0" y="0" z="6087."/>
   <position name="targetCenter" x="0" y="0" z="0"/>
   <position name="upstreamCenter" x="0" y="0" z="7000."/>
   <position name="hybridCenter" x="0" y="0" z="13366.57"/>

--- a/geometry/mollerMother_showerMaxOnly.gdml
+++ b/geometry/mollerMother_showerMaxOnly.gdml
@@ -2,7 +2,7 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
   <define> 
-    <position name="hallCenter" x="0" y="0" z="4000"/>
+    <position name="hallCenter" x="0" y="0" z="6087."/>
     <position name="targetCenter" x="0" y="0" z="0"/>
     <position name="upstreamCenter" x="0" y="0" z="7000."/>
     <position name="trackingCenter" x="0" y="0" z="25635."/>

--- a/geometry/mollerMother_trackingOnly.gdml
+++ b/geometry/mollerMother_trackingOnly.gdml
@@ -2,7 +2,7 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
   <define> 
-    <position name="hallCenter" x="0" y="0" z="4000"/>
+    <position name="hallCenter" x="0" y="0" z="6087."/>
     <position name="targetCenter" x="0" y="0" z="0"/>
     <position name="upstreamCenter" x="0" y="0" z="7000."/>
     <position name="trackingCenter" x="0" y="0" z="25635."/>


### PR DESCRIPTION
Whenever the hall wall and ceiling were included it was not placed at the right position relative to the target center. Was 4000 (not sure why) and is now 6087.0 based off of a measurement of the center of the pivots in the SBU MOLLER CAD. 

It is also possible that the radius of the hall or the relative offset of the roof and its radius of curvature are wrong as well, but I had (about a year ago) used a measurement of the radius from the JLab hall A CAD that is included in the SBU MOLLER CAD (and is centered on the pivot as well) to measure the wall radius, so it is likely correct.