### PR TITLE
Merge bugfix to save all hits into develop

### DIFF
--- a/geometry/hybridDaughter_merged.gdml
+++ b/geometry/hybridDaughter_merged.gdml
@@ -1480,7 +1480,7 @@
       <!-- <solidref ref="boxDSShieldColl1_solid"/> -->
       <solidref ref="boxDSShieldColl1_sub_solid"/>
       <auxiliary auxtype="Color" auxvalue="green"/>
-      <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+      <!--<auxiliary auxtype="Alpha" auxvalue="0.1"/>-->
       <auxiliary auxtype="SensDet" auxvalue="Shielding_Block_3_Det"/> <!-- NEW Sensitive detector FIXME -->
       <auxiliary auxtype="DetNo" auxvalue="6020"/>
     </volume>
@@ -1494,7 +1494,7 @@
 <!--        <materialref ref="Kryptonite"/> -->
       <solidref ref="boxDSPolyShield1_solid"/>
       <auxiliary auxtype="Color" auxvalue="Brown"/>
-      <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+	      <!--<auxiliary auxtype="Alpha" auxvalue="0.1"/>-->
       <auxiliary auxtype="SensDet" auxvalue="Poly_Shielding_Block_3_Det"/> <!-- NEW Sensitive detector FIXME -->
       <auxiliary auxtype="DetNo" auxvalue="6021"/>
     </volume>
@@ -1545,7 +1545,7 @@
       <materialref ref="Concrete"/>
       <solidref ref="boxDSShield1_local_solid"/>
       <auxiliary auxtype="Color" auxvalue="green"/>
-      <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+      <!--<auxiliary auxtype="Alpha" auxvalue="0.1"/>-->
       <auxiliary auxtype="SensDet" auxvalue="Shielding_Block_Local_poly"/> <!-- NEW Sensitive detector FIXME -->
       <auxiliary auxtype="DetNo" auxvalue="6031"/>
     </volume>
@@ -1553,7 +1553,7 @@
       <materialref ref="Polythene"/>
       <solidref ref="boxDSShield1_polylocal_solid"/>
       <auxiliary auxtype="Color" auxvalue="brown"/>
-      <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+	      <!--<auxiliary auxtype="Alpha" auxvalue="0.1"/>-->
       <auxiliary auxtype="SensDet" auxvalue="Shielding_Block_Local_poly"/> <!-- NEW Sensitive detector FIXME -->
       <auxiliary auxtype="DetNo" auxvalue="6032"/>
     </volume>

--- a/geometry/mollerMother_merged.gdml
+++ b/geometry/mollerMother_merged.gdml
@@ -31,7 +31,8 @@
       <solidref ref="boxMother"/>
 
       <physvol>
-      <file name="targetDaughter_Clamshell_Optimized.gdml"/>
+	      <!--<file name="targetDaughter_Clamshell_Optimized.gdml"/>-->
+      <file name="subTargetRegion.gdml"/>
       <positionref ref="targetCenter_Clamshell"/>
       <!--<file name="targetDaughter_merged.gdml"/>
       <positionref ref="targetCenter"/>-->

