### PR TITLE
Bugfix issue 254 save xml files

### DIFF
--- a/geometry/pion/GEM/pionDetectorGEM.gdml
+++ b/geometry/pion/GEM/pionDetectorGEM.gdml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!DOCTYPE gdml [
-  <!ENTITY materials SYSTEM "pionMaterials.xml">
-  <!ENTITY matrices SYSTEM "pionMatrices.xml">
-]>
-
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
 <define>

--- a/include/remollIO.hh
+++ b/include/remollIO.hh
@@ -81,6 +81,7 @@ class remollIO {
         G4String fFilename;
 
 	std::vector<G4String> fGDMLFileNames;
+	std::vector<G4String> fXMLFileNames;
 
 	void SearchGDMLforFiles(G4String );
 	void TraverseChildren(  xercesc::DOMElement * );

--- a/src/remollIO.cc
+++ b/src/remollIO.cc
@@ -247,16 +247,20 @@ void remollIO::SearchGDMLforFiles(G4String fn)
 
     // Get doctype and entities
     xercesc::DOMDocumentType* xmlDocType = xmlDoc->getDoctype();
-    xercesc::DOMNamedNodeMap* xmlNamedNodeMap = xmlDocType->getEntities();
-    for (XMLSize_t xx = 0; xx < xmlNamedNodeMap->getLength(); ++xx ){
-        xercesc::DOMNode* currentNode = xmlNamedNodeMap->item(xx);
-        if (currentNode->getNodeType() == xercesc::DOMNode::ENTITY_NODE) { // is entity
-            xercesc::DOMEntity* currentEntity
-              = dynamic_cast< xercesc::DOMEntity* >( currentNode );
-            const XMLCh* systemID = currentEntity->getSystemId();
-            char* str_systemID = xercesc::XMLString::transcode(systemID);
-            G4cout << "entity: " << str_systemID << G4endl;
-            xercesc::XMLString::release(&str_systemID);
+    if (xmlDocType) {
+        xercesc::DOMNamedNodeMap* xmlNamedNodeMap = xmlDocType->getEntities();
+        if (xmlNamedNodeMap) {
+            for (XMLSize_t xx = 0; xx < xmlNamedNodeMap->getLength(); ++xx) {
+                xercesc::DOMNode* currentNode = xmlNamedNodeMap->item(xx);
+                if (currentNode->getNodeType() == xercesc::DOMNode::ENTITY_NODE) { // is entity
+                    xercesc::DOMEntity* currentEntity
+                      = dynamic_cast< xercesc::DOMEntity* >( currentNode );
+                    const XMLCh* systemID = currentEntity->getSystemId();
+                    char* str_systemID = xercesc::XMLString::transcode(systemID);
+                    G4cout << "entity: " << str_systemID << G4endl;
+                    xercesc::XMLString::release(&str_systemID);
+                }
+            }
         }
     }
 

--- a/src/remollIO.cc
+++ b/src/remollIO.cc
@@ -19,6 +19,8 @@
 #include <errno.h>
 
 #include <xercesc/parsers/XercesDOMParser.hpp>
+#include <xercesc/dom/DOMEntityReference.hpp>
+#include <xercesc/dom/DOMEntity.hpp>
 #include <xercesc/dom/DOMElement.hpp>
 #include <xercesc/dom/DOMNodeList.hpp>
 #include <xercesc/dom/DOMNode.hpp>
@@ -233,6 +235,7 @@ void remollIO::SearchGDMLforFiles(G4String fn)
     xercesc::XMLPlatformUtils::Initialize();
 
     xercesc::XercesDOMParser *xmlParser = new xercesc::XercesDOMParser();
+    const xercesc::EntityResolver *xmlParser->getEntityResolver();
     xmlParser->parse(fn.data());
     xercesc::DOMDocument* xmlDoc = xmlParser->getDocument();
     xercesc::DOMElement* elementRoot = xmlDoc->getDocumentElement();
@@ -252,6 +255,29 @@ void remollIO::TraverseChildren( xercesc::DOMElement *thisel )
     for( XMLSize_t xx = 0; xx < nodeCount; ++xx ){
         xercesc::DOMNode* currentNode = children->item(xx);
         if( currentNode->getNodeType() ){   // true is not NULL
+
+            G4cout << currentNode->getNodeType() << G4endl;
+            const XMLCh* text = currentNode->getNodeName();
+            char* str_text = xercesc::XMLString::transcode(text);
+            G4cout << "node: " << str_text << G4endl;
+            xercesc::XMLString::release(&str_text);
+
+            if (currentNode->getNodeType() == xercesc::DOMNode::ENTITY_REFERENCE_NODE) { // is entity
+                xercesc::DOMEntityReference* currentEntityReference
+                  = dynamic_cast< xercesc::DOMEntityReference* >( currentNode );
+                const XMLCh* text = currentEntityReference->getNodeName();
+                char* str_text = xercesc::XMLString::transcode(text);
+                G4cout << "entity reference: " << str_text << G4endl;
+                xercesc::XMLString::release(&str_text);
+
+                xercesc::DOMNode* childNode = currentEntityReference->getFirstChild();
+                if( childNode ){
+                    const XMLCh* text = childNode->getNodeValue();
+                    char* str_text = xercesc::XMLString::transcode(text);
+                    G4cout << "child: " << str_text << G4endl;
+                    xercesc::XMLString::release(&str_text);
+                }
+            }
 
             if (currentNode->getNodeType() == xercesc::DOMNode::ELEMENT_NODE) { // is element
                 xercesc::DOMElement* currentElement


### PR DESCRIPTION
This branch ensures that the external xml entity files are stored in the ROOT file as well, and recreated when RecreateGDML is called on the ROOT file.

This works on things like:
```
<!DOCTYPE gdml [
  <!ENTITY materials SYSTEM "pionMaterials.xml">
  <!ENTITY matrices SYSTEM "../matrices.xml">
  <!ENTITY matrices SYSTEM "/absolute/path/../../relative/path/matrices.xml">
]>
```
It will strip out the current working dir.

Fixes #254, so will close that one.