### PR TITLE
Adding in user optical physics list

### DIFF
--- a/include/remollPhysicsList.hh
+++ b/include/remollPhysicsList.hh
@@ -30,6 +30,13 @@ class remollPhysicsList: public G4VModularPhysicsList
     // Disable optical physics
     void DisableOpticalPhysics();
 
+    // Set user optical physics
+    void SetUserOptical(G4bool flag2);
+    // Enable user optical physics
+    void EnableUserOptical();
+    // Disable user optical physics
+    void DisableUserOptical();
+
     // Set step limiter physics
     void SetStepLimiterPhysics(G4bool flag);
     // Enable step limiter physics
@@ -47,6 +54,7 @@ class remollPhysicsList: public G4VModularPhysicsList
     G4VModularPhysicsList* fReferencePhysList;
     G4VPhysicsConstructor* fParallelPhysics;
     G4VPhysicsConstructor* fOpticalPhysics;
+    G4VPhysicsConstructor* fUserOptical;
     G4VPhysicsConstructor* fStepLimiterPhysics;
 
     // Deleting an unused physics list also deletes particles, causing
@@ -57,6 +65,7 @@ class remollPhysicsList: public G4VModularPhysicsList
     // Generic messenger as protected to be used in derived classes
     G4GenericMessenger* fPhysListMessenger;
     G4GenericMessenger* fOpticalMessenger;
+    G4GenericMessenger* fUserOpticalMessenger;
     G4GenericMessenger* fParallelMessenger;
     G4GenericMessenger* fStepLimiterMessenger;
     G4GenericMessenger* fBaseMessenger;

--- a/include/remollUserOptical.hh
+++ b/include/remollUserOptical.hh
@@ -1,0 +1,50 @@
+#ifndef __REMOLLUSEROPTICAL_HH
+#define __REMOLLUSEROPTICAL_HH 
+
+#include "globals.hh"
+
+#include "G4OpWLS.hh"
+#include "G4Cerenkov.hh"
+#include "G4Scintillation.hh"
+
+#include "G4OpMieHG.hh"
+#include "G4OpRayleigh.hh"
+#include "G4OpAbsorption.hh"
+#include "G4OpBoundaryProcess.hh"
+
+#include "G4VPhysicsConstructor.hh"
+
+class remollUserOptical : public G4VPhysicsConstructor
+{
+  public:
+
+    remollUserOptical(G4bool toggle=true);
+    virtual ~remollUserOptical();
+
+    virtual void ConstructParticle();
+    virtual void ConstructProcess();
+
+    G4OpWLS* GetWLSProcess() {return theWLSProcess;}
+    G4Cerenkov* GetCerenkovProcess() {return theCerenkovProcess;}
+    G4Scintillation* GetScintillationProcess() {return theScintProcess;}
+    G4OpAbsorption* GetAbsorptionProcess() {return theAbsorptionProcess;}
+    G4OpRayleigh* GetRayleighScatteringProcess() {return theRayleighScattering;}
+    G4OpMieHG* GetMieHGScatteringProcess() {return theMieHGScatteringProcess;}
+    G4OpBoundaryProcess* GetBoundaryProcess() { return theBoundaryProcess;}
+
+    void SetNbOfPhotonsCerenkov(G4int);
+
+private:
+
+    G4OpWLS*             theWLSProcess;
+    G4Cerenkov*          theCerenkovProcess;
+    G4Scintillation*     theScintProcess;
+    G4OpAbsorption*      theAbsorptionProcess;
+    G4OpRayleigh*        theRayleighScattering;
+    G4OpMieHG*           theMieHGScatteringProcess;
+    G4OpBoundaryProcess* theBoundaryProcess;
+ 
+    G4bool AbsorptionOn;
+
+};
+#endif//__REMOLLUSEROPTICAL_HH 

--- a/macros/runexample_useroptical.mac
+++ b/macros/runexample_useroptical.mac
@@ -2,7 +2,8 @@
 
 # store tracks
 #/tracking/storeTrajectory 1
-/remoll/physlist/optical/enable 
+#/remoll/physlist/optical/enable 
+/remoll/physlist/useroptical/enable 
 
 # This must be called before initialize
 /remoll/setgeofile geometry/mollerMother_5open.gdml
@@ -18,6 +19,6 @@
 /remoll/evgen/beam/rasx 105 mm
 /remoll/evgen/beam/rasy 78 mm
 /remoll/beamene 855 MeV
-/remoll/filename remollout_optical.root
+/remoll/filename remollout_useroptical.root
 
 /run/beamOn 10000

--- a/macros/tests/unit/test_physlist_6.mac
+++ b/macros/tests/unit/test_physlist_6.mac
@@ -1,0 +1,6 @@
+# Enable optical physics
+/remoll/physlist/useroptical/enable
+
+# Initialize and run
+/run/initialize
+/run/beamOn 1

--- a/macros/tests/unit/test_physlist_7.mac
+++ b/macros/tests/unit/test_physlist_7.mac
@@ -1,0 +1,9 @@
+# Enable optical physics
+/remoll/physlist/useroptical/enable
+
+# Disable optical physics again
+/remoll/physlist/useroptical/disable
+
+# Initialize and run
+/run/initialize
+/run/beamOn 1