--- a/geometry/subTargetRegion.gdml
+++ b/geometry/subTargetRegion.gdml
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE gdml [
+<!ENTITY materials SYSTEM "materials.xml">
+]>
+
+<gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
+
+  <define>
+
+    <constant name="targetChamber_R" value="1981.0/2.0"/>
+    <constant name="targetChamber_L" value="1829."/>
+    <constant name="targetChamber_thickness" value="13."/>
+    <constant name="targetChamberLid_thickness" value="76."/>
+	    <!--<constant name="targetChamberHat_L" value="3658."/>-->
+    <constant name="targetChamberHat_L" value="1000."/>
+	    
+	    
+    <!--constant for shieldings - dimension from Alan design -->
+    <constant name="polyBoxx" value="7690."/>
+	    <!--<constant name="polyBoxy" value="9510."/>-->
+    <constant name="polyBoxy" value="6700."/>
+    <constant name="polyBoxz" value="6350."/>
+	    <!--<constant name="polyBoxz" value="6990."/>-->
+	    <!--<constant name="polyThickness" value="1550"/>-->
+    <constant name="polyThickness" value="1400"/>
+    
+    <!--constant for lead shieldings - dimension from Alan design -->
+    <constant name="leadBoxx" value="3770."/>
+    <constant name="leadBoxy" value="2550."/>
+    <constant name="leadBoxz" value="400."/>
+    
+    <constant name="Shield_bore" value="400"/>
+    <constant name="Shield_length" value="polyBoxz+2"/>
+    
+    <position name="origin" x="0" y="0" z="0"/>
+
+    <rotation name="rot_x90" unit="deg" x="90"/>
+  </define>
+
+  &materials;
+
+  <solids>
+
+    <box lunit="m" name="targetRegion_solid"
+	 x="10" y="10" z="6.36"/>
+
+    <tube aunit="deg" lunit="mm" deltaphi="360" name="target_solid"
+	  rmax="40" rmin="0" z="1500"/>
+
+    <tube aunit="deg" lunit="mm" deltaphi="360" name="AlWindow"
+	  rmax="40" rmin="0" z="0.127"/>
+
+    <tube aunit="deg" lunit="mm" deltaphi="360" name="targetChamber_solid1"
+	  rmin="targetChamber_R"
+	  rmax="targetChamber_R + targetChamber_thickness"
+	  z="targetChamber_L"/>
+    <tube aunit="deg" lunit="mm" deltaphi="360" name="targetChamberEntrancePort_solid"
+	  rmin="0" rmax="102" z="100"/>
+    <tube aunit="deg" lunit="mm" deltaphi="360" name="targetChamberExitPort_solid"
+	  rmin="0" rmax="204" z="100"/>
+    <subtraction name ="targetChamber_solid2">
+      <first ref="targetChamber_solid1"/>
+      <second ref="targetChamberEntrancePort_solid"/>
+      <position name="targetChamberEntrance_pos" x="0" z="0" y="targetChamber_R" />
+      <rotationref ref="rot_x90"/>
+    </subtraction>
+    <subtraction name ="targetChamber_solid3">
+      <first ref="targetChamber_solid2"/>
+      <second ref="targetChamberExitPort_solid"/>
+      <position name="targetChamberExit_pos" x="0" z="0" y="-targetChamber_R" />
+      <rotationref ref="rot_x90"/>
+    </subtraction>
+
+    <tube aunit="deg" lunit="mm" deltaphi="360" name="targetChamberLid_solid"
+	  rmin="0" rmax="targetChamber_R + targetChamber_thickness"
+	  z="targetChamberLid_thickness"/>
+    <union name ="targetChamber_solid4">
+        <first ref="targetChamber_solid3"/>
+        <second ref="targetChamberLid_solid"/>
+        <position name="targetChamberTop_pos"
+		  z="targetChamber_L/2. + targetChamberLid_thickness/2. - 1"/>
+    </union>
+    <union name ="targetChamber_solid">
+        <first ref="targetChamber_solid4"/>
+        <second ref="targetChamberLid_solid"/>
+        <position name="targetChamberBot_pos"
+		  z="-targetChamber_L/2. - targetChamberLid_thickness/2. + 1"/>
+    </union>
+
+    <tube aunit="deg" lunit="mm" deltaphi="360" name="targetChamberHat_solid"
+	  rmin="targetChamber_R" rmax="targetChamber_R + targetChamber_thickness"
+	  z="targetChamberHat_L"/>
+
+    <!-- Collimator 1 -->
+    <box lunit="mm" name="LeadCollar_solid1"
+   	 x="370" y="370" z="200"/>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="LeadCollarInnerSub_solid"
+   	  rmin="0" rmax="74" z="300"/>
+   <subtraction name ="LeadCollar_solid">
+     <first ref="LeadCollar_solid1"/>
+     <second ref="LeadCollarInnerSub_solid"/>
+     <positionref ref="origin" />
+   </subtraction>
+  
+  
+   <!--shielding poly -->
+    <box lunit="mm" name="poly_outerbox" x="polyBoxx" y="polyBoxy" z="polyBoxz"/>
+    <box lunit="mm" name="poly_innerbox" x="polyBoxx-2*polyThickness" y="polyBoxy" z="polyBoxz-2*polyThickness"/>
+
+    <subtraction name="poly_sub1">
+    <first ref = "poly_outerbox"/>
+    <second ref = "poly_innerbox"/>
+    <position name ="polySub1" lunit="mm" x="0" y="-polyThickness" z="0" />
+    </subtraction>
+
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="Shield_tube"
+   	  rmin="0" rmax="Shield_bore" z="Shield_length"/>
+
+    <subtraction name="poly_sub">
+    <first ref = "poly_sub1"/>
+    <second ref = "Shield_tube"/>
+    <position name ="polySub1" lunit="mm" x="polyBoxx/2.-3550" y="-1.*(polyBoxy/2.-3040)" z="0" />
+    </subtraction>
+
+   <!--shielding front lead -->
+    <box lunit="mm" name="lead_box" x="leadBoxx" y="leadBoxy" z="leadBoxz"/>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="Shield_tube_lead"
+   	  rmin="0" rmax="Shield_bore" z="leadBoxz+2"/>
+
+    <subtraction name="lead_sub">
+    <first ref = "lead_box"/>
+    <second ref = "Shield_tube_lead"/>
+    <position name ="leadSub1" lunit="mm" x="leadBoxx/2.-1880" y="-1.*(leadBoxy/2.-1150)" z="0" />
+    </subtraction>
+
+    <!--vacuum detectors for monitoring skyshine  chandan--> 
+    <box lunit="mm" name="skyshineVacuumDet1_solid"
+	    x="polyBoxx-polyThickness*2-1" y="1.0" z="polyBoxz-polyThickness*2-1.0"/>
+    <box lunit="mm" name="skyshineVacuumDet2_solid"
+	 x="polyBoxx+1000" y="1.0" z="polyBoxz"/>
+
+ </solids>
+
+ <structure>
+
+   <volume name="h2Targ">
+     <materialref ref="LiquidHydrogen"/>
+     <solidref ref="target_solid"/>
+     <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
+     <auxiliary auxtype="Color" auxvalue="blue"/>
+   </volume>
+
+   <volume name="USAlTarg">
+     <materialref ref="Aluminum"/>
+     <solidref ref="AlWindow"/>
+     <!-- <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/> -->
+     <auxiliary auxtype="Color" auxvalue="white"/>
+   </volume>
+
+   <volume name="DSAlTarg">
+     <materialref ref="Aluminum"/>
+     <solidref ref="AlWindow"/>
+     <!-- <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/> -->
+     <auxiliary auxtype="Color" auxvalue="white"/>
+   </volume>
+
+   <volume name="targetChamber">
+     <materialref ref="Aluminum"/>
+     <solidref ref="targetChamber_solid4"/>
+     <auxiliary auxtype="Color" auxvalue="white"/>
+   </volume>
+
+   <volume name="targetChamberHat">
+     <materialref ref="Aluminum"/>
+     <solidref ref="targetChamberHat_solid"/>
+     <auxiliary auxtype="Color" auxvalue="white"/>
+   </volume>
+
+   <volume name="LeadCollar_logic">
+     <materialref ref="Lead"/>
+     <solidref ref="LeadCollar_solid"/>
+     <auxiliary auxtype="Color" auxvalue="red"/>
+   </volume>
+
+
+   <!--Shielding-->
+   <volume name="PolyShield_target">
+   <materialref ref="Concrete"/>
+   <solidref ref="poly_sub"/>
+   <auxiliary auxtype="Color" auxvalue="Green"/>
+   <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+   </volume>
+
+   <volume name="LeadShield_target">
+   <materialref ref="Lead"/>
+   <solidref ref="lead_sub"/>
+   <auxiliary auxtype="Color" auxvalue="Red"/>
+   </volume>
+
+   <volume name="skyshineVacuumDet1_logic">
+   <materialref ref="VacuumDet"/>
+   <solidref ref="skyshineVacuumDet1_solid"/>
+   <auxiliary auxtype="Color" auxvalue="Blue"/>
+   <auxiliary auxtype="SensDet" auxvalue="shyshineVacuumDet_1"/>
+   <auxiliary auxtype="DetNo" auxvalue="5555"/>
+   </volume>
+
+   <volume name="skyshineVacuumDet2_logic">
+   <materialref ref="VacuumDet"/>
+   <solidref ref="skyshineVacuumDet2_solid"/>
+   <auxiliary auxtype="Color" auxvalue="Blue"/>
+   <auxiliary auxtype="SensDet" auxvalue="shyshineVacuumDet_2"/>
+   <auxiliary auxtype="DetNo" auxvalue="5556"/>
+   </volume>
+
+   <volume name="targetRegion">
+     <materialref ref="VacuumTarg"/>
+     <solidref ref="targetRegion_solid"/>
+
+     <physvol>
+       <volumeref ref="USAlTarg"/>
+       <position name="targ_upstream_window" unit="mm" x="0" y="0" z="-750-1"/>
+     </physvol>
+
+     <physvol>
+       <volumeref ref="h2Targ"/>
+       <position name="targ_center1" unit="mm" x="0" y="0" z="0"/>
+     </physvol>
+
+     <physvol>
+       <volumeref ref="DSAlTarg"/>
+       <position name="targ_downstream_window" unit="mm" x="0" y="0" z="750+1"/>
+     </physvol>
+
+     <physvol>
+       <volumeref ref="targetChamber"/>
+       <position name="targetChamber_pos" unit="mm" x="0" y="0" z="0"/>
+       <rotationref ref="rot_x90"/>
+     </physvol>
+
+     <physvol>
+       <volumeref ref="targetChamberHat"/>
+       <position name="targetChamberHat_pos" unit="mm" x="0" z="0"
+		 y="targetChamber_L/2 + targetChamberLid_thickness + targetChamberHat_L/2"/>
+       <rotationref ref="rot_x90"/>
+     </physvol>
+
+     <physvol>
+       <volumeref ref="LeadCollar_logic"/>
+       <position name="LeadCollar_pos" unit="mm" x="0" y="0"
+     		 z="2851 + 100"/>
+     </physvol>
+     
+     <!--shielding placement-->
+     <physvol>
+       <volumeref ref="PolyShield_target"/>
+	       <position name="PolyShield_pos" unit="mm" x="-1.*(polyBoxx/2.-3550)" y="polyBoxy/2.-3040" z="0"/>
+     </physvol>
+
+     <physvol>
+       <volumeref ref="LeadShield_target"/>
+       <position name="LeadShield_pos" unit="mm" x="-1.*(leadBoxx/2.-1880)" y="leadBoxy/2.-1150" z="1200+leadBoxz/2."/>
+     </physvol>
+
+     <!--placement of vacuum detector-->
+     <physvol>
+       <volumeref ref="skyshineVacuumDet1_logic"/>
+       <position name="shyshineVacuumDet1_pos" unit="mm" x="-1.*(polyBoxx/2.-3550)" y="targetChamber_L/2.+targetChamberHat_L+200" z="0"/>
+     </physvol>
+
+     <physvol>
+       <volumeref ref="skyshineVacuumDet2_logic"/>
+       <position name="shyshineVacuumDet2_pos" unit="mm" x="-1.*(polyBoxx/2.-3550)" y="polyBoxy/2+500" z="0"/>
+     </physvol>
+
+     <auxiliary auxtype="TargetSystem" auxvalue=""/>
+   </volume>
+
+ </structure>
+
+ <setup name="Target" version="1.0">
+   <world ref="targetRegion"/>
+ </setup>
+
+</gdml>

