### PR TITLE
Update default beam gen raster origin

### DIFF
--- a/src/remollGenBeam.cc
+++ b/src/remollGenBeam.cc
@@ -21,16 +21,16 @@
 
 remollGenBeam::remollGenBeam()
 : remollVEventGen("beam"),
-  fOriginMean(0.0*m,0.0*m,-7.75*m),
+  fOriginMean(0.0*m,0.0*m,-6.7*m),
   fOriginSpread(0.0,0.0,0.0),
   fOriginModelX(kOriginModelFlat),
   fOriginModelY(kOriginModelFlat),
   fOriginModelZ(kOriginModelFlat),
   fDirection(0.0,0.0,1.0),
-  fCorrelation(0.136*mrad/mm,0.136*mrad/mm,0.0),
+  fCorrelation(0.149*mrad/mm,0.149*mrad/mm,0.0),
   fPolarization(0.0,0.0,0.0),
   fRaster(5*mm,5*mm,0.0),
-  fRasterRefZ(-0.75*m),
+  fRasterRefZ(0.0*m),
   fParticleName("e-")
 {
     fSampType = kNoTargetVolume;


### PR DESCRIPTION
Update default beam gen raster origin to -6.7 m, corr to 149 urad/mm, refz to 0.0 m

Fix to issue #242.

Raster is now by default 5 mm x 5 mm full size at the center of the
target (z = 0.0 mm) with an angle/position correlation of 149 urad/mm
corresponding with origin at -6.7 m per Jay's new designs.