### PR TITLE
Changed default beam current to 65 uA (was 75 uA)

### DIFF
--- a/include/remollglobs.hh
+++ b/include/remollglobs.hh
@@ -15,6 +15,6 @@
 
 const double gDefaultBeamE   = 11.0*GeV;
 const double gDefaultBeamPol = 0.85;
-const double gDefaultBeamCur = 75e-6*ampere;
+const double gDefaultBeamCur = 70e-6*ampere;
 
 #endif //__REMOLLGLOBS_HH

--- a/include/remollglobs.hh
+++ b/include/remollglobs.hh
@@ -15,6 +15,6 @@
 
 const double gDefaultBeamE   = 11.0*GeV;
 const double gDefaultBeamPol = 0.85;
-const double gDefaultBeamCur = 70e-6*ampere;
+const double gDefaultBeamCur = 65e-6*ampere;
 
 #endif //__REMOLLGLOBS_HH


### PR DESCRIPTION
If you don't specify a beam current, it will determine rates based on 70 uA assumption.

You can still override with `/remoll/beamcurr 85 uA` etc. No changes beyond a single character...