--- a/geometry/subTargetRegion.gdml
+++ b/geometry/subTargetRegion.gdml
@@ -12,18 +12,24 @@
     <constant name="targetChamber_L" value="1829."/>
     <constant name="targetChamber_thickness" value="13."/>
     <constant name="targetChamberLid_thickness" value="76."/>
-	    <!--<constant name="targetChamberHat_L" value="3658."/>-->
-    <constant name="targetChamberHat_L" value="1000."/>
+	    <constant name="targetChamberHat_L" value="3658."/> <!--Alan's design -->
+	<!--<constant name="targetChamberHat_L" value="1000."/> --> <!--Silviu's proposal -->
 	    
 	    
     <!--constant for shieldings - dimension from Alan design -->
-    <constant name="polyBoxx" value="7690."/>
-	    <!--<constant name="polyBoxy" value="9510."/>-->
-    <constant name="polyBoxy" value="6700."/>
-    <constant name="polyBoxz" value="6350."/>
-	    <!--<constant name="polyBoxz" value="6990."/>-->
-	    <!--<constant name="polyThickness" value="1550"/>-->
-    <constant name="polyThickness" value="1400"/>
+    <constant name="concreteBoxx" value="7690."/>
+    <constant name="concreteBoxy" value="6060."/><!-- Alan's design-->
+	<!--<constant name="concreteBoxy" value="6700."/> --> <!--Shielding dimension for Silviu's design-->
+    <constant name="concreteBoxz" value="6350."/>
+	    <!--<constant name="concreteBoxz" value="6990."/>-->
+	    <!--<constant name="concreteThickness" value="1550"/>-->
+    <constant name="concreteThickness" value="1400"/>
+
+	    <!--constants for target top shielding -->
+    <constant name="TopconcreteThickness" value="500"/>
+    <constant name="TopconcreteBoxx" value="(targetChamber_R+targetChamber_thickness+TopconcreteThickness)*2+100."/> <!--=TopconcreteBoxz; 100 mm is buffer zone-->
+    <constant name="TopconcreteBoxy" value="1660+TopconcreteThickness+100."/> <!--1660 mm is taken from Alan's design from CAD 100 mm buffer zone -->
+
     
     <!--constant for lead shieldings - dimension from Alan design -->
     <constant name="leadBoxx" value="3770."/>
