### PR TITLE
Changed target length to 1.25 m

### DIFF
--- a/geometry/target/subTargetRegion.gdml
+++ b/geometry/target/subTargetRegion.gdml
@@ -10,6 +10,9 @@
   <define>
     &matrices;
 
+   <constant name="tubeTarget_length" value="1250"/>
+   <constant name="AlWindowTarget_length" value="0.127"/>
+
     <constant name="targetChamber_R" value="1981.0/2.0"/>
     <constant name="targetChamber_L" value="1829."/>
     <constant name="targetChamber_thickness" value="13."/>
@@ -64,10 +67,10 @@
    </subtraction>
 
    <tube aunit="deg" lunit="mm" deltaphi="360" name="target_solid"
-	  rmax="40" rmin="0" z="1500"/>
+	  rmax="40" rmin="0" z="tubeTarget_length"/>
 
     <tube aunit="deg" lunit="mm" deltaphi="360" name="AlWindow"
-	  rmax="40" rmin="0" z="0.127"/>
+	  rmax="40" rmin="0" z="AlWindowTarget_length"/>
 
     <tube aunit="deg" lunit="mm" deltaphi="360" name="targetChamber_solid1"
 	  rmin="targetChamber_R"
@@ -266,7 +269,7 @@
 
      <physvol>
        <volumeref ref="USAlTarg"/>
-       <position name="targ_upstream_window" unit="mm" x="0" y="0" z="-750-1"/>
+       <position name="targ_upstream_window" unit="mm" x="0" y="0" z="-(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>
 
      <physvol>
@@ -276,7 +279,7 @@
 
      <physvol>
        <volumeref ref="DSAlTarg"/>
-       <position name="targ_downstream_window" unit="mm" x="0" y="0" z="750+1"/>
+       <position name="targ_downstream_window" unit="mm" x="0" y="0" z="+(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>
 
      <physvol>

--- a/geometry/target/subTargetRegion.gdml
+++ b/geometry/target/subTargetRegion.gdml
@@ -10,6 +10,7 @@
   <define>
     &matrices;
 
+   <constant name="targetCenterZ" value="500"/>
    <constant name="tubeTarget_length" value="1250"/>
    <constant name="AlWindowTarget_length" value="0.127"/>
 
@@ -269,17 +270,17 @@
 
      <physvol>
        <volumeref ref="USAlTarg"/>
-       <position name="targ_upstream_window" unit="mm" x="0" y="0" z="-(AlWindowTarget_length+tubeTarget_length)/2"/>
+       <position name="targ_upstream_window" unit="mm" x="0" y="0" z="targetCenterZ-(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>
 
      <physvol>
        <volumeref ref="h2Targ"/>
-       <position name="targ_center1" unit="mm" x="0" y="0" z="0"/>
+       <position name="targ_center1" unit="mm" x="0" y="0" z="targetCenterZ"/>
      </physvol>
 
      <physvol>
        <volumeref ref="DSAlTarg"/>
-       <position name="targ_downstream_window" unit="mm" x="0" y="0" z="+(AlWindowTarget_length+tubeTarget_length)/2"/>
+       <position name="targ_downstream_window" unit="mm" x="0" y="0" z="targetCenterZ+(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>
 
      <physvol>

--- a/geometry/target/target12C.gdml
+++ b/geometry/target/target12C.gdml
@@ -2,7 +2,7 @@
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
   <define>
-    <position name="v0" x="60.4388" y="-36.6311" z="65.0000" unit="mm"/>
+    <constant name="targetCenterZ" value="500"/>
   </define>
   
   <materials>
@@ -20,7 +20,7 @@
   </materials>
 
 <solids>
-    <tube aunit="deg" deltaphi="360" lunit="mm" name="tubeTargetMother" rmax="1000" rmin="0" startphi="0" z="20"/>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="tubeTargetMother" rmax="1000" rmin="0" startphi="0" z="2.1*targetCenterZ"/>
     <tube aunit="deg" deltaphi="360" lunit="mm" name="tubeTarget" rmax="40" rmin="0" startphi="0" z="15"/>
 </solids>
 
@@ -37,7 +37,7 @@
 
       <physvol>
         <volumeref ref="C12Targ"/>
-        <position name="targ_center" unit="mm" x="0" y="0" z="0"/>
+        <position name="targ_center" unit="mm" x="0" y="0" z="targetCenterZ"/>
       </physvol>
 
     </volume>

--- a/geometry/target/targetDaughter.gdml
+++ b/geometry/target/targetDaughter.gdml
@@ -3,7 +3,7 @@
 
 <define>
   <constant name="tubeTarget_rmax" value="40"/>
