### PR TITLE
Add cmake option ADDITIONAL_FIELDS to download more fields

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,23 @@ install(FILES
      ${REMOLL_MAP_DIR}/blockyHybrid_rm_3.0.txt
      ${REMOLL_MAP_DIR}/blockyUpstream_rm_1.1.txt
      DESTINATION ${CMAKE_INSTALL_DATADIR}/remoll)
+if(ADDITIONAL_FIELDS)
+  message(STATUS "Ensuring additional fields are available")
+  file(DOWNLOAD
+     ${REMOLL_DOWNLOADS}/upstreamSymmetric_sensR_0.0.txt
+     ${REMOLL_MAP_DIR}/upstreamSymmetric_sensR_0.0.txt
+     EXPECTED_MD5 4ca3d968cadd85a89b86148411eda678)
+  file(DOWNLOAD
+     ${REMOLL_DOWNLOADS}/hybridSymmetric_sensR_0.0.txt
+     ${REMOLL_MAP_DIR}/hybridSymmetric_sensR_0.0.txt
+     EXPECTED_MD5 0f6e9a3a8392d01c63f1609afc4e4c09)
+  install(FILES
+     ${REMOLL_MAP_DIR}/upstreamSymmetric_sensR_0.0.txt
+     ${REMOLL_MAP_DIR}/hybridSymmetric_sensR_0.0.txt
+     DESTINATION ${CMAKE_INSTALL_DATADIR}/remoll)
+else()
+  message(STATUS "Download additional fields with '-DADDITIONAL_FIELDS=ON'.")
+endif()
 
 
 #----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,13 +310,13 @@ install(FILES
 if(ADDITIONAL_FIELDS)
   message(STATUS "Ensuring additional fields are available")
   file(DOWNLOAD
-     ${REMOLL_DOWNLOADS}/upstreamSymmetric_sensR_0.0.txt
-     ${REMOLL_MAP_DIR}/upstreamSymmetric_sensR_0.0.txt
-     EXPECTED_MD5 4ca3d968cadd85a89b86148411eda678)
+     ${REMOLL_DOWNLOADS}/upstreamSymmetric_sensR_0.1.txt
+     ${REMOLL_MAP_DIR}/upstreamSymmetric_sensR_0.1.txt
+     EXPECTED_MD5 849d9dc5abab0842fc13fef7f4918648)
   file(DOWNLOAD
-     ${REMOLL_DOWNLOADS}/hybridSymmetric_sensR_0.0.txt
-     ${REMOLL_MAP_DIR}/hybridSymmetric_sensR_0.0.txt
-     EXPECTED_MD5 0f6e9a3a8392d01c63f1609afc4e4c09)
+     ${REMOLL_DOWNLOADS}/hybridSymmetric_sensR_0.1.txt
+     ${REMOLL_MAP_DIR}/hybridSymmetric_sensR_0.1.txt
+     EXPECTED_MD5 78fad2ffa5b5ae129df11bdf0ce25333)
   install(FILES
      ${REMOLL_MAP_DIR}/upstreamSymmetric_sensR_0.0.txt
      ${REMOLL_MAP_DIR}/hybridSymmetric_sensR_0.0.txt


### PR DESCRIPTION
This addresses issue #221 by adding the following
```
cmake -DADDITIONAL_FIELDS=ON ..
```
which will download upstreamSymmetric_sensR_0.0.txt and
hybridSymmetric_sensR_0.0.txt into map_directory.

Tried to solve this by introducing a separate make target but this was
faster and ultimately equivalent in documentation requirements.