@@ -31,7 +37,7 @@
     <constant name="leadBoxz" value="400."/>
     
     <constant name="Shield_bore" value="400"/>
-    <constant name="Shield_length" value="polyBoxz+2"/>
+    <constant name="Shield_length" value="concreteBoxz+2"/>
     
     <position name="origin" x="0" y="0" z="0"/>
 
@@ -42,10 +48,20 @@
 
   <solids>
 
-    <box lunit="m" name="targetRegion_solid"
-	 x="10" y="10" z="6.36"/>
+    <box lunit="m" name="targetRegion_solid1"
+	 x="10" y="15" z="6.36"/>
 
-    <tube aunit="deg" lunit="mm" deltaphi="360" name="target_solid"
+    <box lunit="m" name="targetRegion_solid2"
+	    x="11" y="5" z="6.4"/>
+
+   <subtraction name ="targetRegion_solid">
+     <first ref="targetRegion_solid1"/>
+     <second ref="targetRegion_solid2"/>
+     <position name="MotherSub_pos" lunit="mm" x="0" y="-3000-5000./2." z="0" />
+	     <!--3000 mm is the distance of beam center from the hall floor--> 
+   </subtraction>
+
+   <tube aunit="deg" lunit="mm" deltaphi="360" name="target_solid"
 	  rmax="40" rmin="0" z="1500"/>
 
     <tube aunit="deg" lunit="mm" deltaphi="360" name="AlWindow"
@@ -92,7 +108,7 @@
 	  rmin="targetChamber_R" rmax="targetChamber_R + targetChamber_thickness"
 	  z="targetChamberHat_L"/>
 
-    <!-- Collimator 1 -->
+    <!-- Lead Collar 1 -->
     <box lunit="mm" name="LeadCollar_solid1"
    	 x="370" y="370" z="200"/>
     <tube aunit="deg" deltaphi="360" lunit="mm" name="LeadCollarInnerSub_solid"
@@ -104,23 +120,44 @@
    </subtraction>
   
   
-   <!--shielding poly -->
-    <box lunit="mm" name="poly_outerbox" x="polyBoxx" y="polyBoxy" z="polyBoxz"/>
-    <box lunit="mm" name="poly_innerbox" x="polyBoxx-2*polyThickness" y="polyBoxy" z="polyBoxz-2*polyThickness"/>
+   <!--shielding concrete -->
+    <box lunit="mm" name="concrete_outerbox" x="concreteBoxx" y="concreteBoxy" z="concreteBoxz"/>
+    <box lunit="mm" name="concrete_innerbox" x="concreteBoxx-2*concreteThickness" y="concreteBoxy" z="concreteBoxz-2*concreteThickness"/>
 
