### PR TITLE
Split out a fraction of cmake lines into modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #----------------------------------------------------------------------------
 # Setup the project
 #
-cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(REMOLL)
 
 # Disallow in-source builds
@@ -10,18 +10,12 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 endif()
 
 # Prepend module search path
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
-# Default install path is the source directory
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    message(STATUS "    Install-prefix was at default -> forcing it to the source-dir" )
-    message(STATUS "    Use -DCMAKE_INSTALL_PREFIX=/usr/local to set to something else" )
-    set (CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}"
-         CACHE PATH "default install path" FORCE )
-endif()
-
-# Use GNU install dirs
-include(GNUInstallDirs)
+# Request C++11 standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS False)
 
 # MAC specific variable
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -36,16 +30,29 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     endif()
 endif()
 
-# ROOT path
-find_package(ROOT 6 REQUIRED)
-include(${ROOT_USE_FILE})
-
 # Update header file
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/gitinfo.hh COMMAND ${PROJECT_SOURCE_DIR}/pullgitinfo.py ${PROJECT_SOURCE_DIR} COMMENT "Creating gitinfo.hh" DEPENDS ${PROJECT_SOURCE_DIR}/pullgitinfo.py)
 
-# this is to ensure we find the header we need
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
+#----------------------------------------------------------------------------
+# Find Geant4 package
+# - we must start with this because the Geant4 use file overwrites the CFLAGS
+#   while the other use files (e.g. ROOT) only append to existing CFLAGS.
+#
+option(WITH_GEANT4_UIVIS "Build example with Geant4 UI and Vis drivers" ON)
+if(WITH_GEANT4_UIVIS)
+  find_package(Geant4 REQUIRED ui_all vis_all)
+else()
+  find_package(Geant4 REQUIRED)
+endif()
+include(${Geant4_USE_FILE})
 
