### PR TITLE
Bugfix: Set default build type to RelWithDebInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ log
 .cproject
 .project
 
+#ignore build type file
+.buildtype
+
 #ignore dot files
 *.dot
 

--- a/cmake/modules/BuildType.cmake
+++ b/cmake/modules/BuildType.cmake
@@ -1,7 +1,10 @@
 # Set a default build type if none was specified
 set(DEFAULT_CMAKE_BUILD_TYPE "Release")
 if (EXISTS "${CMAKE_SOURCE_DIR}/.git")
-  set(DEFAULT_CMAKE_BUILD_TYPE "Debug")
+  set(DEFAULT_CMAKE_BUILD_TYPE "RelWithDebInfo")
+endif()
+if (EXISTS "${CMAKE_SOURCE_DIR}/.buildtype")
+  file(STRINGS "${CMAKE_SOURCE_DIR}/.buildtype" DEFAULT_CMAKE_BUILD_TYPE)
 endif()
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to '${DEFAULT_CMAKE_BUILD_TYPE}' as none was specified.")


### PR DESCRIPTION
The default build type was Debug, which is about ~30% slower than
RelWithDebInfo, and RelWithDebInfo contains the same backtrace info.
This will make code faster (since typically run without changing the
default build type).

A specific build type can be chosen without the neeed to specify a
command line flag by creating a file .buildtype (which is ignored by
git) with as content e.g. Debug. This will persist between deletes
of the build directory (but changing the file will not cause a new
build type to take effect, this is only read on the first call to
cmake in an empty directory). The content of the file can still be
overridden with a command line argument: e.g.
```
cmake -DCMAKE_BUILD_TYPE=Release ..
```