### PR TITLE
Save pid in sum.by_pid.pid ROOT branch.

### DIFF
--- a/include/remollGenericDetectorSum.hh
+++ b/include/remollGenericDetectorSum.hh
@@ -43,6 +43,7 @@ class remollGenericDetectorSum : public G4VHit {
             it  = fSumByPID.begin();
             it != fSumByPID.end(); ++it) {
           sum.by_pid.push_back(it->second);
+          sum.by_pid.back().pid = it->first;
         }
         return sum;
       }


### PR DESCRIPTION
After the sum.by_pid functionality was changed to internally use
branches, I forgot to store the pid (std::map.first) in the vectors
that are written to the ROOT tree. All values of pid were still at 0.