### PR TITLE
Merge feature-sums-refactor branch into develop

### DIFF
--- a/analysis/issues/issue172.C
+++ b/analysis/issues/issue172.C
@@ -19,6 +19,10 @@ void Analyze(TChain* T)
     for (size_t isum = 0; isum < sums->size(); isum++) {
       remollGenericDetectorSum_t sum = sums->at(isum);
       std::cout << "sum: " << sum.edep << " MeV" << std::endl;
+      for (size_t ipid = 0; ipid < sum.by_pid.size(); ipid++) {
+        std::cout << "sum [pid = " << sum.by_pid[ipid].pid << "]: "
+                  << sum.by_pid[ipid].edep << " MeV" << std::endl;
+      }
     }
   }
 }

--- a/analysis/issues/issue172.C
+++ b/analysis/issues/issue172.C
@@ -21,7 +21,11 @@ void Analyze(TChain* T)
       std::cout << "sum: " << sum.edep << " MeV" << std::endl;
       for (size_t ipid = 0; ipid < sum.by_pid.size(); ipid++) {
         std::cout << "sum [pid = " << sum.by_pid[ipid].pid << "]: "
-                  << sum.by_pid[ipid].edep << " MeV" << std::endl;
+                  << sum.by_pid[ipid].edep << " MeV at ("
+                  << sum.by_pid[ipid].x << ", "
+                  << sum.by_pid[ipid].y << ", "
+                  << sum.by_pid[ipid].z << ") mm "
+                  << std::endl;
       }
     }
   }

