### PR TITLE
Feature improve beam generator

### DIFF
--- a/geometry/mollerMother_5open.gdml
+++ b/geometry/mollerMother_5open.gdml
@@ -3,7 +3,7 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
 <define> 
-  <position name="detectorCenter" x="0" y="0" z="125.0 + 0.0*28500."/>
+  <position name="detectorCenter" x="0" y="0" z="0.0*28500."/>
   <rotation name="identity"/>
   <rotation name="rot" unit="deg" x="0" y="90" z="0"/>
 </define>

--- a/include/remollGenBeam.hh
+++ b/include/remollGenBeam.hh
@@ -15,10 +15,12 @@ class remollGenBeam : public remollVEventGen {
     remollGenBeam();
     virtual ~remollGenBeam();
 
-    void SetOrigin(G4ThreeVector origin);
     void SetOriginX(double x);
     void SetOriginY(double y);
     void SetOriginZ(double z);
+
+    void SetRasterX(double RASx);
+    void SetRasterY(double RASy);
 
     void SetDirection(G4ThreeVector direction);
     void SetDirectionX(double dx);
@@ -35,17 +37,12 @@ class remollGenBeam : public remollVEventGen {
   private:
     void SamplePhysics(remollVertex *, remollEvent *);
 
-    double fXpos;
-    double fYpos;
-    double fZpos;
+    G4ThreeVector fOrigin;
+    G4ThreeVector fDirection;
+    G4ThreeVector fPolarization;
 
-    double fXdir;
-    double fYdir;
-    double fZdir;
-
-    double fXpol;
-    double fYpol;
-    double fZpol;
+    double fXras;
+    double fYras;
 
     G4String fParticleName;
 };

--- a/macros/runexample.mac
+++ b/macros/runexample.mac
@@ -38,6 +38,14 @@
 #/remoll/beam_dph 0 mrad
 
 #/remoll/evgen/set beam
+# To hit Ring 5 open in septant 4
+#/remoll/evgen/beam/x -1300 mm
+#/remoll/evgen/beam/rasx -30 mm
+#/remoll/evgen/beam/origin -987.5 0 -50 mm
+#/remoll/evgen/beam/direction (-0.0523,0,0.9986)
+# Mainz test energy
+#/remoll/beamene 855 MeV
+
 /remoll/evgen/set moller
 #/remoll/evgen/thcommin 30.0 deg
 #/remoll/evgen/thcommax 150.0 deg

--- a/macros/runexample_optical.mac
+++ b/macros/runexample_optical.mac
@@ -1,88 +1,22 @@
-#  Example file
+#  Example file for generating optical photons on the Ring 5 open septant 4 cathode
 
 # store tracks
 #/tracking/storeTrajectory 1
-
-# This must be called before initialize
-/remoll/geometry/setfile geometry/mollerMother_5open.gdml
-# Parallel world geometry is optional - detector 28 (the primary detector array's idealize vacuum detector) is included in this parallel world now.
-/remoll/parallel/setfile geometry/mollerParallel.gdml 
-#/remoll/physlist/register QGSP_BERT_HP
-#/remoll/physlist/parallel/enable 
-# if optical physics is turned on it will only work if parallel physics is not turned on.
 /remoll/physlist/optical/enable 
 
+# This must be called before initialize
+/remoll/setgeofile geometry/mollerMother_5open.gdml
+# Parallel world geometry is optional - detector 28 (the primary detector array's idealize vacuum detector) is included in this parallel world now.
 # This must be explicitly called
 /run/initialize
 
-/remoll/printgeometry true
-
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
-
-#/remoll/scalefield map_directory/blockyHybrid_rm_3.0.txt 1.0
-#/remoll/magcurrent map_directory/blockyHybrid_rm_3.0.txt 1000.0 A
-
-# Raster and initial angle stuff
-/remoll/oldras true
-/remoll/rasx 5 mm
-/remoll/rasy 5 mm
-#/remoll/beam_x0 0 mm
-#/remoll/beam_y0 0 mm
-# initial angle
-#/remoll/beam_th0 0 mrad
-#/remoll/beam_ph0 0 mrad
-# gaussian spread widths
-#/remoll/beam_dth 0 mrad
-#/remoll/beam_dph 0 mrad
-
-#/remoll/evgen/set beam
-/remoll/evgen/set moller
-#/remoll/evgen/thcommin 30.0 deg
-#/remoll/evgen/thcommax 150.0 deg
-#/remoll/evgen/set elastic 
-#/remoll/evgen/thmin 0.1 deg
-#/remoll/evgen/thmax 2.0 deg
-#/remoll/evgen/emin 80.0 MeV
-#/remoll/evgen/set inelastic 
-#/remoll/evgen/set pion
-#/remoll/piontype pi+
-#/remoll/evgen/set pion_LUND
-#/remoll/evgen/set inelasticAl
-#/remoll/evgen/set quasielasticAl
-#/remoll/evgen/set elasticAl
-#/remoll/evgen/set external
-#/remoll/externalfile remollout.root
-#/remoll/externaldetid 4051
-
-/remoll/evgen/beamPolarization +L
-/remoll/field/equationtype 2
-/remoll/field/steppertype 2
-/remoll/field/print
-
-/remoll/beamene 11 GeV
-
-# For LH2
-/remoll/targpos   0 cm
-/remoll/targlen 150 cm
-
-# For carbon
-#/remoll/targpos 0.0 cm
-#/remoll/targlen 1.5 mm
-
-/remoll/beamcurr 85 microampere
-
-# Make interactions with W, Cu, and Pb
-# realistic rather than pure absorbers
-/remoll/kryptonite/set true
-
-/process/list
-
-# Specify random number seed
-/remoll/seed 123456
-
-/remoll/filename remollout.root
-
-#/tracking/verbose 2
+/remoll/evgen/set beam
+# To hit Ring 5 open in septant 4
+/remoll/evgen/beam/origin -987.5 0.0 -150.0 mm
+/remoll/evgen/beam/direction (-0.0523,0.0,0.9986)
+/remoll/evgen/beam/rasx 105 mm
+/remoll/evgen/beam/rasy 78 mm
+/remoll/beamene 855 MeV
+/remoll/filename remollout_optical.root
 
 /run/beamOn 100

--- a/macros/vis.mac
+++ b/macros/vis.mac
@@ -4,7 +4,7 @@
 /remoll/physlist/optical/enable
 
 # This is the current working geometry
-/remoll/setgeofile geometry_tests/mollerMother_5open.gdml
+/remoll/setgeofile geometry/mollerMother_5open.gdml
 
 #/remoll/likekryptonite  true
 
@@ -26,16 +26,21 @@
 #/gun/momentum 0.5 1.0 2.0 GeV
 
 # Raster is on by default with 5x5mm
-
 /remoll/rasx 5 mm
 /remoll/rasy 5 mm 
 
 ## Beam generator
 /remoll/evgen/set beam
-/remoll/evgen/beam/x -987.5
-/remoll/evgen/beam/z -120.0
-/remoll/evgen/beam/px -0.0523
-/remoll/evgen/beam/pz 0.9986 
+#/remoll/evgen/beam/origin -987.5,0.0,-150.0 mm
+/remoll/evgen/beam/origin -987.5 0.0 -150.0 mm
+#/remoll/evgen/beam/x -987.5 mm
+/remoll/evgen/beam/direction (-0.0523,0.0,0.9986)
+/remoll/evgen/beam/rasx 105.0 mm
+/remoll/evgen/beam/rasy 78.0 mm
+#/remoll/evgen/beam/x -987.5 mm
+#/remoll/evgen/beam/z -150.0 mm
+#/remoll/evgen/beam/px -0.0523
+#/remoll/evgen/beam/pz 0.9986 
 /remoll/filename remollout_r5o_beam_default.root
 
 

--- a/src/remollGenBeam.cc
+++ b/src/remollGenBeam.cc
@@ -11,6 +11,7 @@
 #include "G4GenericMessenger.hh"
 #include "G4ParticleTable.hh"
 
+#include "Randomize.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 
@@ -20,22 +21,26 @@
 
 remollGenBeam::remollGenBeam()
 : remollVEventGen("beam"),
-  fXpos(0.0), fYpos(0.0), fZpos(-.5*m),
-  fXdir(0.0), fYdir(0.0), fZdir(1.0),
+  fOrigin(0.0*m,0.0*m,-5.0*m),
+  fDirection(0.0,0.0,0.0),
+  //fPolarization(0.0,0.0,0.0),
+  fXras(0.0), fYras(0.0),
   fParticleName("e-")
 {
     fSampType = kNoTargetVolume;
     fApplyMultScatt = true;
 
-    fThisGenMessenger->DeclareMethodWithUnit("origin","mm",&remollGenBeam::SetOrigin,"set origin");
+    fThisGenMessenger->DeclarePropertyWithUnit("origin","mm",fOrigin,"set origin: x y z unit");
     fThisGenMessenger->DeclareMethodWithUnit("x","mm",&remollGenBeam::SetOriginX,"x coordinate of origin for the beam");
     fThisGenMessenger->DeclareMethodWithUnit("y","mm",&remollGenBeam::SetOriginY,"y coordinate of origin for the beam");
     fThisGenMessenger->DeclareMethodWithUnit("z","mm",&remollGenBeam::SetOriginZ,"z coordinate of origin for the beam");
-    fThisGenMessenger->DeclareMethod("direction",&remollGenBeam::SetDirection,"set momentum direction");
+    fThisGenMessenger->DeclareMethodWithUnit("rasx","mm",&remollGenBeam::SetRasterX,"Raster x spread of origin for the beam");
+    fThisGenMessenger->DeclareMethodWithUnit("rasy","mm",&remollGenBeam::SetRasterY,"Raster y spread of origin for the beam");
+    fThisGenMessenger->DeclareMethod("direction",&remollGenBeam::SetDirection,"set momentum direction: (x,y,z)");
     fThisGenMessenger->DeclareMethod("px",&remollGenBeam::SetDirectionX,"x component of momentum direction");
     fThisGenMessenger->DeclareMethod("py",&remollGenBeam::SetDirectionY,"y component of momentum direction");
     fThisGenMessenger->DeclareMethod("pz",&remollGenBeam::SetDirectionZ,"z component of momentum direction");
-    fThisGenMessenger->DeclareMethod("polarization",&remollGenBeam::SetPolarization,"set polarization");
+    fThisGenMessenger->DeclareMethod("polarization",&remollGenBeam::SetPolarization,"set polarization: (x,y,z)");
     fThisGenMessenger->DeclareMethod("sx",&remollGenBeam::SetPolarizationX,"x component of polarization");
     fThisGenMessenger->DeclareMethod("sy",&remollGenBeam::SetPolarizationY,"y component of polarization");
     fThisGenMessenger->DeclareMethod("sz",&remollGenBeam::SetPolarizationZ,"z component of polarization");
@@ -44,20 +49,22 @@ remollGenBeam::remollGenBeam()
 
 remollGenBeam::~remollGenBeam() { }
 
-void remollGenBeam::SetOrigin(G4ThreeVector origin){ fXpos = origin.x(); fYpos = origin.y(); fZpos = origin.z(); }
-void remollGenBeam::SetOriginX(double x){ fXpos = x; }
-void remollGenBeam::SetOriginY(double y){ fYpos = y; }
-void remollGenBeam::SetOriginZ(double z){ fZpos = z; }
+void remollGenBeam::SetOriginX(double x){ fOrigin.setX(x); }
+void remollGenBeam::SetOriginY(double y){ fOrigin.setY(y); }
+void remollGenBeam::SetOriginZ(double z){ fOrigin.setZ(z); }
 
-void remollGenBeam::SetDirection(G4ThreeVector direction){ fXdir = direction.x(); fYdir = direction.y(); fZdir = direction.z(); }
-void remollGenBeam::SetDirectionX(double px){ fXdir = px; }
-void remollGenBeam::SetDirectionY(double py){ fYdir = py; }
-void remollGenBeam::SetDirectionZ(double pz){ fZdir = pz; }
+void remollGenBeam::SetRasterX(double RASx){ fXras = RASx; }
+void remollGenBeam::SetRasterY(double RASy){ fYras = RASy; }
 
-void remollGenBeam::SetPolarization(G4ThreeVector polarization){ fXpol = polarization.x(); fYpol = polarization.y(); fZpol = polarization.z(); }
-void remollGenBeam::SetPolarizationX(double sx){ fXpol = sx; }
-void remollGenBeam::SetPolarizationY(double sy){ fYpol = sy; }
-void remollGenBeam::SetPolarizationZ(double sz){ fZpol = sz; }
+void remollGenBeam::SetDirection(G4ThreeVector direction){ fDirection.setX(direction.x()); fDirection.setY(direction.y()); fDirection.setZ(direction.z()); }
+void remollGenBeam::SetDirectionX(double px){ fDirection.setX(px); }
+void remollGenBeam::SetDirectionY(double py){ fDirection.setY(py); }
+void remollGenBeam::SetDirectionZ(double pz){ fDirection.setZ(pz); }
+
+void remollGenBeam::SetPolarization(G4ThreeVector polarization){ fPolarization.setX(polarization.x()); fPolarization.setY(polarization.y()); fPolarization.setZ(polarization.z()); }
+void remollGenBeam::SetPolarizationX(double sx){ fPolarization.setX(sx); }
+void remollGenBeam::SetPolarizationY(double sy){ fPolarization.setY(sy); }
+void remollGenBeam::SetPolarizationZ(double sz){ fPolarization.setZ(sz); }
 
 void remollGenBeam::SetPartName(G4String& name){ fParticleName = name; }
 
@@ -72,19 +79,24 @@ void remollGenBeam::SamplePhysics(remollVertex * /*vert*/, remollEvent *evt)
     double p = sqrt(E*E - m*m);
 
     evt->fBeamE = E;
-    evt->fBeamMomentum = p * G4ThreeVector(fXdir,fYdir,fZdir).unit();
-    evt->fBeamPolarization = G4ThreeVector(fXpol, fYpol, fZpol);
+    evt->fBeamMomentum = p * fDirection.unit();
+    evt->fBeamPolarization = fPolarization;
 
     // Override target sampling z
-    evt->fVertexPos.setX( fXpos );
-    evt->fVertexPos.setY( fYpos );
-    evt->fVertexPos.setZ( fZpos );
+    evt->fVertexPos.setX( 0.0 );
+    evt->fVertexPos.setY( 0.0 );
+    evt->fVertexPos.setZ( 0.0 );
+
+    // Allow for simplistic raster/spreading in beam generator
+    G4double rasx = G4RandFlat::shoot(fOrigin.x() - fXras/2.0, fOrigin.x() + fXras/2.0);
+    G4double rasy = G4RandFlat::shoot(fOrigin.y() - fYras/2.0, fOrigin.y() + fYras/2.0);
+    G4double rasz = fOrigin.z();
 
     evt->ProduceNewParticle(
-	    G4ThreeVector(0.0, 0.0, 0.0),
+	    G4ThreeVector(rasx, rasy, rasz),
 	    evt->fBeamMomentum,
 	    fParticleName,
-            evt->fBeamPolarization);
+        evt->fBeamPolarization);
 
     evt->SetEffCrossSection(0.0);
     evt->SetAsymmetry(0.0);


### PR DESCRIPTION
Most notably the /remoll/evgen/beam/origin macro command simply didn't work since there is no support for G4ThreeVector data types in DeclareMethodWithUnit(). 

Work around is to set the origin information as a new G4ThreeVector and access that object with a new DeclarePropertyWithUnit() command. 

I also went ahead and made the direction and polarization values into G4ThreeVectors. 

I also added a rudimentary G4RandFlat::shoot(min, max) for x and for y raster functions to the beam generator, which should help in detector parameter scans done with the beam generator (and is nice to have in general).

It may be nice to add a z axis G4RandFlat::shoot feature, and it may be nice to add one for the direction or polarization quantities as well, and to do so should be straightforward copying the position raster procedure.