-  <constant name="tubeTarget_length" value="1500"/>
+  <constant name="tubeTarget_length" value="1250"/>
   <constant name="AlWindowTarget_length" value="0.127"/>
 
   <position name="v0" x="60.4388" y="-36.6311" z="65.0000" unit="mm"/>

--- a/geometry/target/targetDaughter.gdml
+++ b/geometry/target/targetDaughter.gdml
@@ -2,11 +2,10 @@
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
 <define>
+  <constant name="targetCenterZ" value="500"/>
   <constant name="tubeTarget_rmax" value="40"/>
   <constant name="tubeTarget_length" value="1250"/>
   <constant name="AlWindowTarget_length" value="0.127"/>
-
-  <position name="v0" x="60.4388" y="-36.6311" z="65.0000" unit="mm"/>
 </define>
 
   <materials>
@@ -29,7 +28,7 @@
   </materials>
 
 <solids>
-    <tube aunit="deg" deltaphi="360" lunit="mm" name="tubeTargetMother" rmax="1000" rmin="0" startphi="0" z="2000"/>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="tubeTargetMother" rmax="1000" rmin="0" startphi="0" z="2400"/>
     <tube aunit="deg" deltaphi="360" lunit="mm" name="tubeTarget" rmax="tubeTarget_rmax" rmin="0" startphi="0" z="tubeTarget_length"/>
     <tube aunit="deg" deltaphi="360" lunit="mm" name="AlWindow" rmax="tubeTarget_rmax" rmin="0" startphi="0" z="AlWindowTarget_length"/>
 </solids>
@@ -61,17 +60,17 @@
 
       <physvol>
         <volumeref ref="USAlTarg"/>
-        <position name="targ_upstream_window" unit="mm" x="0" y="0" z="-(AlWindowTarget_length+tubeTarget_length)/2.0"/>
+        <position name="targ_upstream_window" unit="mm" x="0" y="0" z="targetCenterZ-(AlWindowTarget_length+tubeTarget_length)/2.0"/>
       </physvol>
 
       <physvol>
         <volumeref ref="h2Targ"/>
-        <position name="targ_center" unit="mm" x="0" y="0" z="0"/>
+        <position name="targ_center" unit="mm" x="0" y="0" z="targetCenterZ"/>
       </physvol>
       
       <physvol>
         <volumeref ref="DSAlTarg"/>
-        <position name="targ_downstream_window" unit="mm" x="0" y="0" z="+(AlWindowTarget_length+tubeTarget_length)/2.0"/>
+        <position name="targ_downstream_window" unit="mm" x="0" y="0" z="targetCenterZ+(AlWindowTarget_length+tubeTarget_length)/2.0"/>
       </physvol>
 
       <auxiliary auxtype="TargetSystem" auxvalue=""/>

--- a/geometry/target/targetDaughter_Clamshell_Optimized.gdml
+++ b/geometry/target/targetDaughter_Clamshell_Optimized.gdml
@@ -13,6 +13,7 @@
     <constant name="y_increase_targ" value="0.0"/>
     <constant name="YOFFSET_targ" value="-1*y_increase_targ/2"/>
 
+    <constant name="targetCenterZ" value="500"/>
     <constant name="tubeTarget_rmax" value="40"/>
     <constant name="tubeTarget_length" value="1250"/>
     <constant name="AlWindowTarget_length" value="0.127"/>
@@ -492,17 +493,17 @@
 
      <physvol>
        <volumeref ref="USAlTarg"/>
-       <position name="targ_upstream_window" unit="mm" x="0" y="YOFFSET_targ" z="-(AlWindowTarget_length+tubeTarget_length)/2"/>
+       <position name="targ_upstream_window" unit="mm" x="0" y="YOFFSET_targ" z="targetCenterZ-(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>
 
      <physvol>
        <volumeref ref="h2Targ"/>
-       <position name="targ_center1" unit="mm" x="0" y="YOFFSET_targ" z="0"/>
+       <position name="targ_center1" unit="mm" x="0" y="YOFFSET_targ" z="targetCenterZ"/>
      </physvol>
 
      <physvol>
        <volumeref ref="DSAlTarg"/>
-       <position name="targ_downstream_window" unit="mm" x="0" y="YOFFSET_targ" z="+(AlWindowTarget_length+tubeTarget_length)/2"/>
+       <position name="targ_downstream_window" unit="mm" x="0" y="YOFFSET_targ" z="targetCenterZ+(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>
 
      <physvol>