-    <subtraction name="poly_sub1">
-    <first ref = "poly_outerbox"/>
-    <second ref = "poly_innerbox"/>
-    <position name ="polySub1" lunit="mm" x="0" y="-polyThickness" z="0" />
+    <subtraction name="concrete_sub1">
+    <first ref = "concrete_outerbox"/>
+    <second ref = "concrete_innerbox"/>
+    <position name ="concreteSub1" lunit="mm" x="0" y="-concreteThickness" z="0" />
     </subtraction>
 
     <tube aunit="deg" deltaphi="360" lunit="mm" name="Shield_tube"
    	  rmin="0" rmax="Shield_bore" z="Shield_length"/>
+	    
+		    
+    <tube aunit="deg" lunit="mm" deltaphi="360" name="TargetShieldHole"
+	    rmax="targetChamber_R+targetChamber_thickness+1." rmin="0" z="10000"/>
 
-    <subtraction name="poly_sub">
-    <first ref = "poly_sub1"/>
+    <subtraction name="concrete_sub2">
+    <first ref = "concrete_sub1"/>
     <second ref = "Shield_tube"/>
-    <position name ="polySub1" lunit="mm" x="polyBoxx/2.-3550" y="-1.*(polyBoxy/2.-3040)" z="0" />
+    <position name ="concreteSub1" lunit="mm" x="concreteBoxx/2.-3550" y="-1.*(concreteBoxy/2.-3040)" z="0" />
+    </subtraction>
+	    
+    <subtraction name="concrete_sub">
+    <first ref = "concrete_sub2"/>
+    <second ref = "TargetShieldHole"/>
+    <position name ="concreteSub2" lunit="mm" x="-concreteBoxx/2.+4140." y="0." z="0." />
+      <rotationref ref="rot_x90"/>
+    </subtraction>
+
+    <!-- concrete shielding of the target hat -->
+    <box lunit="mm" name="concreteHat_outerbox" x="TopconcreteBoxx" y="TopconcreteBoxy" z="TopconcreteBoxx"/>
+    <box lunit="mm" name="concreteHat_innerbox" x="TopconcreteBoxx-2*TopconcreteThickness" y="TopconcreteBoxy" z="TopconcreteBoxx-2*TopconcreteThickness"/>
+
+    <subtraction name="concreteHat_solid">
+    <first ref = "concreteHat_outerbox"/>
+    <second ref = "concreteHat_innerbox"/>
+    <position name ="concreteHatSub1" lunit="mm" x="0" y="-TopconcreteThickness" z="0" />
     </subtraction>
 
    <!--shielding front lead -->
@@ -136,9 +173,9 @@
 
     <!--vacuum detectors for monitoring skyshine  chandan--> 
     <box lunit="mm" name="skyshineVacuumDet1_solid"
-	    x="polyBoxx-polyThickness*2-1" y="1.0" z="polyBoxz-polyThickness*2-1.0"/>
+	    x="TopconcreteBoxx-TopconcreteThickness*2-1" y="1.0" z="TopconcreteBoxx-TopconcreteThickness*2-1.0"/>
     <box lunit="mm" name="skyshineVacuumDet2_solid"
-	 x="polyBoxx+1000" y="1.0" z="polyBoxz"/>
+	 x="concreteBoxx+1000" y="1.0" z="concreteBoxz"/>
 
  </solids>
 
@@ -185,11 +222,18 @@
 
 
    <!--Shielding-->
-   <volume name="PolyShield_target">
+   <volume name="ConcreteShield_target">
    <materialref ref="Concrete"/>
-   <solidref ref="poly_sub"/>
+   <solidref ref="concrete_sub"/>
    <auxiliary auxtype="Color" auxvalue="Green"/>
-   <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+	   <!--<auxiliary auxtype="Alpha" auxvalue="0.1"/>-->
+   </volume>
+	   
+   <volume name="HatConcreteShield_target">
+   <materialref ref="Concrete"/>
+   <solidref ref="concreteHat_solid"/>
+   <auxiliary auxtype="Color" auxvalue="Green"/>
+	   <!--<auxiliary auxtype="Alpha" auxvalue="0.1"/>-->
    </volume>
 
    <volume name="LeadShield_target">
@@ -238,15 +282,15 @@
        <position name="targetChamber_pos" unit="mm" x="0" y="0" z="0"/>
        <rotationref ref="rot_x90"/>
      </physvol>
-
+	     
      <physvol>
        <volumeref ref="targetChamberHat"/>
        <position name="targetChamberHat_pos" unit="mm" x="0" z="0"
 		 y="targetChamber_L/2 + targetChamberLid_thickness + targetChamberHat_L/2"/>
        <rotationref ref="rot_x90"/>
      </physvol>
-
-     <physvol>
+	     
+	     <physvol>
        <volumeref ref="LeadCollar_logic"/>
        <position name="LeadCollar_pos" unit="mm" x="0" y="0"
      		 z="2851 + 100"/>
@@ -254,10 +298,15 @@
      
      <!--shielding placement-->
      <physvol>
