### PR TITLE
Merge improvements to bfield header reading

### DIFF
--- a/include/remollGlobalField.hh
+++ b/include/remollGlobalField.hh
@@ -7,6 +7,7 @@
 */
 
 #include "G4MagneticField.hh"
+#include "G4ThreeVector.hh"
 
 #include <vector>
 
@@ -34,6 +35,7 @@ class remollGlobalField : public G4MagneticField {
         void SetMagnetCurrentByString(G4String& name_scale);
 	void SetMagnetCurrent(const G4String& name, G4double scale);
 
+	void PrintFieldValue(const G4ThreeVector&);
 	void GetFieldValue(const G4double[], G4double*) const;
 
     private:

--- a/macros/tests/unit/test_fields.mac
+++ b/macros/tests/unit/test_fields.mac
@@ -1,0 +1,32 @@
+/run/numberOfThreads 1
+/run/initialize
+
+/remoll/field/value 0.0 +0.16 9.55
+/remoll/field/value 0.0 -0.16 9.55
+/remoll/field/value +0.16 0.0 9.55
+/remoll/field/value -0.16 0.0 9.55
+/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
+/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/remoll/field/value 0.0 +0.16 9.55
+/remoll/field/value 0.0 -0.16 9.55
+/remoll/field/value +0.16 0.0 9.55
+/remoll/field/value -0.16 0.0 9.55
+
+/remoll/field/value +0.00037 +0.014 9.55
+/remoll/field/value +0.00037 -0.014 9.55
+/remoll/field/value +0.014 +0.00037 9.55
+/remoll/field/value -0.014 +0.00037 9.55
+/remoll/field/value -0.00037 +0.014 9.55
+/remoll/field/value -0.00037 -0.014 9.55
+/remoll/field/value +0.014 -0.00037 9.55
+/remoll/field/value -0.014 -0.00037 9.55
+#/remoll/addfield map_directory/hybridSymmetric_sensR_0.0.txt
+#/remoll/addfield map_directory/upstreamSymmetric_sensR_0.0.txt
+/remoll/field/value +0.00037 +0.014 9.55
+/remoll/field/value +0.00037 -0.014 9.55
+/remoll/field/value +0.014 +0.00037 9.55
+/remoll/field/value -0.014 +0.00037 9.55
+/remoll/field/value -0.00037 +0.014 9.55
+/remoll/field/value -0.00037 -0.014 9.55
+/remoll/field/value +0.014 -0.00037 9.55
+/remoll/field/value -0.014 -0.00037 9.55

--- a/src/remollGlobalField.cc
+++ b/src/remollGlobalField.cc
@@ -85,6 +85,7 @@ remollGlobalField::remollGlobalField()
     fGlobalFieldMessenger->DeclareProperty("deltachord",fDeltaChord,"Set delta chord for the chord finder");
     fGlobalFieldMessenger->DeclareProperty("deltaonestep",fDeltaOneStep,"Set delta one step for the field manager");
     fGlobalFieldMessenger->DeclareProperty("deltaintersection",fMinStep,"Set delta intersection for the field manager");
+    fGlobalFieldMessenger->DeclareMethod("value",&remollGlobalField::PrintFieldValue,"Print the field value at a given point (in m)");
 }
 
 remollGlobalField::~remollGlobalField()
@@ -251,7 +252,19 @@ remollMagneticField* remollGlobalField::GetFieldByName(const G4String& name)
     }
 }
 
-void remollGlobalField::GetFieldValue( const G4double p[], G4double *resB) const
+void remollGlobalField::PrintFieldValue(const G4ThreeVector& r)
+{
+    G4double B[__GLOBAL_NDIM];
+    G4double p[] = {r.x()*m, r.y()*m, r.z()*m, 0.0};
+    GetFieldValue(p, B);
+    G4cout << "At r" << r << " [m]: B = ";
+    for (int i = 0; i < __GLOBAL_NDIM; i++) {
+        G4cout << B[i] << " ";
+    }
+    G4cout << "T" << G4endl;
+}
+
+void remollGlobalField::GetFieldValue(const G4double p[], G4double *resB) const
 {
     G4double Bsum [__GLOBAL_NDIM], thisB[__GLOBAL_NDIM];
 

--- a/src/remollMagneticField.cc
+++ b/src/remollMagneticField.cc
@@ -219,8 +219,8 @@ void remollMagneticField::ReadFieldMap(){
     // Sanity check on header data
 
     if( !( fMin[kR] >= 0.0 && fMin[kR] < fMax[kR] &&
-	   -180.0 <= fMin[kPhi] && fMin[kPhi] < 180.0 && 
-	   -180.0 <= fMax[kPhi] && fMax[kPhi] < 180.0 && 
+	   -180.0 <= fMin[kPhi] && fMin[kPhi] <= 180.0 &&
+	   -180.0 <= fMax[kPhi] && fMax[kPhi] <= 180.0 &&
 	   fMin[kPhi]  < fMax[kPhi] &&
 	   fMin[kZ] < fMax[kZ] &&
 	   fN[kR] > 0 && fN[kPhi] > 0 && fN[kZ] > 0 &&

--- a/src/remollMagneticField.cc
+++ b/src/remollMagneticField.cc
@@ -276,7 +276,6 @@ void remollMagneticField::ReadFieldMap(){
 
     ///////////////////////////////////
 
-
     if( !( fMin[kPhi] >= -pi && fMin[kPhi] <= pi ) ){
 	G4cerr << "Error " << __FILE__ << " line " << __LINE__ 
 	    << ": File " << fFilename << " header contains invalid phi range.  Aborting" << G4endl;
@@ -284,8 +283,16 @@ void remollMagneticField::ReadFieldMap(){
     }
 
     if( fabs( fabs((mapphirange - fxtantSize)/mapphirange)) > 0.03 ){
-	G4cerr << "Warning " << __FILE__ << " line " << __LINE__ 
-	    << ": File " << fFilename << " header contains too narrow phi range for given xtants." << G4endl <<  "Warning:   Proceeding assuming null field in non-described regions" << G4endl << (fMax[kPhi] - fMin[kPhi])/degree << " deg range < " <<  fxtantSize/degree << " deg xtant" << G4endl;
+	G4cerr << "Warning " << __FILE__ << " line " << __LINE__ << G4endl
+	    << "File " << fFilename << " header contains too narrow phi range for given xtants." << G4endl
+            << "Warning:   Proceeding assuming null field in non-described regions" << G4endl
+            << (fMax[kPhi] - fMin[kPhi])/degree << " deg range < " <<  fxtantSize/degree << " deg xtant" << G4endl;
+    }
+
+    if( fabs(fabs(mapphirange - fxtantSize) / (mapphirange/fN[kPhi]) - 1) < 0.03 ){
+	G4cerr << "Warning " << __FILE__ << " line " << __LINE__ << G4endl
+	    << "File " << fFilename << " header contains a gap in the phi range which seems" << G4endl
+            << "to correspond perfectly with a slice in phi. This will result in a gap in coverage." << G4endl;
     }
 
 


### PR DESCRIPTION
This follows up on PR #217 which was already merged, but where discussion indicated that gaps in fields can occur. Additional warnings will be added into develop through this PR, and field maps with upper boundaries of +180 deg are now allowed.