--- a/geometry/target/targetDaughter_Clamshell_Optimized.gdml
+++ b/geometry/target/targetDaughter_Clamshell_Optimized.gdml
@@ -14,7 +14,7 @@
     <constant name="YOFFSET_targ" value="-1*y_increase_targ/2"/>
 
     <constant name="tubeTarget_rmax" value="40"/>
-    <constant name="tubeTarget_length" value="1500"/>
+    <constant name="tubeTarget_length" value="1250"/>
     <constant name="AlWindowTarget_length" value="0.127"/>
 
     <!-- Mother volume parameters -->
@@ -492,7 +492,7 @@
 
      <physvol>
        <volumeref ref="USAlTarg"/>
-       <position name="targ_upstream_window" unit="mm" x="0" y="YOFFSET_targ" z="-750-1"/>
+       <position name="targ_upstream_window" unit="mm" x="0" y="YOFFSET_targ" z="-(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>
 
      <physvol>
@@ -502,7 +502,7 @@
 
      <physvol>
        <volumeref ref="DSAlTarg"/>
-       <position name="targ_downstream_window" unit="mm" x="0" y="YOFFSET_targ" z="750+1"/>
+       <position name="targ_downstream_window" unit="mm" x="0" y="YOFFSET_targ" z="+(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>
 
      <physvol>

--- a/geometry/target/targetDaughter_acceptanceDefinition.gdml
+++ b/geometry/target/targetDaughter_acceptanceDefinition.gdml
@@ -13,6 +13,7 @@
     <constant name="y_increase_targ" value="0.0"/>
     <constant name="YOFFSET_targ" value="-1*y_increase_targ/2"/>
 
+    <constant name="targetCenterZ" value="500"/>
     <constant name="tubeTarget_rmax" value="40"/>
     <constant name="tubeTarget_length" value="1250"/>
     <constant name="AlWindowTarget_length" value="0.127"/>
@@ -492,17 +493,17 @@
 
      <physvol>
        <volumeref ref="USAlTarg"/>
-       <position name="targ_upstream_window" unit="mm" x="0" y="YOFFSET_targ" z="-(AlWindowTarget_length+tubeTarget_length)/2"/>
+       <position name="targ_upstream_window" unit="mm" x="0" y="YOFFSET_targ" z="targetCenterZ-(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>
 
      <physvol>
        <volumeref ref="h2Targ"/>
-       <position name="targ_center1" unit="mm" x="0" y="YOFFSET_targ" z="0"/>
+       <position name="targ_center1" unit="mm" x="0" y="YOFFSET_targ" z="targetCenterZ"/>
      </physvol>
 
      <physvol>
        <volumeref ref="DSAlTarg"/>
-       <position name="targ_downstream_window" unit="mm" x="0" y="YOFFSET_targ" z="+(AlWindowTarget_length+tubeTarget_length)/2"/>
+       <position name="targ_downstream_window" unit="mm" x="0" y="YOFFSET_targ" z="targetCenterZ+(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>
 
      <physvol>

--- a/geometry/target/targetDaughter_acceptanceDefinition.gdml
+++ b/geometry/target/targetDaughter_acceptanceDefinition.gdml
@@ -14,7 +14,7 @@
     <constant name="YOFFSET_targ" value="-1*y_increase_targ/2"/>
 
     <constant name="tubeTarget_rmax" value="40"/>
-    <constant name="tubeTarget_length" value="1500"/>
+    <constant name="tubeTarget_length" value="1250"/>
     <constant name="AlWindowTarget_length" value="0.127"/>
 
     <!-- Mother volume parameters -->
@@ -492,7 +492,7 @@
 
      <physvol>
        <volumeref ref="USAlTarg"/>
-       <position name="targ_upstream_window" unit="mm" x="0" y="YOFFSET_targ" z="-750-1"/>
+       <position name="targ_upstream_window" unit="mm" x="0" y="YOFFSET_targ" z="-(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>
 
      <physvol>
@@ -502,7 +502,7 @@
 
      <physvol>
        <volumeref ref="DSAlTarg"/>
-       <position name="targ_downstream_window" unit="mm" x="0" y="YOFFSET_targ" z="750+1"/>
+       <position name="targ_downstream_window" unit="mm" x="0" y="YOFFSET_targ" z="+(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>
 
      <physvol>

--- a/geometry/target/targetDaughter_merged.gdml
+++ b/geometry/target/targetDaughter_merged.gdml
@@ -10,6 +10,7 @@
 <define>
   &matrices;
 