--- a/src/remollUserOptical.cc
+++ b/src/remollUserOptical.cc
@@ -1,0 +1,116 @@
+#include "G4LossTableManager.hh"
+#include "G4EmSaturation.hh"
+#include "remollUserOptical.hh"
+
+remollUserOptical::remollUserOptical(G4bool toggle)
+    : G4VPhysicsConstructor("Optical")
+{
+
+  theWLSProcess                = NULL;
+  theScintProcess              = NULL;
+  theCerenkovProcess           = NULL;
+  theBoundaryProcess           = NULL;
+  theAbsorptionProcess         = NULL;
+  theRayleighScattering        = NULL;
+  theMieHGScatteringProcess    = NULL;
+
+  AbsorptionOn                 = toggle;
+}
+
+remollUserOptical::~remollUserOptical() { }
+
+#include "G4OpticalPhoton.hh"
+
+void remollUserOptical::ConstructParticle()
+{
+  G4OpticalPhoton::OpticalPhotonDefinition();
+}
+
+#include "G4ProcessManager.hh"
+
+void remollUserOptical::ConstructProcess()
+{
+    /*
+
+FIXME:  Add to verbosity responsiveness
+    G4cout << "remollUserOptical:: Add Optical Physics Processes"
+           << G4endl;
+	   */
+
+  theWLSProcess = new G4OpWLS();
+
+  theScintProcess = new G4Scintillation();
+  theScintProcess->SetScintillationYieldFactor(1.);// if 0 then no scint, if 1 then yes scint
+  theScintProcess->SetTrackSecondariesFirst(true);
+
+  theCerenkovProcess = new G4Cerenkov();
+  theCerenkovProcess->SetMaxNumPhotonsPerStep(2000);// Default 2000, if 0 then no cherenkov
+  theCerenkovProcess->SetTrackSecondariesFirst(true);
+
+  theAbsorptionProcess      = new G4OpAbsorption();
+  theRayleighScattering     = new G4OpRayleigh();
+  theMieHGScatteringProcess = new G4OpMieHG();
+  theBoundaryProcess        = new G4OpBoundaryProcess();
+
+  G4ProcessManager* pManager =
+                G4OpticalPhoton::OpticalPhoton()->GetProcessManager();
+
+  if (!pManager) {
+     std::ostringstream o;
+     o << "Optical Photon without a Process Manager";
+     G4Exception("remollUserOptical::ConstructProcess()","",
+                  FatalException,o.str().c_str());
+  }
+
+  if (AbsorptionOn) pManager->AddDiscreteProcess(theAbsorptionProcess);
+
+  //pManager->AddDiscreteProcess(theRayleighScattering);
+  //pManager->AddDiscreteProcess(theMieHGScatteringProcess);
+
+  pManager->AddDiscreteProcess(theBoundaryProcess);
+
+  theWLSProcess->UseTimeProfile("delta");
+  //theWLSProcess->UseTimeProfile("exponential");
+
+  pManager->AddDiscreteProcess(theWLSProcess);
+
+  theScintProcess->SetScintillationYieldFactor(1.);// if 0 then no scint, if 1 then yes scint
+  theScintProcess->SetScintillationExcitationRatio(0.0);
+  theScintProcess->SetTrackSecondariesFirst(true);
+
+  // Use Birks Correction in the Scintillation process
+
+  G4EmSaturation* emSaturation = G4LossTableManager::Instance()->EmSaturation();
+  theScintProcess->AddSaturation(emSaturation);
+
+  GetParticleIterator()->reset();
+  while ( (*GetParticleIterator())() ){
+
+    G4ParticleDefinition* particle = GetParticleIterator()->value();
+    G4String particleName = particle->GetParticleName();
+
+    pManager = particle->GetProcessManager();
+    if (!pManager) {
+       std::ostringstream o;
+       o << "Particle " << particleName << "without a Process Manager";
+       G4Exception("remollUserOptical::ConstructProcess()","",
+                    FatalException,o.str().c_str());
+    }
+
+    if(theCerenkovProcess->IsApplicable(*particle)){
+      pManager->AddProcess(theCerenkovProcess);
+      pManager->SetProcessOrdering(theCerenkovProcess,idxPostStep);
+    }
+    if(theScintProcess->IsApplicable(*particle)){
+      pManager->AddProcess(theScintProcess);
+      pManager->SetProcessOrderingToLast(theScintProcess,idxAtRest);
+      pManager->SetProcessOrderingToLast(theScintProcess,idxPostStep);
+    }
+
+  }
+}
+
+void remollUserOptical::SetNbOfPhotonsCerenkov(G4int MaxNumber)
+{
+  theCerenkovProcess->SetMaxNumPhotonsPerStep(MaxNumber);
+}


### PR DESCRIPTION
This duplicates the already implemented "optical" list, but now the constituent processes are laid bare, allowing for the user to edit which optical processes are included. This is critical for performing blackening studies in the light guides and to determine the relative impact of scintillation vs. cherenkov.

I also ran some simple tests turning on and off cherenkov and scintillation in the user optical code, and compared also against the "optical" list to verify satisfactorily that these two lists are giving consistent results and that both scintillation and cherenkov have been included this whole time in the "optical" list.

This may still have the issue where parallel world can't be loaded at the same time (probably because these lists overwrite eachother, so that may require condensing all user lists into one class that allows multiple being turned on and off simultaneously - this UserOptical class will be a good groundwork to start from).