### PR TITLE
Bugfix to issue #172. Now kryptonite works again.

### DIFF
--- a/analysis/issues/issue172.C
+++ b/analysis/issues/issue172.C
@@ -25,6 +25,12 @@ void Analyze(TChain* T)
 
 void issue172()
 {
+  TChain* lead_all = new TChain("T");
+  lead_all->Add("issue172_lead_all.root");
+
+  std::cout << "Lead (all)" << std::endl;
+  Analyze(lead_all);
+
   TChain* lead = new TChain("T");
   lead->Add("issue172_lead.root");
 

--- a/include/remollDetectorConstruction.hh
+++ b/include/remollDetectorConstruction.hh
@@ -6,6 +6,7 @@
 #include "G4Types.hh"
 
 #include <vector>
+#include <set>
 
 class G4Tubs;
 class G4LogicalVolume;
@@ -23,12 +24,52 @@ class remollDetectorConstruction : public G4VUserDetectorConstruction
     remollDetectorConstruction(const G4String& name, const G4String& gdmlfile);
     virtual ~remollDetectorConstruction();
 
+  private:
+
+    remollDetectorConstruction(const remollDetectorConstruction&);
+    remollDetectorConstruction& operator=(remollDetectorConstruction);
+
+
   public:
 
     G4VPhysicalVolume* Construct();
     void ConstructSDandField();
 
+
+  public:
+
+    void SetVerboseLevel(G4int verbose) { fVerboseLevel = verbose; };
+
+  private:
+
+    G4int fVerboseLevel;
+
+
+  private:
+
+    G4GDMLParser *fGDMLParser;
+
+    G4bool fGDMLValidate;
+    G4bool fGDMLOverlapCheck;
+
+    G4String fGDMLPath;
+    G4String fGDMLFile;
+
+    void SetGDMLFile(G4String gdmlfile) {
+      size_t i = gdmlfile.rfind('/');
+      if (i != std::string::npos) {
+        fGDMLPath = gdmlfile.substr(0,i);
+      } else fGDMLPath = ".";
+      fGDMLFile = gdmlfile.substr(i + 1);
+    }
+
+    G4GenericMessenger* fMessenger;
+    G4GenericMessenger* fGeometryMessenger;
+
     void ReloadGeometry(const G4String gdmlfile);
+
+
+  public:
 
     void SetUserLimits(const G4String& type, const G4String& name, const G4String& value_units) const;
     void SetUserLimits(G4LogicalVolume* logical_volume, const G4String& type, const G4String& value_units) const;
@@ -42,27 +83,30 @@ class remollDetectorConstruction : public G4VUserDetectorConstruction
 
   private:
 
-    G4String fGDMLPath;
-    G4String fGDMLFile;
-
-    void SetGDMLFile(G4String gdmlfile) {
-      size_t i = gdmlfile.rfind('/');
-      if (i != std::string::npos) {
-        fGDMLPath = gdmlfile.substr(0,i);
-      } else fGDMLPath = ".";
-      fGDMLFile = gdmlfile.substr(i + 1);
-    }
-
-    G4GDMLParser *fGDMLParser;
-
-    G4bool fGDMLValidate;
-    G4bool fGDMLOverlapCheck;
-
-    G4GenericMessenger* fMessenger;
-    G4GenericMessenger* fGeometryMessenger;
     G4GenericMessenger* fUserLimitsMessenger;
 
-    G4int fVerboseLevel;
+
+  public:
+
+    void SetKryptoniteVerbose(G4int verbose) { fKryptoniteVerbose = verbose; }
+    void EnableKryptonite();
+    void DisableKryptonite();
+    void AddKryptoniteCandidate(const G4String& name);
+    void ListKryptoniteCandidates();
+
+  private:
+
+    G4GenericMessenger* fKryptoniteMessenger;
+    static G4UserLimits* fKryptoniteUserLimits;
+    G4bool fKryptoniteEnable;
+    G4int fKryptoniteVerbose;
+    std::set<G4String> fKryptoniteCandidates;
+    std::set<G4Material*> fKryptoniteMaterials;
+
+    void SetKryptoniteUserLimits(G4VPhysicalVolume* volume = 0);
+
+    void InitKryptoniteMaterials();
+
 
     //----------------------
     // global magnet section

--- a/include/remollGenericDetector.hh
+++ b/include/remollGenericDetector.hh
@@ -118,6 +118,16 @@ class remollGenericDetector : public G4VSensitiveDetector {
           return (left? (right? (left->fDetNo < right->fDetNo): false): true);
         }
 
+        void SetOneDetectorType(G4int det, G4String type) {
+          for (std::list<remollGenericDetector*>::iterator
+            it  = fGenericDetectors.begin();
+            it != fGenericDetectors.end();
+            it++) {
+              if ((*it)->fDetNo == det)
+                (*it)->SetDetectorType(type);
+          }
+        }
+
     public:
       remollGenericDetector( G4String name, G4int detnum );
       virtual ~remollGenericDetector();
@@ -141,13 +151,14 @@ class remollGenericDetector : public G4VSensitiveDetector {
         if (det_type.compareTo("opticalphoton",G4String::ignoreCase) == 0) {
             G4cout << SensitiveDetectorName << " detects optical photons" << G4endl;
             fDetectOpticalPhotons = true;
-            fDetectLowEnergyNeutrals = true;
         }
         if (det_type.compareTo("boundaryhits",G4String::ignoreCase) == 0) {
-            G4cout << SensitiveDetectorName << " detects charged particle hits only on the entering boundary" << G4endl;
-            fDetectOpticalPhotons = false;
-            fDetectLowEnergyNeutrals = false;
-            fBoundaryHits = true;
+            G4cout << SensitiveDetectorName << " detects hits only on entry boundary" << G4endl;
+            fDetectBoundaryHits = true;
+        }
+        if (det_type.compareTo("secondaries",G4String::ignoreCase) == 0) {
+            G4cout << SensitiveDetectorName << " detects secondaries" << G4endl;
+            fDetectSecondaries = true;
         }
     }
 
@@ -176,7 +187,7 @@ class remollGenericDetector : public G4VSensitiveDetector {
     G4bool fDetectSecondaries;
     G4bool fDetectOpticalPhotons;
     G4bool fDetectLowEnergyNeutrals;
-    G4bool fBoundaryHits;
+    G4bool fDetectBoundaryHits;
 
 	G4int fDetNo;
 

--- a/include/remollGenericDetector.hh
+++ b/include/remollGenericDetector.hh
@@ -34,101 +34,104 @@ class remollGenericDetectorSum;
 namespace { G4Mutex remollGenericDetectorMutex = G4MUTEX_INITIALIZER; }
 
 class remollGenericDetector : public G4VSensitiveDetector {
-    private:
-        static G4GenericMessenger* fStaticMessenger;
-        static std::list<remollGenericDetector*> fGenericDetectors;
-        static void InsertGenericDetector(remollGenericDetector* det) {
-          G4AutoLock lock(&remollGenericDetectorMutex);
-          fGenericDetectors.push_back(det);
-          fGenericDetectors.sort(isBefore);
-        }
-        static void EraseGenericDetector(remollGenericDetector* det) {
-          G4AutoLock lock(&remollGenericDetectorMutex);
-          fGenericDetectors.remove(det);
-        }
-        static void Sort() {
-          G4AutoLock lock(&remollGenericDetectorMutex);
-          fGenericDetectors.sort(isBefore);
-        }
-        void PrintAll() {
-          for (std::list<remollGenericDetector*>::const_iterator
-            it  = fGenericDetectors.begin();
-            it != fGenericDetectors.end();
-            it++) {
-              (*it)->PrintEnabled();
-          }
-        }
 
-        void SetAllEnabled() {
-          for (std::list<remollGenericDetector*>::iterator
-            it  = fGenericDetectors.begin();
-            it != fGenericDetectors.end();
-            it++) {
-              (*it)->SetEnabled();
-          }
-        }
-        void SetAllDisabled() {
-          for (std::list<remollGenericDetector*>::iterator
-            it  = fGenericDetectors.begin();
-            it != fGenericDetectors.end();
-            it++) {
-              (*it)->SetDisabled();
-          }
-        }
+  private:
 
-        void SetOneEnabled(G4int det) {
-          for (std::list<remollGenericDetector*>::iterator
-            it  = fGenericDetectors.begin();
-            it != fGenericDetectors.end();
-            it++) {
-              if ((*it)->fDetNo == det)
-                (*it)->SetEnabled();
-          }
-        }
-        void SetOneDisabled(G4int det) {
-          for (std::list<remollGenericDetector*>::iterator
-            it  = fGenericDetectors.begin();
-            it != fGenericDetectors.end();
-            it++) {
-              if ((*it)->fDetNo == det)
-                (*it)->SetDisabled();
-          }
-        }
+    static G4GenericMessenger* fStaticMessenger;
+    static std::list<remollGenericDetector*> fGenericDetectors;
+    static void InsertGenericDetector(remollGenericDetector* det) {
+      G4AutoLock lock(&remollGenericDetectorMutex);
+      fGenericDetectors.push_back(det);
+      fGenericDetectors.sort(isBefore);
+    }
+    static void EraseGenericDetector(remollGenericDetector* det) {
+      G4AutoLock lock(&remollGenericDetectorMutex);
+      fGenericDetectors.remove(det);
+    }
+    static void Sort() {
+      G4AutoLock lock(&remollGenericDetectorMutex);
+      fGenericDetectors.sort(isBefore);
+    }
 
-        void SetRangeEnabled(G4TwoVector v) {
-          for (std::list<remollGenericDetector*>::iterator
-            it  = fGenericDetectors.begin();
-            it != fGenericDetectors.end();
-            it++) {
-              if ((*it)->fDetNo >= v.x() && (*it)->fDetNo <= v.y())
-                (*it)->SetEnabled();
-          }
-        }
-        void SetRangeDisabled(G4TwoVector v) {
-          for (std::list<remollGenericDetector*>::iterator
-            it  = fGenericDetectors.begin();
-            it != fGenericDetectors.end();
-            it++) {
-              if ((*it)->fDetNo >= v.x() && (*it)->fDetNo <= v.y())
-                (*it)->SetDisabled();
-          }
-        }
+    void PrintAll() {
+      for (std::list<remollGenericDetector*>::const_iterator
+        it  = fGenericDetectors.begin();
+        it != fGenericDetectors.end();
+        it++) {
+          (*it)->PrintEnabled();
+      }
+    }
 
-        static bool isBefore(const remollGenericDetector* left, const remollGenericDetector* right) {
-          return (left? (right? (left->fDetNo < right->fDetNo): false): true);
-        }
+    void SetAllEnabled() {
+      for (std::list<remollGenericDetector*>::iterator
+        it  = fGenericDetectors.begin();
+        it != fGenericDetectors.end();
+        it++) {
+          (*it)->SetEnabled();
+      }
+    }
+    void SetAllDisabled() {
+      for (std::list<remollGenericDetector*>::iterator
+        it  = fGenericDetectors.begin();
+        it != fGenericDetectors.end();
+        it++) {
+          (*it)->SetDisabled();
+      }
+    }
 
-        void SetOneDetectorType(G4int det, G4String type) {
-          for (std::list<remollGenericDetector*>::iterator
-            it  = fGenericDetectors.begin();
-            it != fGenericDetectors.end();
-            it++) {
-              if ((*it)->fDetNo == det)
-                (*it)->SetDetectorType(type);
-          }
-        }
+    void SetOneEnabled(G4int det) {
+      for (std::list<remollGenericDetector*>::iterator
+        it  = fGenericDetectors.begin();
+        it != fGenericDetectors.end();
+        it++) {
+          if ((*it)->fDetNo == det)
+            (*it)->SetEnabled();
+      }
+    }
+    void SetOneDisabled(G4int det) {
+      for (std::list<remollGenericDetector*>::iterator
+        it  = fGenericDetectors.begin();
+        it != fGenericDetectors.end();
+        it++) {
+          if ((*it)->fDetNo == det)
+            (*it)->SetDisabled();
+      }
+    }
 
-    public:
+    void SetRangeEnabled(G4TwoVector v) {
+      for (std::list<remollGenericDetector*>::iterator
+        it  = fGenericDetectors.begin();
+        it != fGenericDetectors.end();
+        it++) {
+          if ((*it)->fDetNo >= v.x() && (*it)->fDetNo <= v.y())
+            (*it)->SetEnabled();
+      }
+    }
+    void SetRangeDisabled(G4TwoVector v) {
+      for (std::list<remollGenericDetector*>::iterator
+        it  = fGenericDetectors.begin();
+        it != fGenericDetectors.end();
+        it++) {
+          if ((*it)->fDetNo >= v.x() && (*it)->fDetNo <= v.y())
+            (*it)->SetDisabled();
+      }
+    }
+
+    static bool isBefore(const remollGenericDetector* left, const remollGenericDetector* right) {
+      return (left? (right? (left->fDetNo < right->fDetNo): false): true);
+    }
+
+    void SetOneDetectorType(G4String type, G4int det) {
+      for (std::list<remollGenericDetector*>::iterator
+        it  = fGenericDetectors.begin();
+        it != fGenericDetectors.end();
+        it++) {
+          if ((*it)->fDetNo == det)
+            (*it)->SetDetectorType(type);
+      }
+    }
+
+  public:
       remollGenericDetector( G4String name, G4int detnum );
       virtual ~remollGenericDetector();
 
@@ -139,61 +142,61 @@ class remollGenericDetector : public G4VSensitiveDetector {
       void BuildStaticMessenger();
 
       virtual void SetDetectorType(G4String det_type) {
-        if (det_type.compareTo("charged",G4String::ignoreCase) == 0) {
-            G4cout << SensitiveDetectorName << " detects charged particles" << G4endl;
-            fDetectOpticalPhotons = false;
-            fDetectLowEnergyNeutrals = false;
+        if (det_type.compareTo("charged", G4String::ignoreCase) == 0) {
+          G4cout << GetName() << " detects charged particles" << G4endl;
+          fDetectOpticalPhotons = false;
+          fDetectLowEnergyNeutrals = false;
         }
-        if (det_type.compareTo("lowenergyneutral",G4String::ignoreCase) == 0) {
-            G4cout << SensitiveDetectorName << " detects low energy neutrals" << G4endl;
-            fDetectLowEnergyNeutrals = true;
+        if (det_type.compareTo("lowenergyneutral", G4String::ignoreCase) == 0) {
+          G4cout << GetName() << " detects low energy neutrals" << G4endl;
+          fDetectLowEnergyNeutrals = true;
         }
-        if (det_type.compareTo("opticalphoton",G4String::ignoreCase) == 0) {
-            G4cout << SensitiveDetectorName << " detects optical photons" << G4endl;
-            fDetectOpticalPhotons = true;
+        if (det_type.compareTo("opticalphoton", G4String::ignoreCase) == 0) {
+          G4cout << GetName() << " detects optical photons" << G4endl;
+          fDetectOpticalPhotons = true;
         }
-        if (det_type.compareTo("boundaryhits",G4String::ignoreCase) == 0) {
-            G4cout << SensitiveDetectorName << " detects hits only on entry boundary" << G4endl;
-            fDetectBoundaryHits = true;
+        if (det_type.compareTo("boundaryhits", G4String::ignoreCase) == 0) {
+          G4cout << GetName() << " detects hits only on entry boundary" << G4endl;
+          fDetectBoundaryHits = true;
         }
-        if (det_type.compareTo("secondaries",G4String::ignoreCase) == 0) {
-            G4cout << SensitiveDetectorName << " detects secondaries" << G4endl;
-            fDetectSecondaries = true;
+        if (det_type.compareTo("secondaries", G4String::ignoreCase) == 0) {
+          G4cout << GetName() << " detects secondaries" << G4endl;
+          fDetectSecondaries = true;
         }
-    }
+      }
 
-    void SetEnabled(G4bool flag = true) {
+      void SetEnabled(G4bool flag = true) {
         fEnabled = flag;
-    };
-    void SetDisabled(G4bool flag = true) {
+      };
+      void SetDisabled(G4bool flag = true) {
         fEnabled = !flag;
-    };
-    void PrintEnabled() const {
+      };
+      void PrintEnabled() const {
         G4cout << "Det " << GetName() << " (" << fDetNo << ") "
             << (fEnabled? "enabled" : "disabled") << G4endl;
-    };
+      };
 
-    void  SetDetNo(G4int detno) { fDetNo = detno; }
-    G4int GetDetNo() const { return fDetNo; }
+      void  SetDetNo(G4int detno) { fDetNo = detno; }
+      G4int GetDetNo() const { return fDetNo; }
 
     private:
-	remollGenericDetectorHitCollection *fHitColl;
-	remollGenericDetectorSumCollection *fSumColl;
+      remollGenericDetectorHitCollection *fHitColl;
+      remollGenericDetectorSumCollection *fSumColl;
 
-	G4int fHCID, fSCID;
+      G4int fHCID, fSCID;
 
-	std::map<int, remollGenericDetectorSum *> fSumMap;
+      std::map<int, remollGenericDetectorSum *> fSumMap;
 
-    G4bool fDetectSecondaries;
-    G4bool fDetectOpticalPhotons;
-    G4bool fDetectLowEnergyNeutrals;
-    G4bool fDetectBoundaryHits;
+      G4bool fDetectSecondaries;
+      G4bool fDetectOpticalPhotons;
+      G4bool fDetectLowEnergyNeutrals;
+      G4bool fDetectBoundaryHits;
 
-	G4int fDetNo;
+      G4int fDetNo;
 
-	G4bool fEnabled;
+      G4bool fEnabled;
 
-	G4GenericMessenger* fMessenger;
+      G4GenericMessenger* fMessenger;
 
 };
 

--- a/macros/issues/issue172.mac
+++ b/macros/issues/issue172.mac
@@ -27,8 +27,8 @@
 
 /remoll/seed 1234
 /remoll/filename issue172_lead_all.root
-/remoll/SD/type 1 lowenergyneutral
-/remoll/SD/type 1 secondaries
+/remoll/SD/detect lowenergyneutral 1
+/remoll/SD/detect secondaries 1
 /run/beamOn 1
 
 

--- a/macros/issues/issue172.mac
+++ b/macros/issues/issue172.mac
@@ -1,8 +1,8 @@
 /remoll/geometry/verbose 1
 /remoll/geometry/setfile geometry/issues/issue172.gdml
 
-/remoll/physlist/verbose 1
-/remoll/physlist/steplimiter/enable
+/remoll/kryptonite/verbose 1
+/remoll/kryptonite/add G4_Pb
 
 /run/initialize
 
@@ -12,19 +12,23 @@
 /remoll/evgen/set beam
 /remoll/evgen/beam/origin 0 0 -0.5 m
 
-/remoll/kryptonite/add G4_Pb
-/remoll/kryptonite/list
-
 
 /remoll/seed 1234
 /remoll/filename issue172_krypt.root
-/remoll/kryptonite/set true
+/remoll/kryptonite/enable
 /run/beamOn 1
 
 
 /remoll/seed 1234
 /remoll/filename issue172_lead.root
-/remoll/kryptonite/set false
+/remoll/kryptonite/disable
+/run/beamOn 1
+
+
+/remoll/seed 1234
+/remoll/filename issue172_lead_all.root
+/remoll/SD/type 1 lowenergyneutral
+/remoll/SD/type 1 secondaries
 /run/beamOn 1
 
 

--- a/src/remollActionInitialization.cc
+++ b/src/remollActionInitialization.cc
@@ -9,7 +9,6 @@
 
 #include "remollRunAction.hh"
 #include "remollEventAction.hh"
-#include "remollSteppingAction.hh"
 #include "remollTrackingAction.hh"
 #include "remollPrimaryGeneratorAction.hh"
 
@@ -22,10 +21,6 @@ void remollActionInitialization::Build() const
   // Event action
   remollEventAction* event_action = new remollEventAction();
   SetUserAction(event_action);
-
-  // Stepping action
-  remollSteppingAction* stepping_action = new remollSteppingAction();
-  SetUserAction(stepping_action);
 
   // Tracking action
   remollTrackingAction* tracking_action = new remollTrackingAction();

--- a/src/remollGenericDetector.cc
+++ b/src/remollGenericDetector.cc
@@ -93,7 +93,7 @@ void remollGenericDetector::BuildStaticMessenger()
     "Print all detectors");
 
   fStaticMessenger->DeclareMethod(
-    "type",
+    "detect",
     &remollGenericDetector::SetOneDetectorType,
     "Set detector type");
 }
@@ -170,7 +170,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
         G4cout << "remoll: To save optical photon hits, use the following in gdml:" << G4endl;
         G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"opticalphoton\"/>" << G4endl;
         G4cout << "remoll: or use the following in your macro:" << G4endl;
-        G4cout << "remoll:   /remoll/SD/detect_opticalphoton 4001" << G4endl;
+        G4cout << "remoll:   /remoll/SD/detect opticalphoton 4001" << G4endl;
         has_been_warned = true;
       }
       return false;
@@ -187,7 +187,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
         G4cout << "remoll: To save low energy neutral hits, use the following in gdml:" << G4endl;
         G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"lowenergyneutral\"/>" << G4endl;
         G4cout << "remoll: or use the following in your macro:" << G4endl;
-        G4cout << "remoll:   /remoll/SD/detect_lowenergyneutral 4001" << G4endl;
+        G4cout << "remoll:   /remoll/SD/detect lowenergyneutral 4001" << G4endl;
         has_been_warned = true;
       }
       return false;
@@ -222,7 +222,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
         G4cout << "remoll: To save entry boundary hits alone, use the following in gdml:" << G4endl;
         G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"boundaryhits\"/>" << G4endl;
         G4cout << "remoll: or use the following in your macro:" << G4endl;
-        G4cout << "remoll:   /remoll/SD/detect_boundaryhits 4001" << G4endl;
+        G4cout << "remoll:   /remoll/SD/detect boundaryhits 4001" << G4endl;
         has_been_warned = true;
       }
       return false;
@@ -239,7 +239,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
         G4cout << "remoll: To save secondary track hits too, use the following in gdml:" << G4endl;
         G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"secondaries\"/>" << G4endl;
         G4cout << "remoll: or use the following in your macro:" << G4endl;
-        G4cout << "remoll:   /remoll/SD/detect_secondaries 4001" << G4endl;
+        G4cout << "remoll:   /remoll/SD/detect secondaries 4001" << G4endl;
         has_been_warned = true;
       }
       return false;

--- a/src/remollGenericDetector.cc
+++ b/src/remollGenericDetector.cc
@@ -180,6 +180,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
     // Ignore neutral particles below 0.1 MeV (non optical photon) as set by DetType == lowenergyneutral
     G4double charge = particle->GetPDGCharge();
     if (! fDetectLowEnergyNeutrals
+        && particle != G4OpticalPhoton::OpticalPhotonDefinition()
         && charge == 0.0 && track->GetTotalEnergy() < 0.1*CLHEP::MeV) {
       static bool has_been_warned = false;
       if (! has_been_warned) {

--- a/src/remollGenericDetector.cc
+++ b/src/remollGenericDetector.cc
@@ -24,10 +24,10 @@ remollGenericDetector::remollGenericDetector( G4String name, G4int detnum )
   assert(detnum > 0);
   SetDetNo(detnum);
 
-  fDetectSecondaries = true;
+  fDetectSecondaries = false;
   fDetectOpticalPhotons = false;
   fDetectLowEnergyNeutrals = false;
-  fBoundaryHits = false;
+  fDetectBoundaryHits = false;
 
   std::stringstream genhit;
   genhit << "genhit_" << detnum;
@@ -50,6 +50,8 @@ remollGenericDetector::remollGenericDetector( G4String name, G4int detnum )
 remollGenericDetector::~remollGenericDetector()
 {
   EraseGenericDetector(this);
+
+  fSumMap.clear();
 }
 
 void remollGenericDetector::BuildStaticMessenger()
@@ -89,22 +91,32 @@ void remollGenericDetector::BuildStaticMessenger()
     "print_all",
     &remollGenericDetector::PrintAll,
     "Print all detectors");
+
+  fStaticMessenger->DeclareMethod(
+    "type",
+    &remollGenericDetector::SetOneDetectorType,
+    "Set detector type");
 }
 
 void remollGenericDetector::Initialize(G4HCofThisEvent*)
 {
-    fHitColl = new remollGenericDetectorHitCollection(SensitiveDetectorName, collectionName[0]);
-    fSumColl = new remollGenericDetectorSumCollection(SensitiveDetectorName, collectionName[1]);
+  fHitColl = new remollGenericDetectorHitCollection(SensitiveDetectorName, collectionName[0]);
+  fSumColl = new remollGenericDetectorSumCollection(SensitiveDetectorName, collectionName[1]);
 
-    fSumMap.clear();
+  fSumMap.clear();
 }
 
-G4bool remollGenericDetector::ProcessHits(G4Step *step, G4TouchableHistory *)
+G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
 {
-    G4bool badedep = false;
-    G4bool badhit  = false;
+    // Process the hits in this detector:
+    // - if the detector is disabled entirely, we do not store anything, not even sums
+    // - all hits are always processed into detector sums with energy deposition
+    // - depending on the detector settings we can return false without writing an
+    //   individual hit
+    // - if we do write an individual hit we return true
 
-    // Ignore this detector if disabled
+
+    // Ignore this detector if disabled as set by /remoll/SD/disable
     if (! fEnabled) {
       static bool has_been_warned = false;
       if (! has_been_warned) {
@@ -120,38 +132,67 @@ G4bool remollGenericDetector::ProcessHits(G4Step *step, G4TouchableHistory *)
       return false;
     }
 
-    // Ignore optical photons as hits (but still simulate them
-    // so they can knock out electrons of the photocathode)
-    if (! fDetectOpticalPhotons
-        && step->GetTrack()->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()) {
-      static bool has_been_warned = false;
-      if (! has_been_warned) {
-        G4cout << "remoll: Optical photons simulated but not stored for all detectors." << G4endl;
-        G4cout << "remoll: To save optical photon hits, use the following in gdml:" << G4endl;
-        G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"opticalphoton\"/>" << G4endl;
-        has_been_warned = true;
-      }
-      return false;
-    }
-
-    // Det Type: Ignore neutral particles below 0.1 MeV
-    G4double charge = step->GetTrack()->GetDefinition()->GetPDGCharge();
-    if (! fDetectLowEnergyNeutrals
-        && charge == 0.0 && step->GetTrack()->GetTotalEnergy() < 0.1*CLHEP::MeV) {
-      static bool has_been_warned = false;
-      if (! has_been_warned) {
-        G4cout << "remoll: <0.1 MeV neutrals simulated but not stored for all detectors." << G4endl;
-        G4cout << "remoll: To save low energy neutral hits, use the following in gdml:" << G4endl;
-        G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"lowenergyneutral\"/>" << G4endl;
-        has_been_warned = true;
-      }
-      return false;
-    }
 
     // Get the step point and track
-    G4StepPoint* prepoint = step->GetPreStepPoint();
-    G4StepPoint* postpoint = step->GetPostStepPoint();
     G4Track*     track = step->GetTrack();
+    G4StepPoint* prepoint  = step->GetPreStepPoint();
+    G4StepPoint* postpoint = step->GetPostStepPoint();
+    G4ParticleDefinition* particle = track->GetDefinition();
+
+    // Get copy ID from touchable history
+    G4TouchableHistory* hist
+      = (G4TouchableHistory*) (prepoint->GetTouchable());
+    G4VPhysicalVolume* volume = hist->GetVolume();
+    G4int copyID = volume->GetCopyNo();
+
+
+    // Create a detector sum for this detector, if necessary
+    if (! fSumMap.count(copyID)) {
+      remollGenericDetectorSum* sum = new remollGenericDetectorSum(fDetNo, copyID);
+      fSumMap[copyID] = sum;
+      fSumColl->insert(sum);
+    }
+
+    // Add energy deposit to detector sum
+    G4int pid = particle->GetPDGEncoding();
+    G4ThreeVector pos = prepoint->GetPosition();
+    G4double edep = step->GetTotalEnergyDeposit();
+    remollGenericDetectorSum* sum = fSumMap[copyID];
+    sum->AddEDep(pid, pos, edep);
+
+
+    // Ignore optical photons as hits as set by DetType == opticalphoton
+    if (! fDetectOpticalPhotons
+        && particle == G4OpticalPhoton::OpticalPhotonDefinition()) {
+      static bool has_been_warned = false;
+      if (! has_been_warned) {
+        G4cout << "remoll: Optical photons simulated but not stored for some detectors." << G4endl;
+        G4cout << "remoll: To save optical photon hits, use the following in gdml:" << G4endl;
+        G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"opticalphoton\"/>" << G4endl;
+        G4cout << "remoll: or use the following in your macro:" << G4endl;
+        G4cout << "remoll:   /remoll/SD/detect_opticalphoton 4001" << G4endl;
+        has_been_warned = true;
+      }
+      return false;
+    }
+
+
+    // Ignore neutral particles below 0.1 MeV (non optical photon) as set by DetType == lowenergyneutral
+    G4double charge = particle->GetPDGCharge();
+    if (! fDetectLowEnergyNeutrals
+        && charge == 0.0 && track->GetTotalEnergy() < 0.1*CLHEP::MeV) {
+      static bool has_been_warned = false;
+      if (! has_been_warned) {
+        G4cout << "remoll: <0.1 MeV neutrals simulated but not stored for some detectors." << G4endl;
+        G4cout << "remoll: To save low energy neutral hits, use the following in gdml:" << G4endl;
+        G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"lowenergyneutral\"/>" << G4endl;
+        G4cout << "remoll: or use the following in your macro:" << G4endl;
+        G4cout << "remoll:   /remoll/SD/detect_lowenergyneutral 4001" << G4endl;
+        has_been_warned = true;
+      }
+      return false;
+    }
+
 
     // First step in volume?
     G4bool firststepinvolume = false;
@@ -171,101 +212,85 @@ G4bool remollGenericDetector::ProcessHits(G4Step *step, G4TouchableHistory *)
       }
     }
 
-    // Get touchable volume info
-    G4TouchableHistory *hist = (G4TouchableHistory*)(prepoint->GetTouchable());
-    G4int  copyID = hist->GetVolume()->GetCopyNo();//return the copy id of the logical volume
-
-    G4double edep = step->GetTotalEnergyDeposit();
-
-    // We're just going to record primary particles and things
-    // that have just entered our boundary
-    //the following condition ensure that not all the hits are recorded. This will reflect in the energy deposit sum from the hits compared to the energy deposit from the hit sum detectors.
-    badhit = true;
-    if (track->GetCreatorProcess() == 0 ||
-	(fDetectSecondaries && firststepinvolume)) {
-	badhit = false;
-    }
-
-    badedep = false;
-    if (edep <= 0.0) {
-        badedep = true;
-    }
-
-    // Det Type: Only detect hits that are on the incident boundary edge of the geometry in question
-    if (fBoundaryHits
+    // Only detect hits that are on the incident boundary edge of the geometry in question
+    // as set by DetType == boundaryhits
+    if (fDetectBoundaryHits
         && ! firststepinvolume){
       static bool has_been_warned = false;
       if (! has_been_warned) {
-        G4cout << "remoll: only hits on the boundary are being stored for boundaryhits==true detectors." << G4endl;
-        G4cout << "remoll: To save just boundary hits alone, use the following in gdml:" << G4endl;
+        G4cout << "remoll: Only hits at the entry boundary are stored for some detectors." << G4endl;
+        G4cout << "remoll: To save entry boundary hits alone, use the following in gdml:" << G4endl;
         G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"boundaryhits\"/>" << G4endl;
+        G4cout << "remoll: or use the following in your macro:" << G4endl;
+        G4cout << "remoll:   /remoll/SD/detect_boundaryhits 4001" << G4endl;
         has_been_warned = true;
       }
       return false;
     }
 
+
+    // Ignore interior tracks
+    if (! fDetectSecondaries
+        && track->GetCreatorProcess() != 0 && ! firststepinvolume) {
+      static bool has_been_warned = false;
+      if (! has_been_warned) {
+        G4cout << "remoll: Only full hits from primary tracks are being stored by default." << G4endl;
+        G4cout << "remoll: For secondaries only the first hit in the volume is stored." << G4endl;
+        G4cout << "remoll: To save secondary track hits too, use the following in gdml:" << G4endl;
+        G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"secondaries\"/>" << G4endl;
+        G4cout << "remoll: or use the following in your macro:" << G4endl;
+        G4cout << "remoll:   /remoll/SD/detect_secondaries 4001" << G4endl;
+        has_been_warned = true;
+      }
+      return false;
+    }
+
+
     /////////////////////////////////////////////////////
 
-    // Do the actual data grabbing
+    remollGenericDetectorHit* hit = new remollGenericDetectorHit(fDetNo, copyID);
+    fHitColl->insert(hit);
 
-    if (! badedep) {
-        // Sum
-        remollGenericDetectorSum* thissum = 0;
-        if (! fSumMap.count(copyID)) {
-	    thissum = new remollGenericDetectorSum(fDetNo, copyID);
-	    fSumMap[copyID] = thissum;
-	    fSumColl->insert(thissum);
-        } else thissum = fSumMap[copyID];
 
-        // Add energy deposit
-        thissum->AddEDep(track->GetDefinition()->GetPDGEncoding(), prepoint->GetPosition(), edep );
+    // Which point do we store? (important for optical photons at boundaries)
+    G4StepPoint* point = 0;
+    // optical absorption
+    if (particle == G4OpticalPhoton::OpticalPhotonDefinition()
+     && postpoint->GetStepStatus() == fGeomBoundary) {
+      point = postpoint;
+    // all other cases
+    } else {
+      point = prepoint;
     }
 
-    if (! badhit) {
-        // Hit
-        remollGenericDetectorHit* thishit = new remollGenericDetectorHit(fDetNo, copyID);
-        fHitColl->insert( thishit );
 
-        // Which point do we store?
-        G4StepPoint* point = 0;
-        // optical absorption
-        if (step->GetTrack()->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()
-         && postpoint->GetStepStatus() == fGeomBoundary) {
-          point = postpoint;
-        // all other cases
-        } else {
-          point = prepoint;
-        }
+    // Positions
+    G4ThreeVector global_position = point->GetPosition();
+    G4ThreeVector local_position = point->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(global_position);
+    hit->f3X  = global_position;
+    hit->f3Xl = local_position;
 
-        // Positions
-        G4ThreeVector global_position = point->GetPosition();
-        G4ThreeVector local_position = point->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(global_position);
-        thishit->f3X  = global_position;
-        thishit->f3Xl = local_position;
+    hit->f3V  = track->GetVertexPosition();
+    hit->f3P  = track->GetMomentum();
+    hit->f3S  = track->GetPolarization();
 
-        thishit->f3V  = track->GetVertexPosition();
-        thishit->f3P  = track->GetMomentum();
-        thishit->f3S  = track->GetPolarization();
+    hit->fTime = point->GetGlobalTime();
 
-        thishit->fTime = point->GetGlobalTime();
+    hit->f3dP = track->GetMomentumDirection();
 
-        thishit->f3dP = track->GetMomentumDirection();
+    hit->fP = track->GetMomentum().mag();
+    hit->fE = track->GetTotalEnergy();
+    hit->fM = particle->GetPDGMass();
 
-        thishit->fP = track->GetMomentum().mag();
-        thishit->fE = track->GetTotalEnergy();
-        thishit->fM = track->GetDefinition()->GetPDGMass();
+    hit->fTrID  = track->GetTrackID();
+    hit->fmTrID = track->GetParentID();
+    hit->fPID   = particle->GetPDGEncoding();
 
-        thishit->fTrID  = track->GetTrackID();
-        thishit->fmTrID = track->GetParentID();
-        thishit->fPID   = track->GetDefinition()->GetPDGEncoding();
-        thishit->fEdep  = edep; 
-        // FIXME - Enumerate encodings
-        thishit->fGen   = (long int) track->GetCreatorProcess();
+    hit->fGen   = (long int) track->GetCreatorProcess();
 
-        thishit->fEdep  = step->GetTotalEnergyDeposit();
-    }
+    hit->fEdep  = step->GetTotalEnergyDeposit();
 
-    return !badedep && !badhit;
+    return true;
 }
 
 void remollGenericDetector::EndOfEvent(G4HCofThisEvent* HCE)


### PR DESCRIPTION
Since this is a quite major set of changes to how some of the hits
are being stored, I am putting this in a bugfix branch first so I
can test optical photon hit behavior and let @cameronc137 take a look.

In any case, here's hit behavior:
- by default only hits are stored that satisfy the following:
  - charge particle, energy > 0.1 MeV
  - anywhere along a primary track
  - first hit in volume for secondary track
- all hits (even those not stored) are added to the detector sums

To modify this behavior you can use
```
/remoll/SD/type 4001 lowenergyneutral
/remoll/SD/type 4001 secondaries
```
along with similar GDML statements (also possible: `opticalphotons`
and `boundaryhits`).

As for kryptonite, this was all moved to remollDetectorConstruction
and stepping action was removed (since now not useful). Here is the
code for kryptonite:
```
/remoll/kryptonite/verbose 1
/remoll/kryptonite/add G4_Pb
/remoll/kryptonite/list
/remoll/kryptonite/enable
/remoll/kryptonite/disable
```
(This is different from previous `/remoll/kryptonite/set true` since
we need a method and those don't work with `G4GenericMessenger::DefineMethod`
since a G4bool looks like a G4int and yada yada yada.)

Finally, kryptonite now acts by setting all volumes that have the
specified material in question with userlimits to (0,0,0,inf,inf).
This means that all energy is deposited in the first hit, making
the sums correct. Essentially it sets the userlimits to:
```
/remoll/geometry/userlimits/usermaxallowedstep krypt_logical 0.0*mm
/remoll/geometry/userlimits/usermaxtracklength krypt_logical 0.0*mm
/remoll/geometry/userlimits/usermaxtime krypt_logical 0.0*ns
/remoll/geometry/userlimits/userminekine krypt_logical 1000*GeV
/remoll/geometry/userlimits/userminrange krypt_logical 1000*km
```
for those volumes. It does mean that steplimiter must be enabled
by default. And if you disable steplimiter and still try to use
userlimits or kryptonite there is no warning... so don't do that.