-       <volumeref ref="PolyShield_target"/>
-	       <position name="PolyShield_pos" unit="mm" x="-1.*(polyBoxx/2.-3550)" y="polyBoxy/2.-3040" z="0"/>
+       <volumeref ref="ConcreteShield_target"/>
+	       <position name="ConcreteShield_pos" unit="mm" x="-1.*(concreteBoxx/2.-3550)" y="concreteBoxy/2.-3040" z="0"/>
      </physvol>
-
+	     
+     <physvol>
+       <volumeref ref="HatConcreteShield_target"/>
+	       <position name="HatConcreteShield_pos" unit="mm" x="0.0" y="concreteBoxy/2+TopconcreteBoxy/2." z="0"/>
+     </physvol>
+	     
      <physvol>
        <volumeref ref="LeadShield_target"/>
        <position name="LeadShield_pos" unit="mm" x="-1.*(leadBoxx/2.-1880)" y="leadBoxy/2.-1150" z="1200+leadBoxz/2."/>
@@ -266,12 +315,13 @@
      <!--placement of vacuum detector-->
      <physvol>
        <volumeref ref="skyshineVacuumDet1_logic"/>
-       <position name="shyshineVacuumDet1_pos" unit="mm" x="-1.*(polyBoxx/2.-3550)" y="targetChamber_L/2.+targetChamberHat_L+200" z="0"/>
+       <position name="shyshineVacuumDet1_pos" unit="mm" x="0." y="targetChamber_L/2.+targetChamberHat_L+200" z="0"/>
      </physvol>
 
      <physvol>
        <volumeref ref="skyshineVacuumDet2_logic"/>
-       <position name="shyshineVacuumDet2_pos" unit="mm" x="-1.*(polyBoxx/2.-3550)" y="polyBoxy/2+500" z="0"/>
+       <position name="shyshineVacuumDet2_pos" unit="mm" x="0.0" y="targetChamber_L/2+targetChamberHat_L+TopconcreteThickness+400" z="0.0"/>
+	       <!--<position name="shyshineVacuumDet2_pos" unit="mm" x="-1.*(concreteBoxx/2.-3550)" y="concreteBoxy/2+500" z="0"/> used for Silviu's design-->
      </physvol>
 
      <auxiliary auxtype="TargetSystem" auxvalue=""/>

--- a/geometry/upstreamDaughter_merged.gdml
+++ b/geometry/upstreamDaughter_merged.gdml
@@ -756,7 +756,7 @@
 	<materialref ref="CW95"/>
 	<solidref ref="col1_7"/>
 	<auxiliary auxtype="SensDet" auxvalue="collDet"/>
-    <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+        <auxiliary auxtype="DetType" auxvalue="all"/>
 	<auxiliary auxtype="DetNo" auxvalue="2001"/>
     </volume>
 
@@ -766,7 +766,7 @@
 	<solidref ref="col1fin_15"/>
 	<auxiliary auxtype="Color" auxvalue="red"/>
 	<auxiliary auxtype="SensDet" auxvalue="collDet"/>
-    <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+        <auxiliary auxtype="DetType" auxvalue="all"/>
 	<auxiliary auxtype="DetNo" auxvalue="2006"/>
     </volume>
 
@@ -774,7 +774,7 @@
       <materialref ref="CW95"/>
       <solidref ref="uscoll2_union_6"/>
       <auxiliary auxtype="SensDet" auxvalue="collDet"/>
-      <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+      <auxiliary auxtype="DetType" auxvalue="all"/>
       <auxiliary auxtype="DetNo" auxvalue="2002"/>
     </volume>
 
@@ -782,7 +782,7 @@
       <materialref ref="VacuumColl"/>
       <solidref ref="coll2trap"/>
       <auxiliary auxtype="SensDet" auxvalue="collDet"/>
-      <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+      <auxiliary auxtype="DetType" auxvalue="all"/>
       <auxiliary auxtype="DetNo" auxvalue="200"/>
     </volume>
 

--- a/geometry/upstreamDaughter_merged.gdml
+++ b/geometry/upstreamDaughter_merged.gdml
@@ -757,7 +757,8 @@
 	<materialref ref="CW95"/>
 	<solidref ref="col1_7"/>
 	<auxiliary auxtype="SensDet" auxvalue="collDet"/>
-        <auxiliary auxtype="DetType" auxvalue="all"/>
+        <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+        <auxiliary auxtype="DetType" auxvalue="secondaries"/>
 	<auxiliary auxtype="DetNo" auxvalue="2001"/>
     </volume>
 
@@ -767,7 +768,8 @@
 	<solidref ref="col1fin_15"/>
 	<auxiliary auxtype="Color" auxvalue="red"/>
 	<auxiliary auxtype="SensDet" auxvalue="collDet"/>
-        <auxiliary auxtype="DetType" auxvalue="all"/>
+        <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+        <auxiliary auxtype="DetType" auxvalue="secondaries"/>
 	<auxiliary auxtype="DetNo" auxvalue="2006"/>
     </volume>
 
@@ -775,7 +777,8 @@
       <materialref ref="CW95"/>
       <solidref ref="uscoll2_union_6"/>
       <auxiliary auxtype="SensDet" auxvalue="collDet"/>