+  <constant name="targetCenterZ" value="500"/>
   <constant name="tubeTarget_rmax" value="40"/>
   <constant name="tubeTarget_length" value="1250"/>
   <constant name="AlWindowTarget_length" value="0.127"/>
@@ -308,17 +309,17 @@
 
       <physvol>
         <volumeref ref="USAlTarg"/>
-        <position name="targ_upstream_window" unit="mm" x="0" y="0" z="-(AlWindowTarget_length+tubeTarget_length)/2.0"/>
+        <position name="targ_upstream_window" unit="mm" x="0" y="0" z="targetCenterZ-(AlWindowTarget_length+tubeTarget_length)/2.0"/>
       </physvol>
 
       <physvol>
         <volumeref ref="h2Targ"/>
-        <position name="targ_center1" unit="mm" x="0" y="0" z="0"/>
+        <position name="targ_center1" unit="mm" x="0" y="0" z="targetCenterZ"/>
       </physvol>
 
       <physvol>
         <volumeref ref="DSAlTarg"/>
-        <position name="targ_downstream_window" unit="mm" x="0" y="0" z="+(AlWindowTarget_length+tubeTarget_length)/2.0"/>
+        <position name="targ_downstream_window" unit="mm" x="0" y="0" z="targetCenterZ+(AlWindowTarget_length+tubeTarget_length)/2.0"/>
       </physvol>
 
       <!--Shown below are initial target shielding cylinder - Rakitha  -->

--- a/geometry/target/targetDaughter_merged.gdml
+++ b/geometry/target/targetDaughter_merged.gdml
@@ -11,7 +11,7 @@
   &matrices;
 
   <constant name="tubeTarget_rmax" value="40"/>
-  <constant name="tubeTarget_length" value="1500"/>
+  <constant name="tubeTarget_length" value="1250"/>
   <constant name="AlWindowTarget_length" value="0.127"/>
 
   <!-- Mother volume parameters -->

--- a/geometry/target/targetDaughter_noShlds.gdml
+++ b/geometry/target/targetDaughter_noShlds.gdml
@@ -11,7 +11,7 @@
   &matrices;
 
   <constant name="tubeTarget_rmax" value="40"/>
-  <constant name="tubeTarget_length" value="1500"/>
+  <constant name="tubeTarget_length" value="1250"/>
   <constant name="AlWindowTarget_length" value="0.127"/>
 
   <!-- Mother volume parameters -->
@@ -301,7 +301,7 @@
 
       <physvol>
         <volumeref ref="USAlTarg"/>
-        <position name="targ_upstream_window" unit="mm" x="0" y="0" z="-750"/>
+        <position name="targ_upstream_window" unit="mm" x="0" y="0" z="-(AlWindowTarget_length+tubeTarget_length)/2"/>
       </physvol>
 
       <physvol>
@@ -311,7 +311,7 @@
 
       <physvol>
         <volumeref ref="DSAlTarg"/>
-        <position name="targ_downstream_window" unit="mm" x="0" y="0" z="750"/>
+        <position name="targ_downstream_window" unit="mm" x="0" y="0" z="+(AlWindowTarget_length+tubeTarget_length)/2"/>
       </physvol>
 
       <!--Shown below are initial target shielding cylinder - Rakitha  -->

--- a/geometry/target/targetDaughter_noShlds.gdml
+++ b/geometry/target/targetDaughter_noShlds.gdml
@@ -10,6 +10,7 @@
 <define>
   &matrices;
 
+  <constant name="targetCenterZ" value="500"/>
   <constant name="tubeTarget_rmax" value="40"/>
   <constant name="tubeTarget_length" value="1250"/>
   <constant name="AlWindowTarget_length" value="0.127"/>
@@ -301,17 +302,17 @@
 
       <physvol>
         <volumeref ref="USAlTarg"/>
-        <position name="targ_upstream_window" unit="mm" x="0" y="0" z="-(AlWindowTarget_length+tubeTarget_length)/2"/>
+        <position name="targ_upstream_window" unit="mm" x="0" y="0" z="targetCenterZ-(AlWindowTarget_length+tubeTarget_length)/2"/>
       </physvol>
 
       <physvol>
         <volumeref ref="h2Targ"/>
-        <position name="targ_center1" unit="mm" x="0" y="0" z="0"/>
+        <position name="targ_center1" unit="mm" x="0" y="0" z="targetCenterZ"/>
       </physvol>
 
       <physvol>
         <volumeref ref="DSAlTarg"/>
