### PR TITLE
Use kinetic energy in lowenergyneutrals

### DIFF
--- a/src/remollGenericDetector.cc
+++ b/src/remollGenericDetector.cc
@@ -115,6 +115,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
     //   individual hit
     // - if we do write an individual hit we return true
 
+    std::cout << "hit" << std::endl;
 
     // Ignore this detector if disabled as set by /remoll/SD/disable
     if (! fEnabled) {
@@ -181,7 +182,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
     G4double charge = particle->GetPDGCharge();
     if (! fDetectLowEnergyNeutrals
         && particle != G4OpticalPhoton::OpticalPhotonDefinition()
-        && charge == 0.0 && track->GetTotalEnergy() < 0.1*CLHEP::MeV) {
+        && charge == 0.0 && track->GetKineticEnergy() < 0.1*CLHEP::MeV) {
       static bool has_been_warned = false;
       if (! has_been_warned) {
         G4cout << "remoll: <0.1 MeV neutrals simulated but not stored for some detectors." << G4endl;
@@ -280,6 +281,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
 
     hit->fP = track->GetMomentum().mag();
     hit->fE = track->GetTotalEnergy();
+    G4cout << track->GetMomentum().mag() << " " << track->GetKineticEnergy() << " " << track->GetDynamicParticle()->GetMass() << G4endl;
     hit->fM = particle->GetPDGMass();
 
     hit->fTrID  = track->GetTrackID();

--- a/src/remollGenericDetector.cc
+++ b/src/remollGenericDetector.cc
@@ -115,8 +115,6 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
     //   individual hit
     // - if we do write an individual hit we return true
 
-    std::cout << "hit" << std::endl;
-
     // Ignore this detector if disabled as set by /remoll/SD/disable
     if (! fEnabled) {
       static bool has_been_warned = false;
@@ -281,7 +279,6 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
 
     hit->fP = track->GetMomentum().mag();
     hit->fE = track->GetTotalEnergy();
-    G4cout << track->GetMomentum().mag() << " " << track->GetKineticEnergy() << " " << track->GetDynamicParticle()->GetMass() << G4endl;
     hit->fM = particle->GetPDGMass();
 
     hit->fTrID  = track->GetTrackID();


### PR DESCRIPTION
Instead of selecting low energy neutrals on total energy, use kinetic energy

Effects:
- You may lose low energy neutral hits from massive neutral particles which
  were stored in the output ROOT file until now: use `lowenergyneutrals` tag
  to indicate that you want to store those hits after all.
- Anyone who already relied on the `lowenergyneutrals` tag will likely not
  see a difference.