+#----------------------------------------------------------------------------
+# Find ROOT libraries
+#
+find_package(ROOT 6 REQUIRED)
+include(${ROOT_USE_FILE})
+# Generate dictionaries
 ROOT_GENERATE_DICTIONARY(
     remollDict                         # path to dictionary to generate
     "include/remolltypes.hh"           # list of classes to process
@@ -57,35 +64,17 @@ ROOT_GENERATE_DICTIONARY(
 
 #----------------------------------------------------------------------------
 # Find Boost libraries, in particular iostreams
-
-if(USE_BOOST)
-    find_package(Boost COMPONENTS iostreams)
-    include_directories(${Boost_INCLUDE_DIRS})
-    link_directories(${Boost_LIBRARY_DIR})
-    ADD_DEFINITIONS(-D__USE_BOOST)
-    if(Boost_IOSTREAMS_FOUND)
-        ADD_DEFINITIONS(-D__USE_BOOST_IOSTREAMS)
-    endif()
-endif()
-
-
-#----------------------------------------------------------------------------
-# Find Geant4 package, activating all available UI and Vis drivers by default
-# You can set WITH_GEANT4_UIVIS to OFF via the command line or ccmake/cmake-gui
-# to build a batch mode only executable
 #
-option(WITH_GEANT4_UIVIS "Build example with Geant4 UI and Vis drivers" ON)
-if(WITH_GEANT4_UIVIS)
-  find_package(Geant4 REQUIRED ui_all vis_all)
-else()
-  find_package(Geant4 REQUIRED)
+find_package(Boost QUIET COMPONENTS iostreams)
+if(Boost_FOUND)
+  message(STATUS "Boost found --> building with Boost enabled.")
+  link_directories(${Boost_LIBRARY_DIR})
+  ADD_DEFINITIONS(-D__USE_BOOST)
+  if(Boost_IOSTREAMS_FOUND)
+    message(STATUS "Boost::iostreams found --> building with boost::iostreams enabled.")
+    ADD_DEFINITIONS(-D__USE_BOOST_IOSTREAMS)
+  endif()
 endif()
-
-#----------------------------------------------------------------------------
-# Setup Geant4 include directories and compile definitions
-# Setup include directory for this project
-#
-include(${Geant4_USE_FILE})
 
 #----------------------------------------------------------------------------
 # Find HepMC (optional package)
@@ -110,51 +99,31 @@ else()
 endif()
 
 #----------------------------------------------------------------------------
-# Debugging symbols, warnings
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -pg")
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -g -Woverloaded-virtual")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -g -Wno-shadow -Wno-pedantic -Wno-overloaded-virtual")
-
-# Ignore warning of struct initialization { } for gcc < 5.0 (after that it is ignored internally)
-if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-field-initializers")
-endif()
-
-# C++11 standard if avialable
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-if(COMPILER_SUPPORTS_CXX11)
-        message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has C++11 support.")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-elseif(COMPILER_SUPPORTS_CXX0X)
-        message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has C++0x support.")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-else()
-        message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support.")
-endif()
-
-#----------------------------------------------------------------------------
-# Generate dictionaries as well (so we can write objects to ROOT files
-
-include_directories(${PROJECT_SOURCE_DIR}/include ${ROOT_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/include)
-
-#----------------------------------------------------------------------------
 # Locate sources and headers for this project
-# NB: headers are included so they will show up in IDEs
 #
 file(GLOB sources ${PROJECT_SOURCE_DIR}/src/remoll*.cc)
 file(GLOB headers ${PROJECT_SOURCE_DIR}/include/remoll*.hh)
+include_directories(${PROJECT_SOURCE_DIR}/include)
 if(HepMC_FOUND)
-	file(GLOB hepmc_sources ${PROJECT_SOURCE_DIR}/src/HepMC*.cc)
-	file(GLOB hepmc_headers ${PROJECT_SOURCE_DIR}/src/HepMC*.hh)
-	set(sources ${sources} ${hepmc_sources})
-	set(headers ${headers} ${hepmc_headers})
+  file(GLOB hepmc_sources ${PROJECT_SOURCE_DIR}/src/HepMC*.cc)
+  file(GLOB hepmc_headers ${PROJECT_SOURCE_DIR}/src/HepMC*.hh)
+  set(sources ${sources} ${hepmc_sources})
+  set(headers ${headers} ${hepmc_headers})
 endif()
 
 #----------------------------------------------------------------------------
 # Add the executable, and link it to the Geant4 libraries
 #
+
+# Set default prefix, default build type, consistent set of compiler flags
+include(PrefixDir)
+include(BuildType)
+include(CompilerFlags)
+
+# Use GNU install dirs
+include(GNUInstallDirs)
+
+# Set rpath
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}:${ROOT_LIBRARY_DIR}:${GEANT4_LIBRARY_DIR}")
 
 add_library(remoll-lib SHARED ${sources} ${headers} ${CMAKE_CURRENT_BINARY_DIR}/include/gitinfo.hh remollDict.cxx)

--- a/cmake/modules/BuildType.cmake
+++ b/cmake/modules/BuildType.cmake
@@ -1,0 +1,14 @@
+# Set a default build type if none was specified
+set(DEFAULT_CMAKE_BUILD_TYPE "Release")
+if (EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  set(DEFAULT_CMAKE_BUILD_TYPE "Debug")
+endif()
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${DEFAULT_CMAKE_BUILD_TYPE}' as none was specified.")
+  message(STATUS "    Use -DCMAKE_BUILD_TYPE= to set to: Debug, Release, MinSizeRel, RelWithDebInfo.")
+  set(CMAKE_BUILD_TYPE "${DEFAULT_CMAKE_BUILD_TYPE}" CACHE
+    STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()

--- a/cmake/modules/CompilerFlags.cmake
+++ b/cmake/modules/CompilerFlags.cmake
@@ -1,0 +1,36 @@
+# The following compiler flag variables are available (limiting to CXX code):
+# - CMAKE_CXX_FLAGS: used by ALL build types
+# - CMAKE_CXX_FLAGS_{DEBUG,RELWITHDEBINFO,MINSIZEREL,RELEASE}: used for specified build type only
+#
+# There is no need to add -g to the debug types since it is already included.
+
+include(CheckCXXCompilerFlag)
+
+# Set up CMAKE_CXX_FLAGS_WARN for warnings that are only used for DEBUG or RELWITHDEBINFO
+set(CMAKE_CXX_FLAGS_WARN "-W -Wall -Wnon-virtual-dtor -Wno-long-long -Wcast-align -Wchar-subscripts -Wpointer-arith -Wformat-security -Woverloaded-virtual -fno-check-new -fno-common")
+# Ideally no warnings should get turned off below, all should have a plan for getting fixed...
+string(APPEND CMAKE_CXX_FLAGS_WARN " -Wno-shadow")
+string(APPEND CMAKE_CXX_FLAGS_WARN " -Wno-pedantic")
+string(APPEND CMAKE_CXX_FLAGS_WARN " -Wno-overloaded-virtual")
+# Ignore warning of struct initialization { } for gcc < 5.0 (after that it is ignored internally)
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+  string(APPEND CMAKE_CXX_FLAGS_WARN " -Wno-missing-field-initializers")
+endif()
+
+# Set up the debug CXX_FLAGS for extra warnings
+string(APPEND CMAKE_CXX_FLAGS_DEBUG " ${CMAKE_CXX_FLAGS_WARN}")
+string(APPEND CMAKE_CXX_FLAGS_DEBUG " ${CMAKE_CXX_FLAGS_ERROR}")
+string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO " ${CMAKE_CXX_FLAGS_WARN}")
+
+# Not returning from a non-void function is an error on some compilers
+CHECK_CXX_COMPILER_FLAG("-Werror=return-type" HAVE_GCC_ERROR_RETURN_TYPE)
+if(HAVE_GCC_ERROR_RETURN_TYPE)
+  string(APPEND CMAKE_CXX_FLAGS_ERROR " -Werror=return-type")
+endif()
+
+# If we are compiling on Linux then set some extra linker flags too
+if(CMAKE_SYSTEM_NAME MATCHES Linux)
+  string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,--fatal-warnings -Wl,--no-undefined -lc")
+  string(APPEND CMAKE_MODULE_LINKER_FLAGS " -Wl,--fatal-warnings -Wl,--no-undefined -lc")
+  string(APPEND CMAKE_EXE_LINKER_FLAGS    " -Wl,--fatal-warnings -Wl,--no-undefined -lc")
+endif()

--- a/cmake/modules/PrefixDir.cmake
+++ b/cmake/modules/PrefixDir.cmake
@@ -1,0 +1,8 @@
+# Default install path is the source directory
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    message(STATUS "    Install-prefix was at default -> forcing it to the source-dir" )
+    message(STATUS "    Use -DCMAKE_INSTALL_PREFIX=/usr/local to set to something else" )
+    set (CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}"
+         CACHE PATH "default install path" FORCE )
+endif()
+


### PR DESCRIPTION
In particular:
- BuildType gets set up by default as RelWithDebInfo
  but Debug if a .git directory is present (i.e. developers)
- CompilerFlags are handled consistently between build types
- Prefix is also set to defaults

Some rearranging in the CMakeLists.txt because the Geant4 use file
overrides the cflags.