### PR TITLE
Enhancement pivot is new origin

### DIFF
--- a/geometry/mollerMother_5open.gdml
+++ b/geometry/mollerMother_5open.gdml
@@ -26,7 +26,7 @@
 
     <physvol>
       <file name="detector_5open.gdml"/>
-      <position name="detectorCenter" x="0" y="0" z="0.0*28500."/>
+      <position name="detectorCenter" x="0" y="0" z="0.0"/>
       <rotation name="rot" unit="deg" x="0" y="90" z="0"/>
     </physvol>
 

--- a/geometry/mollerMother_black.gdml
+++ b/geometry/mollerMother_black.gdml
@@ -8,11 +8,8 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
 <define> 
-  <position name="hallCenter" x="0" y="0" z="4000"/>
   <position name="targetCenter" x="0" y="0" z="10000"/>
-  <position name="upstreamCenter" x="0" y="0" z="7000."/>
-  <position name="hybridCenter" x="0" y="0" z="13366.57"/>
-  <position name="detectorCenter" x="0" y="0" z="0.0*28500."/>
+  <position name="detectorCenter" x="0" y="0" z="0.0"/>
   <rotation name="rot" unit="deg" x="0" y="90" z="0"/>
 </define>
 

--- a/geometry/positions.xml
+++ b/geometry/positions.xml
@@ -7,34 +7,34 @@
 -->
      
 <!-- Hall center position (MOLLER target is upstream of pivot) -->
-<position name="hallCenter" x="0" y="0" z="6087." unit="mm"/>
+<position name="hallCenter" x="0.0" y="0.0" z="0.0" unit="mm"/>
 
 <!-- Target position -->
-<position name="targetCenter" x="0" y="0" z="0" unit="mm"/>
+<position name="targetCenter" x="0.0" y="0.0" z="-6087.00" unit="mm"/>
 
 <!-- Upstream spectrometer position -->
-<position name="upstreamCenter" x="0" y="0" z="7000." unit="mm"/>
+<position name="upstreamCenter" x="0.0" y="0.0" z="913.00" unit="mm"/>
 
 <!-- Hybrid spectrometer position -->
-<position name="hybridCenter" x="0" y="0" z="13366.57" unit="mm"/>
+<position name="hybridCenter" x="0.0" y="0.0" z="7279.57" unit="mm"/>
 
 <!-- Physical tracking detector position -->
-<position name="trackingCenter" x="0" y="0" z="26635." unit="mm"/>
+<position name="trackingCenter" x="0.0" y="0.0" z="20548.00" unit="mm"/>
 <!-- Virtual planes in the parallel world -->
-<position name="trackingDetectorVirtualPlaneCenter_pos" z="25.635" unit="m"/>
+<position name="trackingDetectorVirtualPlaneCenter_pos" z="20548.00" unit="mm"/>
 <position name="trackingDetectorVirtualPlaneFront1_pos" z="-1.45" unit="m"/>
 <position name="trackingDetectorVirtualPlaneFront2_pos" z="-1.25" unit="m"/>
 <position name="trackingDetectorVirtualPlaneBack1_pos"  z="+1.25" unit="m"/>
 <position name="trackingDetectorVirtualPlaneBack2_pos"  z="+1.45" unit="m"/>
 
 <!-- Physical main detector array position -->
-<position name="detectorCenter" x="0" y="0" z="28500." unit="mm"/>
+<position name="detectorCenter" x="0.0" y="0.0" z="22413.00" unit="mm"/>
 <!-- Virtual planes in the parallel world -->
-<position name="mainDetectorVirtualPlane_pos" z="28.500" unit="m"/>
+<position name="mainDetectorVirtualPlane_pos" z="22413.00" unit="mm"/>
 
 <!-- Z position of the plane about which the two arrays of showermax
 detectors are placed -->
-<position name="showerMaxDetectorCenter" x="0" y="0" z="28750." unit="mm"/>
+<position name="showerMaxDetectorCenter" x="0.0" y="0.0" z="22663.00" unit="mm"/>
 
 <!-- Z position of the center of the lucite stack of the pion detector. -->
-<position name="pionDetectorCenter" x="0" y="0" z="29600." unit="mm"/>
+<position name="pionDetectorCenter" x="0.0" y="0.0" z="23513.00" unit="mm"/>

--- a/geometry/positions.xml
+++ b/geometry/positions.xml
@@ -21,7 +21,7 @@
 <!-- Physical tracking detector position -->
 <position name="trackingCenter" x="0.0" y="0.0" z="20548.00" unit="mm"/>
 <!-- Virtual planes in the parallel world -->
-<position name="trackingDetectorVirtualPlaneCenter_pos" z="20548.00" unit="mm"/>
+<position name="trackingDetectorVirtualPlaneCenter_pos" z="19548.00" unit="mm"/>
 <position name="trackingDetectorVirtualPlaneFront1_pos" z="-1.45" unit="m"/>
 <position name="trackingDetectorVirtualPlaneFront2_pos" z="-1.25" unit="m"/>
 <position name="trackingDetectorVirtualPlaneBack1_pos"  z="+1.25" unit="m"/>
@@ -30,7 +30,7 @@
 <!-- Physical main detector array position -->
 <position name="detectorCenter" x="0.0" y="0.0" z="22413.00" unit="mm"/>
 <!-- Virtual planes in the parallel world -->
-<position name="mainDetectorVirtualPlane_pos" z="22413.00" unit="mm"/>
+<position name="mainDetectorVirtualPlane_pos" z="22.41300" unit="m"/>
 
 <!-- Z position of the plane about which the two arrays of showermax
 detectors are placed -->

--- a/src/remollGenBeam.cc
+++ b/src/remollGenBeam.cc
@@ -21,7 +21,7 @@
 
 remollGenBeam::remollGenBeam()
 : remollVEventGen("beam"),
-  fOriginMean(0.0*m,0.0*m,-6.7*m),
+  fOriginMean(0.0*m,0.0*m,-12.787*m),
   fOriginSpread(0.0,0.0,0.0),
   fOriginModelX(kOriginModelFlat),
   fOriginModelY(kOriginModelFlat),
@@ -30,7 +30,7 @@ remollGenBeam::remollGenBeam()
   fCorrelation(0.149*mrad/mm,0.149*mrad/mm,0.0),
   fPolarization(0.0,0.0,0.0),
   fRaster(5*mm,5*mm,0.0),
-  fRasterRefZ(0.5*m),
+  fRasterRefZ(-5.587*m),
   fParticleName("e-")
 {
     fSampType = kNoTargetVolume;


### PR DESCRIPTION
Moving all geometry (rather trivially) to a new geometry origin. Since geometry is tree-based and top-level absolute positions are in `geometry/positions.xml`, this is a fairly easy.

- Some absolute positions are also in the beam generator raster (and in remollBeamTarget raster if one uses the angle correlations there, not touched here since the raster origin at -8000 m is somewhat arbitrary and needs a rewrite as part of #10).

I think that's all, though.