-      <auxiliary auxtype="DetType" auxvalue="all"/>
+      <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+      <auxiliary auxtype="DetType" auxvalue="secondaries"/>
       <auxiliary auxtype="DetNo" auxvalue="2002"/>
     </volume>
 
@@ -783,7 +786,8 @@
       <materialref ref="VacuumColl"/>
       <solidref ref="coll2trap"/>
       <auxiliary auxtype="SensDet" auxvalue="collDet"/>
-      <auxiliary auxtype="DetType" auxvalue="all"/>
+      <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+      <auxiliary auxtype="DetType" auxvalue="secondaries"/>
       <auxiliary auxtype="DetNo" auxvalue="200"/>
     </volume>
 

--- a/geometry/upstreamDaughter_merged.gdml
+++ b/geometry/upstreamDaughter_merged.gdml
@@ -248,11 +248,12 @@
     <!--CAD based shielding beampipe for col-1 to end of US magnet -->
     <constant name="shield_US_beampipe_length" value="1945"/>
     <constant name="shield_US_beampipe_thickness" value="3"/>
-    <constant name="shield_US_beampipe_US_rmin" value="25.5"/>
+    <constant name="shield_US_beampipe_US_rmin" value="26.5"/>
     <constant name="shield_US_beampipe_DS_rmin" value="31"/>
     <constant name="shield_US_beampipe_US_rmax" value="shield_US_beampipe_US_rmin+shield_US_beampipe_thickness"/>
     <constant name="shield_US_beampipe_DS_rmax" value="shield_US_beampipe_DS_rmin+shield_US_beampipe_thickness"/>
-    <constant name="shield_US_beampipe_center_z" value="shield_US_beampipe_length/2 + COLL1_z + COLL1_THICK/2 + 1"/>
+	    <!--<constant name="shield_US_beampipe_center_z" value="shield_US_beampipe_length/2 + COLL1_z + COLL1_THICK/2 + 1"/>-->
+    <constant name="shield_US_beampipe_center_z" value="shield_US_beampipe_length/2 + posCOLL2z + COLL2_THICK/2+0.001"/>
     <position name="shield_US_beampipe_center" unit="mm" x="0" y="0" z="shield_US_beampipe_center_z"/>
 
     <constant name="posCOLL2_det_z" value ="posCOLL2z+(COLL2_THICK/2.0) + 0.1"/>
@@ -849,8 +850,8 @@
       <materialref ref="Tungsten"/> -->
       <materialref ref="Concrete"/>
       <solidref ref="boxUSShieldColl1_solid"/> 
-      <auxiliary auxtype="Color" auxvalue="green"/>
-      <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+      <auxiliary auxtype="Color" auxvalue="Green"/>
+<!--      <auxiliary auxtype="Alpha" auxvalue="0.1"/>-->
       <auxiliary auxtype="SensDet" auxvalue="Shielding_Block_US_1_Det"/> <!-- NEW Sensitive detector FIXME -->
       <auxiliary auxtype="DetNo" auxvalue="6010"/>
     </volume>
@@ -861,8 +862,8 @@
       <materialref ref="Tungsten"/> --> 
       <materialref ref="Concrete"/>
       <solidref ref="boxUSShieldColl2_solid"/>
-      <auxiliary auxtype="Color" auxvalue="green"/>
-      <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+      <auxiliary auxtype="Color" auxvalue="Green"/>
+	<!--      <auxiliary auxtype="Alpha" auxvalue="0.1"/>-->
       <auxiliary auxtype="SensDet" auxvalue="Shielding_Block_US_2_Det"/> <!-- NEW Sensitive detector FIXME -->
       <auxiliary auxtype="DetNo" auxvalue="6011"/>
     </volume>
@@ -870,13 +871,13 @@
     <!-- Neutron Poly Shielding -->
     <!-- PolyShield1 will be outside shielding blocks 2 and 3 -->
     <volume name="boxUSPolyShield1_logic">
-<!--  <materialref ref="Concrete"/> -->
+    <materialref ref="Concrete"/>
 <!--  <materialref ref="Tungsten"/> -->
-      <materialref ref="Polythene"/>
+<!--      <materialref ref="Polythene"/>  changed by chandan -->
 <!--        <materialref ref="Kryptonite"/> -->
       <solidref ref="boxUSPolyShield1_solid"/>
-      <auxiliary auxtype="Color" auxvalue="Brown"/>
-      <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+      <auxiliary auxtype="Color" auxvalue="Green"/>
+	<!--      <auxiliary auxtype="Alpha" auxvalue="0.1"/>-->
       <auxiliary auxtype="SensDet" auxvalue="Poly_Shielding_Block_US_1_2_Det"/> <!-- NEW Sensitive detector FIXME -->
       <auxiliary auxtype="DetNo" auxvalue="6012"/>
     </volume>
@@ -911,7 +912,7 @@
       <materialref ref="Tungsten"/>
       <solidref ref="solid_shield_US_beampipe_1"/>
       <auxiliary auxtype="Color" auxvalue="yellow"/>
-      <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+	    <!--  <auxiliary auxtype="Alpha" auxvalue="0.1"/>-->
     </volume>
 
     <volume name="logicUpstream">