--- a/include/remollGenericDetectorSum.hh
+++ b/include/remollGenericDetectorSum.hh
@@ -29,21 +29,20 @@ class remollGenericDetectorSum : public G4VHit {
 	G4int    fCopyID;
 	G4double fEdep;
 
-	void AddEDep( int pid, G4ThreeVector x, double ene );
+	void AddEDep(int pid, G4ThreeVector x, double edep);
 
-	double GetEdep(int pid = 0) const;
-	G4ThreeVector GetPos(int pid = 0) const;
-
-	std::vector<remollGenericDetectorSumByPID_t> fSumByPID;
+	std::map<int,remollGenericDetectorSumByPID_t> fSumByPID;
 
     public:
       const remollGenericDetectorSum_t GetGenericDetectorSumIO() const {
         remollGenericDetectorSum_t sum;
         sum.det = fDetID;
         sum.vid = fCopyID;
-        sum.edep = GetEdep();
-        for (size_t i = 0; i < fSumByPID.size(); i++) {
-          sum.by_pid.push_back(fSumByPID[i]);
+        sum.edep = fEdep;
+        for (std::map<int,remollGenericDetectorSumByPID_t>::const_iterator
+            it  = fSumByPID.begin();
+            it != fSumByPID.end(); ++it) {
+          sum.by_pid.push_back(it->second);
         }
         return sum;
       }

--- a/src/remollGenericDetectorSum.cc
+++ b/src/remollGenericDetectorSum.cc
@@ -12,7 +12,7 @@ void remollGenericDetectorSum::AddEDep(int pid, G4ThreeVector pos, double edep)
   fEdep += edep;
 
   if (fSumByPID.count(pid) == 0)
-    fSumByPID.at(pid) = {.x = 0, .y = 0, .z = 0, .edep = 0, .pid = pid};
+    fSumByPID[pid] = {.x = 0, .y = 0, .z = 0, .edep = 0, .pid = pid};
 
   G4double oldedep = fSumByPID[pid].edep;
   fSumByPID[pid].edep += edep;

--- a/src/remollGenericDetectorSum.cc
+++ b/src/remollGenericDetectorSum.cc
@@ -18,9 +18,11 @@ void remollGenericDetectorSum::AddEDep(int pid, G4ThreeVector pos, double edep)
   fSumByPID[pid].edep += edep;
   G4double newedep = fSumByPID[pid].edep;
 
-  fSumByPID[pid].x = (oldedep * fSumByPID[pid].x + edep * pos.x()) / newedep;
-  fSumByPID[pid].y = (oldedep * fSumByPID[pid].y + edep * pos.y()) / newedep;
-  fSumByPID[pid].z = (oldedep * fSumByPID[pid].z + edep * pos.z()) / newedep;
+  if (newedep > 0.0) { // avoid division by zero for first hit with zero edep
+    fSumByPID[pid].x = (oldedep * fSumByPID[pid].x + edep * pos.x()) / newedep;
+    fSumByPID[pid].y = (oldedep * fSumByPID[pid].y + edep * pos.y()) / newedep;
+    fSumByPID[pid].z = (oldedep * fSumByPID[pid].z + edep * pos.z()) / newedep;
+  }
 }
 
 remollGenericDetectorSum::remollGenericDetectorSum(const remollGenericDetectorSum &right)

--- a/src/remollGenericDetectorSum.cc
+++ b/src/remollGenericDetectorSum.cc
@@ -3,65 +3,24 @@
 G4ThreadLocal G4Allocator<remollGenericDetectorSum>* remollGenericDetectorSumAllocator = 0;
 
 remollGenericDetectorSum::remollGenericDetectorSum(int detid, int copyid)
-: fDetID(detid),fCopyID(copyid) {
-  fEdep   = 0.0;
-
-  // Particles that are payed attention to in our sums, 0 means all types
-  std::vector<int> particles_to_track;
-  particles_to_track.push_back(0);
-  particles_to_track.push_back(-11);
-  particles_to_track.push_back( 11);
-  particles_to_track.push_back( 22);
-  particles_to_track.push_back(2112);
-  particles_to_track.push_back(2212);
-  particles_to_track.push_back(-211);
-  particles_to_track.push_back( 211);
-}
+: fDetID(detid),fCopyID(copyid),fEdep(0.0) { }
 
 remollGenericDetectorSum::~remollGenericDetectorSum() { }
 
-void remollGenericDetectorSum::AddEDep(int pid, G4ThreeVector pos, double ene)
+void remollGenericDetectorSum::AddEDep(int pid, G4ThreeVector pos, double edep)
 {
-    remollGenericDetectorSumByPID_t sum_by_pid;
+  fEdep += edep;
 
-    sum_by_pid.edep = ene;
-    sum_by_pid.x    = pos.x();
-    sum_by_pid.y    = pos.y();
-    sum_by_pid.z    = pos.z();
-    sum_by_pid.pid  = pid;
+  if (fSumByPID.count(pid) == 0)
+    fSumByPID.at(pid) = {.x = 0, .y = 0, .z = 0, .edep = 0, .pid = pid};
 
-    fSumByPID.push_back(sum_by_pid);
-}
+  G4double oldedep = fSumByPID[pid].edep;
+  fSumByPID[pid].edep += edep;
+  G4double newedep = fSumByPID[pid].edep;
 
-double remollGenericDetectorSum::GetEdep(int pid) const
-{
-    double esum = 0.0;
-
-    for (std::vector<remollGenericDetectorSumByPID_t>::const_iterator it = fSumByPID.begin() ; it != fSumByPID.end(); ++it){
-	if( pid==0 || (*it).pid == pid ){
-	    esum += (*it).edep;
-	}
-    }
-
-    return esum;
-}
-
-G4ThreeVector remollGenericDetectorSum::GetPos(int pid) const
-{
-    double esum = 0.0;
-    double xsum, ysum, zsum;
-    xsum = ysum = zsum = 0.0;
-
-    for (std::vector<remollGenericDetectorSumByPID_t>::const_iterator it = fSumByPID.begin() ; it != fSumByPID.end(); ++it){
-	if( pid==0 || (*it).pid == pid ){
-	    xsum += (*it).x*(*it).edep;
-	    ysum += (*it).y*(*it).edep;
-	    zsum += (*it).z*(*it).edep;
-	    esum += (*it).edep;
-	}
-    }
-
-    return G4ThreeVector(xsum/esum, ysum/esum, zsum/esum);
+  fSumByPID[pid].x = (oldedep * fSumByPID[pid].x + edep * pos.x()) / newedep;
+  fSumByPID[pid].y = (oldedep * fSumByPID[pid].y + edep * pos.y()) / newedep;
+  fSumByPID[pid].z = (oldedep * fSumByPID[pid].z + edep * pos.z()) / newedep;
 }
 
 remollGenericDetectorSum::remollGenericDetectorSum(const remollGenericDetectorSum &right)


### PR DESCRIPTION
This seems to work fine now on the #172 test case.

For an electron hitting lead, only a subset of hits are stored (those with > 0.1 MeV energy, for example) but all are included in the sums. The pids 1000822060 and 1000822080 are lead 206 and 208 nuclei (see http://pdg.lbl.gov/2017/reviews/rpp2017-rev-monte-carlo-numbering.pdf if you are curious).
```
Lead
hit: 2.79084 0.250722 0.126983 0.751546 0.689868 0.136596 0.169301 1.72661 0.695538 0.00539331 0.232751 0.0403262 0.136237 0.624287 0.344374 0.638755 0.684848 0.231549 0.831656 1.49825 0.16947 0.233465 0.031472 0.214394 0.572451 0.593841 0.919408 0.0527639 0.66293 0.281838 0.386466 0.69345 0.653826 0.206384 0.727071 0.923065 1.09825 3.8036 0.773688 1.65728 4.2843 1.58518 0.969855 1.89878 2.54394 3.02038 0.554339 MeV
hit sum = 42.1183 MeV
sum: 10971.5 MeV
sum [pid = -11]: 3229.72 MeV
sum [pid = 11]: 7339.18 MeV
sum [pid = 22]: 402.575 MeV
sum [pid = 1000822060]: 0.00104249 MeV
sum [pid = 1000822080]: 0.00179189 MeV
Krypt
hit: 10999.5 MeV
hit sum = 10999.5 MeV
sum: 10999.5 MeV
sum [pid = 11]: 10999.5 MeV
```