-        <position name="targ_downstream_window" unit="mm" x="0" y="0" z="+(AlWindowTarget_length+tubeTarget_length)/2"/>
+        <position name="targ_downstream_window" unit="mm" x="0" y="0" z="targetCenterZ+(AlWindowTarget_length+tubeTarget_length)/2"/>
       </physvol>
 
       <!--Shown below are initial target shielding cylinder - Rakitha  -->

--- a/include/remollBeamTarget.hh
+++ b/include/remollBeamTarget.hh
@@ -55,8 +55,6 @@ class remollBeamTarget {
         static std::vector<G4VPhysicalVolume*> GetTargetVolumes(){ return fTargetVolumes; }
 
         void SetActiveTargetVolume(G4String name);
-        void SetTargetPos(G4double z);
-        void SetTargetLen(G4double l);
 
         void PrintTargetInfo();
 

--- a/macros/hepmc/ee_ee_hepmc.mac
+++ b/macros/hepmc/ee_ee_hepmc.mac
@@ -15,10 +15,6 @@
 # Beam current
 /remoll/beamcurr 85 microampere
 
-# Target position
-/remoll/targpos 0 cm
-/remoll/targlen 1 mm
-
 # Raster
 /remoll/oldras true
 /remoll/rasx 0 mm

--- a/macros/hepmc/ee_ee_moller.mac
+++ b/macros/hepmc/ee_ee_moller.mac
@@ -15,10 +15,6 @@
 # Beam current
 /remoll/beamcurr 85 microampere
 
-# Target position
-/remoll/targpos 0 cm
-/remoll/targlen 1 mm
-
 # Raster
 /remoll/oldras true
 /remoll/rasx 0 mm

--- a/macros/hepmc/ep_ep_elastic.mac
+++ b/macros/hepmc/ep_ep_elastic.mac
@@ -15,10 +15,6 @@
 # Beam current
 /remoll/beamcurr 85 microampere
 
-# Target position
-/remoll/targpos 0 cm
-/remoll/targlen 1 mm
-
 # Raster
 /remoll/oldras true
 /remoll/rasx 0 mm

--- a/macros/hepmc/ep_ep_hepmc.mac
+++ b/macros/hepmc/ep_ep_hepmc.mac
@@ -15,10 +15,6 @@
 # Beam current
 /remoll/beamcurr 85 microampere
 
-# Target position
-/remoll/targpos 0 cm
-/remoll/targlen 1 mm
-
 # Raster
 /remoll/oldras true
 /remoll/rasx 0 mm

--- a/macros/issues/issue187.mac
+++ b/macros/issues/issue187.mac
@@ -1,8 +1,5 @@
 /run/initialize
 
-/remoll/targpos 0 cm
-/remoll/targlen 0 cm
-
 /remoll/filename remollout.root
 
 /run/beamOn 100

--- a/macros/pionwall/moller_lead_wall_100mm.in
+++ b/macros/pionwall/moller_lead_wall_100mm.in
@@ -48,9 +48,6 @@
 #/remoll/gen quasielasticAl
 #/remoll/gen elasticAl
 
-/remoll/targpos   0 cm
-/remoll/targlen 150 cm
-
 /remoll/beamcurr 85 microampere
 
 # Make interactions with W, Cu, and Pb

--- a/macros/pionwall/pion_lead_wall_100mm.in
+++ b/macros/pionwall/pion_lead_wall_100mm.in
@@ -49,9 +49,6 @@
 #/remoll/gen quasielasticAl
 #/remoll/gen elasticAl
 
-/remoll/targpos   0 cm
-/remoll/targlen 150 cm
-
 /remoll/beamcurr 85 microampere
 
 # Make interactions with W, Cu, and Pb

--- a/macros/remoll_test.in
+++ b/macros/remoll_test.in
@@ -51,9 +51,6 @@
 #/remoll/gen quasielasticAl
 #/remoll/gen elasticAl
 
-/remoll/targpos   0 cm
-/remoll/targlen 150 cm
-
 /remoll/beamcurr 85 microampere
 
 #Enable optical photons and processes

--- a/macros/runbatch_eAlelastic_down.mac
+++ b/macros/runbatch_eAlelastic_down.mac
@@ -19,8 +19,6 @@
 /remoll/gen elasticAl
 
 /remoll/targname DSAlTarg
-#/remoll/targpos   +75.0 cm
-#/remoll/targlen  0.0127 cm
 
 /remoll/beamcurr 85 microampere
 

--- a/macros/runbatch_eAlelastic_up.mac
+++ b/macros/runbatch_eAlelastic_up.mac
@@ -19,8 +19,6 @@
 /remoll/gen elasticAl
 
 /remoll/targname USAlTarg
-#/remoll/targpos   -75.0 cm
-#/remoll/targlen  0.0127 cm
 
 /remoll/beamcurr 85 microampere
 

--- a/macros/runbatch_eAlinelastic_down.mac
+++ b/macros/runbatch_eAlinelastic_down.mac
@@ -19,8 +19,6 @@
 #/remoll/gen elasticAl
 
 /remoll/targname DSAlTarg
-#/remoll/targpos   +75.0 cm
-#/remoll/targlen  0.0127 cm
 
 /remoll/beamcurr 85 microampere
 

--- a/macros/runbatch_eAlinelastic_up.mac
+++ b/macros/runbatch_eAlinelastic_up.mac
@@ -19,8 +19,6 @@
 #/remoll/gen elasticAl
 
 /remoll/targname USAlTarg
-#/remoll/targpos   -75.0 cm
-#/remoll/targlen  0.0127 cm
 
 /remoll/beamcurr 85 microampere
 

--- a/macros/runbatch_eAlquasielastic_down.mac
+++ b/macros/runbatch_eAlquasielastic_down.mac
@@ -19,8 +19,6 @@
 #/remoll/gen elasticAl
 
 /remoll/targname DSAlTarg
-#/remoll/targpos   +75.0 cm
-#/remoll/targlen  0.0127 cm
 
 /remoll/beamcurr 85 microampere
 

--- a/macros/runbatch_eAlquasielastic_up.mac
+++ b/macros/runbatch_eAlquasielastic_up.mac
@@ -19,8 +19,6 @@
 #/remoll/gen elasticAl
 
 /remoll/targname USAlTarg
-#/remoll/targpos   -75.0 cm
-#/remoll/targlen  0.0127 cm
 
 /remoll/beamcurr 85 microampere
 

--- a/macros/runexample.mac
+++ b/macros/runexample.mac
@@ -71,14 +71,6 @@
 
 /remoll/beamene 11 GeV
 
-# For LH2
-/remoll/targpos   0 cm
-/remoll/targlen 150 cm
-
-# For carbon
-#/remoll/targpos 0.0 cm
-#/remoll/targlen 1.5 mm
-
 /remoll/beamcurr 85 microampere
 
 # Make interactions with W, Cu, and Pb
@@ -93,5 +85,5 @@
 /remoll/filename remollout.root
 
 #/tracking/verbose 2
-
+/remoll/printtargetinfo
 /run/beamOn 100

--- a/macros/runexample_C12.mac
+++ b/macros/runexample_C12.mac
@@ -28,10 +28,6 @@
 /remoll/thmin 0.1 deg
 /remoll/thmax 2.0 deg
 
-# Only have this AFTER we've initalized geometry
-/remoll/targpos 0.0 cm
-/remoll/targlen 1.5 mm
-
 /remoll/beamcurr 85 microampere
 
 #Enable optical photons and processes

--- a/macros/sim_dump_backscatter.in
+++ b/macros/sim_dump_backscatter.in
@@ -23,9 +23,6 @@
 /remoll/evgen/thmin 0.00 deg
 /remoll/evgen/thmax 2.00 deg
 
-/remoll/targpos   0 cm
-/remoll/targlen 150 cm
-
 /remoll/beamcurr 85 microampere
 
 # Make interactions with W, Cu, and Pb

--- a/macros/sim_dump_backscatter.mac
+++ b/macros/sim_dump_backscatter.mac
@@ -23,9 +23,6 @@
 /remoll/evgen/thmin 0.00 deg
 /remoll/evgen/thmax 2.00 deg
 
-/remoll/targpos   0 cm
-/remoll/targlen 150 cm
-
 /remoll/beamcurr 85 microampere
 
 # Make interactions with W, Cu, and Pb

--- a/macros/sim_moller.mac
+++ b/macros/sim_moller.mac
@@ -48,9 +48,6 @@
 #/remoll/gen quasielasticAl
 #/remoll/gen elasticAl
 
-/remoll/targpos   0 cm
-/remoll/targlen 150 cm
-
 /remoll/beamcurr 85 microampere
 
 #Enable optical photons and processes

--- a/macros/sim_pion.mac
+++ b/macros/sim_pion.mac
@@ -49,9 +49,6 @@
 #/remoll/gen quasielasticAl
 #/remoll/gen elasticAl
 
-/remoll/targpos   0 cm
-/remoll/targlen 150 cm
-
 /remoll/beamcurr 85 microampere
 
 #Enable optical photons and processes

--- a/macros/tests/commit/test_elasticAl_DS.mac
+++ b/macros/tests/commit/test_elasticAl_DS.mac
@@ -23,8 +23,6 @@
 /remoll/evgen/set elasticAl
 
 /remoll/targname DSAlTarg
-#/remoll/targpos   +75.0 cm
-#/remoll/targlen  0.0127 cm
 
 # Generation limits
 # theta

--- a/macros/tests/commit/test_elasticAl_US.mac
+++ b/macros/tests/commit/test_elasticAl_US.mac
@@ -23,8 +23,6 @@
 /remoll/evgen/set elasticAl
 
 /remoll/targname USAlTarg
-#/remoll/targpos   -75.0 cm
-#/remoll/targlen  0.0127 cm
 
 # Generation limits
 # theta

--- a/macros/tests/commit/test_raster.mac
+++ b/macros/tests/commit/test_raster.mac
@@ -50,10 +50,6 @@
 #/remoll/evgen/phmin -20.0 deg
 #/remoll/evgen/phmax +20.0 deg
 
-# Target positioning
-#/remoll/targpos  10 cm
-#/remoll/targlen 100 cm
-
 # Beam current for rate
 /remoll/beamcurr 85 microampere
 

--- a/macros/tests/unit/test_target.mac
+++ b/macros/tests/unit/test_target.mac
@@ -1,7 +1,5 @@
 /run/initialize
 /remoll/targname USAlTarg
-/remoll/targpos   -74.9 cm
-/remoll/targlen  0.0127 cm
 /remoll/printtargetinfo
 /run/beamOn 1
 

--- a/src/remollBeamTarget.cc
+++ b/src/remollBeamTarget.cc
@@ -57,8 +57,6 @@ remollBeamTarget::remollBeamTarget()
     // Create generic messenger
     fMessenger = new G4GenericMessenger(this,"/remoll/","Remoll properties");
     fMessenger->DeclareMethod("targname",&remollBeamTarget::SetActiveTargetVolume,"Target name").SetStates(G4State_Idle);
-    fMessenger->DeclareMethodWithUnit("targlen","cm",&remollBeamTarget::SetTargetLen,"Target length").SetStates(G4State_Idle);
-    fMessenger->DeclareMethodWithUnit("targpos","cm",&remollBeamTarget::SetTargetPos,"Target position").SetStates(G4State_Idle);
     fMessenger->DeclareMethod("printtargetinfo",&remollBeamTarget::PrintTargetInfo).SetStates(G4State_Idle);
 
     fMessenger->DeclarePropertyWithUnit("beamcurr","microampere",fBeamCurrent,"Beam current");
@@ -172,110 +170,6 @@ void remollBeamTarget::SetActiveTargetVolume(G4String name)
 
   lock.unlock();
   UpdateInfo();
-}
-
-
-void remollBeamTarget::SetTargetLen(G4double z)
-{
-    G4AutoLock lock(&remollBeamTargetMutex);
-
-    // Loop over target volumes
-    G4bool active_target_volume_found = false;
-    for (std::vector<G4VPhysicalVolume *>::iterator
-        it = fTargetVolumes.begin(); it != fTargetVolumes.end(); it++) {
-
-        G4GeometryManager::GetInstance()->OpenGeometry((*it));
-
-        // If target tubs
-	if ((*it)->GetLogicalVolume()->GetName() == fActiveTargetVolume)
-	{
-            G4VSolid* solid = (*it)->GetLogicalVolume()->GetSolid();
-            G4Tubs* tubs = dynamic_cast<G4Tubs*>(solid);
-            // Change the length of the target volume
-            if (tubs) tubs->SetZHalfLength(z/2.0);
-            active_target_volume_found = true;
-
-	}
-
-	G4GeometryManager::GetInstance()->CloseGeometry(true, false, (*it));
-    }
-
-    if (!active_target_volume_found) {
-
-        G4cerr << "WARNING " << __PRETTY_FUNCTION__ << " line " << __LINE__ <<
-            ": volume other than target has been specified, but handling not implemented" << G4endl;
-
-        // Move position of all other volumes based on half length change
-
-        /*
-        G4ThreeVector pos = (*it)->GetFrameTranslation();
-
-        if( pos.z() < fLH2pos ){
-            pos = pos + G4ThreeVector(0.0, 0.0, (fLH2Length-z)/2.0 );
-        } else {
-            pos = pos - G4ThreeVector(0.0, 0.0, (fLH2Length-z)/2.0 );
-        }
-
-        (*it)->SetTranslation(pos);
-        */
-    }
-
-    G4RunManager* runManager = G4RunManager::GetRunManager();
-    runManager->GeometryHasBeenModified();
-
-    lock.unlock();
-    UpdateInfo();
-
-    //  G4cout << "\nLeaving remollBeamTarget::SetTargetLen(z)" << G4endl;
-}
-
-void remollBeamTarget::SetTargetPos(G4double z)
-{
-    G4AutoLock lock(&remollBeamTargetMutex);
-
-    //G4double zshift = z-(fZpos+fLH2pos);
-
-    // Loop over target volumes
-    G4bool active_target_volume_found = false;
-    for (std::vector<G4VPhysicalVolume *>::iterator
-        it = fTargetVolumes.begin(); it != fTargetVolumes.end(); it++ ) {
-
-        G4GeometryManager::GetInstance()->OpenGeometry((*it));
-
-	if ((*it)->GetLogicalVolume()->GetName() == fActiveTargetVolume) {
-
-	    // Change the length of the target volume
-	    (*it)->SetTranslation(G4ThreeVector(0.0, 0.0, z-fMotherTargetAbsolutePosition));
-            active_target_volume_found = true;
-
-	}
-
-	G4GeometryManager::GetInstance()->CloseGeometry(true, false, (*it));
-    }
-
-    if (!active_target_volume_found) {
-
-        G4cerr << "WARNING " << __PRETTY_FUNCTION__ << " line " << __LINE__ <<
-            ": volume other than target has been specified, but handling not implemented" << G4endl;
-
-        // Move position of all other volumes based on half length change
-
-        /*
-        G4ThreeVector prespos = (*it)->GetFrameTranslation();
-
-        G4ThreeVector pos = prespos + G4ThreeVector(0.0, 0.0, zshift );
-
-        (*it)->SetTranslation(prespos);
-        */
-    }
-
-    G4RunManager* runManager = G4RunManager::GetRunManager();
-    runManager->GeometryHasBeenModified();
-
-    lock.unlock();
-    UpdateInfo();
-
-    //  G4cout << "\nLeaving remollBeamTarget::SetTargetPos(z)" << G4endl;
 }
 
 