--- a/include/remollDetectorConstruction.hh
+++ b/include/remollDetectorConstruction.hh
@@ -2,6 +2,7 @@
 #define __MOLLERDETECTORCONSTRUCTION_HH
 
 #include "G4GDMLParser.hh"
+#include "G4GDMLAuxStructType.hh"
 #include "G4VUserDetectorConstruction.hh"
 #include "G4Types.hh"
 
@@ -141,6 +142,20 @@ class remollDetectorConstruction : public G4VUserDetectorConstruction
     void PrintGDMLWarning() const;
 
     G4VPhysicalVolume* ParseGDMLFile();
+
+    G4bool HasAuxWithType(const G4GDMLAuxListType& list, const G4String& type)
+    {
+      return NextAuxWithType(list.begin(), list.end(), type) != list.end();
+    }
+    G4GDMLAuxListType::const_iterator NextAuxWithType(
+        const G4GDMLAuxListType::const_iterator& begin,
+        const G4GDMLAuxListType::const_iterator& end,
+        const G4String& type)
+    {
+      return std::find_if(begin, end,
+        [type](const G4GDMLAuxStructType& element) {
+          return element.type.compareTo(type, G4String::ignoreCase) == 0;} );
+    }
 
     void PrintAuxiliaryInfo() const;
     void ParseAuxiliaryTargetInfo();

--- a/include/remollGenericDetector.hh
+++ b/include/remollGenericDetector.hh
@@ -147,6 +147,11 @@ class remollGenericDetector : public G4VSensitiveDetector {
           fDetectOpticalPhotons = false;
           fDetectLowEnergyNeutrals = false;
         }
+        if (det_type.compareTo("all", G4String::ignoreCase) == 0) {
+          G4cout << GetName() << " detects all particles" << G4endl;
+          fDetectSecondaries = true;
+          fDetectLowEnergyNeutrals = true;
+        }
         if (det_type.compareTo("lowenergyneutral", G4String::ignoreCase) == 0) {
           G4cout << GetName() << " detects low energy neutrals" << G4endl;
           fDetectLowEnergyNeutrals = true;

--- a/include/remollGenericDetector.hh
+++ b/include/remollGenericDetector.hh
@@ -178,7 +178,11 @@ class remollGenericDetector : public G4VSensitiveDetector {
       };
       void PrintEnabled() const {
         G4cout << "Det " << GetName() << " (" << fDetNo << ") "
-            << (fEnabled? "enabled" : "disabled") << G4endl;
+            << (fEnabled? "enabled" : "disabled")
+            << (fDetectLowEnergyNeutrals? " lowenergyneutral":"")
+            << (fDetectOpticalPhotons? " opticalphoton":"")
+            << (fDetectSecondaries? " secondaries":"")
+            << G4endl;
       };
 
       void  SetDetNo(G4int detno) { fDetNo = detno; }

--- a/macros/tests/unit/test_det_enable.mac
+++ b/macros/tests/unit/test_det_enable.mac
@@ -28,3 +28,10 @@
 # Enable one detector
 /remoll/SD/enable 4000
 /remoll/SD/print_all
+
+# Enable specific sensitivity
+/remoll/SD/enable_all
+/remoll/SD/detect lowenergyneutral 4000
+/remoll/SD/detect opticalphoton 4001
+/remoll/SD/detect all 4002
+/remoll/SD/print_all

--- a/macros/vis.mac
+++ b/macros/vis.mac
@@ -4,7 +4,7 @@
 /remoll/physlist/optical/enable
 
 # This is the current working geometry
-/remoll/setgeofile geometry/mollerMother_5open.gdml
+/remoll/setgeofile geometry/mollerMother_merged.gdml
 
 #/remoll/likekryptonite  true
 

--- a/vis/vis.mac
+++ b/vis/vis.mac
@@ -57,7 +57,7 @@
 /vis/viewer/set/lightsThetaPhi 40 50
 #New cutaway plane setting
 #/vis/viewer/set/cutawayMode intersection
-#/vis/viewer/addCutawayPlane 0.0 0.0 0.0 m 1.0 0.0 0.0
+/vis/viewer/addCutawayPlane 0.0 0.0 0.0 m 1.0 0.0 0.0
 #old value
 #/vis/viewer/set/lightsMove with-camera
 #


### PR DESCRIPTION
Once again :-) by default remoll only stores hits:
- at the geometry boundary upon entering the sensitive detector volume,
- when the particle causing the hit is charged,
- when the particle has a kinetic energy above 0.1 MeV,
- and for primary particle also throughout the volume.

If you want to store more, you set DetType to "lowenenergyneutral", "secondaries", "opticalphoton" etc. What if you want to store both low energy neutrals and secondaries (like for a full shower)? It would seem logical that you can specify two DetType tags in the logical volume. Unfortunately that didn't work since in that case it only used the last DetType and ignore the earlier ones.

In this branch I rewrote how the auxiliary tags are parsed for the sensitive detector volumes. It's probably also a good approach to (at some point) extend this method by writing some functions like `bool HasAuxTag(G4LogicalVolume, G4String /*eg "SensDet" */)` and `iterator GetAuxTag(G4LogicalVolume, G4String /*eg "SensDet" */)` etc.

For now, this again removes (not really) the detector type "all" which I introduced to keep @chandabindu from being stuck.