--- a/src/remollGenBeam.cc
+++ b/src/remollGenBeam.cc
@@ -30,7 +30,7 @@ remollGenBeam::remollGenBeam()
   fCorrelation(0.149*mrad/mm,0.149*mrad/mm,0.0),
   fPolarization(0.0,0.0,0.0),
   fRaster(5*mm,5*mm,0.0),
-  fRasterRefZ(0.0*m),
+  fRasterRefZ(0.5*m),
   fParticleName("e-")
 {
     fSampType = kNoTargetVolume;

--- a/src/remollGenBeam.cc
+++ b/src/remollGenBeam.cc
@@ -21,16 +21,16 @@
 
 remollGenBeam::remollGenBeam()
 : remollVEventGen("beam"),
-  fOriginMean(0.0*m,0.0*m,-7.75*m),
+  fOriginMean(0.0*m,0.0*m,-6.7*m),
   fOriginSpread(0.0,0.0,0.0),
   fOriginModelX(kOriginModelFlat),
   fOriginModelY(kOriginModelFlat),
   fOriginModelZ(kOriginModelFlat),
   fDirection(0.0,0.0,1.0),
-  fCorrelation(0.136*mrad/mm,0.136*mrad/mm,0.0),
+  fCorrelation(0.149*mrad/mm,0.149*mrad/mm,0.0),
   fPolarization(0.0,0.0,0.0),
   fRaster(5*mm,5*mm,0.0),
-  fRasterRefZ(-0.75*m),
+  fRasterRefZ(0.0*m),
   fParticleName("e-")
 {
     fSampType = kNoTargetVolume;


### PR DESCRIPTION
This propagates the constants
```
    <constant name="tubeTarget_length" value="1250"/>
    <constant name="AlWindowTarget_length" value="0.127"/>
```
and placement of the windows
```
      <physvol>
        <volumeref ref="USAlTarg"/>
        <position name="targ_upstream_window" unit="mm" x="0" y="0" z="-(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>

      <physvol>
        <volumeref ref="DSAlTarg"/>
        <position name="targ_downstream_window" unit="mm" x="0" y="0" z="+(AlWindowTarget_length+tubeTarget_length)/2"/>
      </physvol>

```
in all target implementations.

Asides:
- the `/remoll/targlen` command is likely to disappear since changing
this currently won't move the aluminum windows.