### PR TITLE
Enhancement updated geometry

### DIFF
--- a/geometry/mollerMother_5open.gdml
+++ b/geometry/mollerMother_5open.gdml
@@ -26,7 +26,7 @@
 
     <physvol>
       <file name="detector_5open.gdml"/>
-      <position name="detectorCenter" x="0" y="0" z="0.0*28500."/>
+      <position name="detectorCenter" x="0" y="0" z="0.0"/>
       <rotation name="rot" unit="deg" x="0" y="90" z="0"/>
     </physvol>
 

--- a/geometry/mollerMother_black.gdml
+++ b/geometry/mollerMother_black.gdml
@@ -8,11 +8,8 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
 <define> 
-  <position name="hallCenter" x="0" y="0" z="4000"/>
   <position name="targetCenter" x="0" y="0" z="10000"/>
-  <position name="upstreamCenter" x="0" y="0" z="7000."/>
-  <position name="hybridCenter" x="0" y="0" z="13366.57"/>
-  <position name="detectorCenter" x="0" y="0" z="0.0*28500."/>
+  <position name="detectorCenter" x="0" y="0" z="0.0"/>
   <rotation name="rot" unit="deg" x="0" y="90" z="0"/>
 </define>
 

--- a/geometry/positions.xml
+++ b/geometry/positions.xml
@@ -21,7 +21,7 @@
 <!-- Physical tracking detector position -->
 <position name="trackingCenter" x="0.0" y="0.0" z="20048.00" unit="mm"/>
 <!-- Virtual planes in the parallel world -->
-<position name="trackingDetectorVirtualPlaneCenter_pos" z="20048.00" unit="mm"/>
+<position name="trackingDetectorVirtualPlaneCenter_pos" z="19048.00" unit="mm"/>
 <position name="trackingDetectorVirtualPlaneFront1_pos" z="-1.45" unit="m"/>
 <position name="trackingDetectorVirtualPlaneFront2_pos" z="-1.25" unit="m"/>
 <position name="trackingDetectorVirtualPlaneBack1_pos"  z="+1.25" unit="m"/>

--- a/geometry/positions.xml
+++ b/geometry/positions.xml
@@ -7,34 +7,34 @@
 -->
      
 <!-- Hall center position (MOLLER target is upstream of pivot) -->
-<position name="hallCenter" x="0" y="0" z="6087." unit="mm"/>
+<position name="hallCenter" x="0.0" y="0.0" z="0.0" unit="mm"/>
 
 <!-- Target position -->
-<position name="targetCenter" x="0" y="0" z="0" unit="mm"/>
+<position name="targetCenter" x="0.0" y="0.0" z="-6087.00" unit="mm"/>
 
 <!-- Upstream spectrometer position -->
-<position name="upstreamCenter" x="0" y="0" z="7000." unit="mm"/>
+<position name="upstreamCenter" x="0.0" y="0.0" z="913.00" unit="mm"/>
 
 <!-- Hybrid spectrometer position -->
-<position name="hybridCenter" x="0" y="0" z="13366.57" unit="mm"/>
+<position name="hybridCenter" x="0.0" y="0.0" z="7279.57" unit="mm"/>
 
 <!-- Physical tracking detector position -->
-<position name="trackingCenter" x="0" y="0" z="26635." unit="mm"/>
+<position name="trackingCenter" x="0.0" y="0.0" z="20548.00" unit="mm"/>
 <!-- Virtual planes in the parallel world -->
-<position name="trackingDetectorVirtualPlaneCenter_pos" z="25.635" unit="m"/>
+<position name="trackingDetectorVirtualPlaneCenter_pos" z="20548.00" unit="mm"/>
 <position name="trackingDetectorVirtualPlaneFront1_pos" z="-1.45" unit="m"/>
 <position name="trackingDetectorVirtualPlaneFront2_pos" z="-1.25" unit="m"/>
 <position name="trackingDetectorVirtualPlaneBack1_pos"  z="+1.25" unit="m"/>
 <position name="trackingDetectorVirtualPlaneBack2_pos"  z="+1.45" unit="m"/>
 
 <!-- Physical main detector array position -->
-<position name="detectorCenter" x="0" y="0" z="28500." unit="mm"/>
+<position name="detectorCenter" x="0.0" y="0.0" z="22413.00" unit="mm"/>
 <!-- Virtual planes in the parallel world -->
-<position name="mainDetectorVirtualPlane_pos" z="28.500" unit="m"/>
+<position name="mainDetectorVirtualPlane_pos" z="22413.00" unit="mm"/>
 
 <!-- Z position of the plane about which the two arrays of showermax
 detectors are placed -->
-<position name="showerMaxDetectorCenter" x="0" y="0" z="28750." unit="mm"/>
+<position name="showerMaxDetectorCenter" x="0.0" y="0.0" z="22663.00" unit="mm"/>
 
 <!-- Z position of the center of the lucite stack of the pion detector. -->
-<position name="pionDetectorCenter" x="0" y="0" z="29600." unit="mm"/>
+<position name="pionDetectorCenter" x="0.0" y="0.0" z="23513.00" unit="mm"/>

--- a/geometry/positions.xml
+++ b/geometry/positions.xml
@@ -10,31 +10,31 @@
 <position name="hallCenter" x="0.0" y="0.0" z="0.0" unit="mm"/>
 
 <!-- Target position -->
-<position name="targetCenter" x="0.0" y="0.0" z="-6087.00" unit="mm"/>
+<position name="targetCenter" x="0.0" y="0.0" z="-4587.00" unit="mm"/>
 
 <!-- Upstream spectrometer position -->
-<position name="upstreamCenter" x="0.0" y="0.0" z="913.00" unit="mm"/>
+<position name="upstreamCenter" x="0.0" y="0.0" z="1913.00" unit="mm"/>
 
 <!-- Hybrid spectrometer position -->
-<position name="hybridCenter" x="0.0" y="0.0" z="7279.57" unit="mm"/>
+<position name="hybridCenter" x="0.0" y="0.0" z="8279.57" unit="mm"/>
 
 <!-- Physical tracking detector position -->
-<position name="trackingCenter" x="0.0" y="0.0" z="20548.00" unit="mm"/>
+<position name="trackingCenter" x="0.0" y="0.0" z="20048.00" unit="mm"/>
 <!-- Virtual planes in the parallel world -->
-<position name="trackingDetectorVirtualPlaneCenter_pos" z="20548.00" unit="mm"/>
+<position name="trackingDetectorVirtualPlaneCenter_pos" z="20048.00" unit="mm"/>
 <position name="trackingDetectorVirtualPlaneFront1_pos" z="-1.45" unit="m"/>
 <position name="trackingDetectorVirtualPlaneFront2_pos" z="-1.25" unit="m"/>
 <position name="trackingDetectorVirtualPlaneBack1_pos"  z="+1.25" unit="m"/>
 <position name="trackingDetectorVirtualPlaneBack2_pos"  z="+1.45" unit="m"/>
 
 <!-- Physical main detector array position -->
-<position name="detectorCenter" x="0.0" y="0.0" z="22413.00" unit="mm"/>
+<position name="detectorCenter" x="0.0" y="0.0" z="21913.00" unit="mm"/>
 <!-- Virtual planes in the parallel world -->
-<position name="mainDetectorVirtualPlane_pos" z="22413.00" unit="mm"/>
+<position name="mainDetectorVirtualPlane_pos" z="21913.00" unit="mm"/>
 
 <!-- Z position of the plane about which the two arrays of showermax
 detectors are placed -->
-<position name="showerMaxDetectorCenter" x="0.0" y="0.0" z="22663.00" unit="mm"/>
+<position name="showerMaxDetectorCenter" x="0.0" y="0.0" z="22163.00" unit="mm"/>
 
 <!-- Z position of the center of the lucite stack of the pion detector. -->
-<position name="pionDetectorCenter" x="0.0" y="0.0" z="23513.00" unit="mm"/>
+<position name="pionDetectorCenter" x="0.0" y="0.0" z="23013.00" unit="mm"/>

--- a/geometry/target/subTargetRegion.gdml
+++ b/geometry/target/subTargetRegion.gdml
@@ -10,7 +10,7 @@
   <define>
     &matrices;
 
-   <constant name="targetCenterZ" value="500"/>
+   <constant name="targetCenterZ" value="0"/>
    <constant name="tubeTarget_length" value="1250"/>
    <constant name="AlWindowTarget_length" value="0.127"/>
 

--- a/geometry/target/target12C.gdml
+++ b/geometry/target/target12C.gdml
@@ -2,7 +2,7 @@
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
   <define>
-    <constant name="targetCenterZ" value="500"/>
+    <constant name="targetCenterZ" value="0"/>
   </define>
   
   <materials>

--- a/geometry/target/targetDaughter.gdml
+++ b/geometry/target/targetDaughter.gdml
@@ -2,7 +2,7 @@
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
 
 <define>
-  <constant name="targetCenterZ" value="500"/>
+  <constant name="targetCenterZ" value="0"/>
   <constant name="tubeTarget_rmax" value="40"/>
   <constant name="tubeTarget_length" value="1250"/>
   <constant name="AlWindowTarget_length" value="0.127"/>

--- a/geometry/target/targetDaughter_Clamshell_Optimized.gdml
+++ b/geometry/target/targetDaughter_Clamshell_Optimized.gdml
@@ -13,7 +13,7 @@
     <constant name="y_increase_targ" value="0.0"/>
     <constant name="YOFFSET_targ" value="-1*y_increase_targ/2"/>
 
-    <constant name="targetCenterZ" value="500"/>
+    <constant name="targetCenterZ" value="0"/>
     <constant name="tubeTarget_rmax" value="40"/>
     <constant name="tubeTarget_length" value="1250"/>
     <constant name="AlWindowTarget_length" value="0.127"/>

--- a/geometry/target/targetDaughter_acceptanceDefinition.gdml
+++ b/geometry/target/targetDaughter_acceptanceDefinition.gdml
@@ -13,7 +13,7 @@
     <constant name="y_increase_targ" value="0.0"/>
     <constant name="YOFFSET_targ" value="-1*y_increase_targ/2"/>
 
-    <constant name="targetCenterZ" value="500"/>
+    <constant name="targetCenterZ" value="0"/>
     <constant name="tubeTarget_rmax" value="40"/>
     <constant name="tubeTarget_length" value="1250"/>
     <constant name="AlWindowTarget_length" value="0.127"/>

--- a/geometry/target/targetDaughter_merged.gdml
+++ b/geometry/target/targetDaughter_merged.gdml
@@ -10,7 +10,7 @@
 <define>
   &matrices;
 
-  <constant name="targetCenterZ" value="500"/>
+  <constant name="targetCenterZ" value="0"/>
   <constant name="tubeTarget_rmax" value="40"/>
   <constant name="tubeTarget_length" value="1250"/>
   <constant name="AlWindowTarget_length" value="0.127"/>

--- a/geometry/target/targetDaughter_noShlds.gdml
+++ b/geometry/target/targetDaughter_noShlds.gdml
@@ -10,7 +10,7 @@
 <define>
   &matrices;
 
-  <constant name="targetCenterZ" value="500"/>
+  <constant name="targetCenterZ" value="0"/>
   <constant name="tubeTarget_rmax" value="40"/>
   <constant name="tubeTarget_length" value="1250"/>
   <constant name="AlWindowTarget_length" value="0.127"/>

--- a/geometry/upstream/upstreamDaughter_merged.gdml
+++ b/geometry/upstream/upstreamDaughter_merged.gdml
@@ -153,7 +153,7 @@
     <!-- Neutron Poly Shielding -->
     <!-- PolyShield1 will be outside shielding blocks 2 and 3 -->
     <constant name="USPolyShield1_front_thickness" value="400 + 400"/>
-    <constant name="USPolyShield1_back_thickness" value="400 + 400"/>
+    <constant name="USPolyShield1_back_thickness" value="394 + 400"/>
     <constant name="USPolyShield1_side_thickness" value="400 + 400"/>
     <constant name="USPolyShield1_top_thickness" value="400 + 400"/>
     <constant name="USPolyShield1_bottom_thickness" value="400 + 400"/>

--- a/geometry/upstream/upstreamDaughter_merged.gdml
+++ b/geometry/upstream/upstreamDaughter_merged.gdml
@@ -132,7 +132,7 @@
     <!-- Default value before check3 -->
     <!-- <constant name="boxUSShieldColl1_inner_rmax" value="140"/>  -->
     <constant name="USShield1_extension" value="829.5 - 50"/> <!-- subtract 50 to prevent overlaps? - make this parametrized in the future to avoid arbitrariness -->
-    <constant name="USBoxmother_extensionUS" value="1100"/>
+    <constant name="USBoxmother_extensionUS" value="0"/>
     <constant name="USShield2_extension" value="370 - 90"/> <!-- subtract 90 to prevent overlaps?? -->
     <constant name="USBoxmother_extensionDS" value="0"/>
     <constant name="boxUSShieldColl1_inner_rmax" value="100"/> <!-- FIXME this is marginally close to the acceptance defining collimator's outer radius of 98 mm and will consequently cause the concrete to absorb a significant amount of power that was otherwise intended for collimator 2-->
@@ -152,7 +152,7 @@
 
     <!-- Neutron Poly Shielding -->
     <!-- PolyShield1 will be outside shielding blocks 2 and 3 -->
-    <constant name="USPolyShield1_front_thickness" value="400 + 400"/>
+    <constant name="USPolyShield1_front_thickness" value="200"/>
     <constant name="USPolyShield1_back_thickness" value="394 + 400"/>
     <constant name="USPolyShield1_side_thickness" value="400 + 400"/>
     <constant name="USPolyShield1_top_thickness" value="400 + 400"/>

--- a/geometry/upstream/upstreamDaughter_merged.gdml
+++ b/geometry/upstream/upstreamDaughter_merged.gdml
@@ -152,18 +152,21 @@
 
     <!-- Neutron Poly Shielding -->
     <!-- PolyShield1 will be outside shielding blocks 2 and 3 -->
+    <constant name="USPolyShield1_front_thickness" value="400 + 400"/>
+    <constant name="USPolyShield1_back_thickness" value="400 + 400"/>
     <constant name="USPolyShield1_side_thickness" value="400 + 400"/>
     <constant name="USPolyShield1_top_thickness" value="400 + 400"/>
     <constant name="USPolyShield1_bottom_thickness" value="400 + 400"/>
-    <constant name="USPolyShield1_length" value="USShield1_length + USShield2_length + 1 + 2*USPolyShield1_side_thickness + 100"/>
+    <constant name="USPolyShield1_length" value="USShield1_length + USShield2_length + 1 + USPolyShield1_front_thickness + USPolyShield1_back_thickness + 100"/>
     <constant name="USPolyShield1_width" value="USShield2_width + 1 + 2*USPolyShield1_side_thickness"/>
     <constant name="USPolyShield1_height" value="USShield2_height + 1 + USPolyShield1_top_thickness + USPolyShield1_bottom_thickness"/>
     <constant name="boxPolyShield1_beam_bore" value="boxUSShieldColl2_inner_rmax + 15"/>
     <!--offeset when no bottom shield (USPolyShield1_top_thickness + USPolyShield1_bottom_thickness)/2 -->
     <constant name="USPolyShield1_y_offset" value="(USPolyShield1_top_thickness - USPolyShield1_bottom_thickness)/2"/>
-    <position name="boxUSPolyShield1_trans1" unit="mm" x="0" y="-1*USPolyShield1_top_thickness/2 + USPolyShield1_bottom_thickness/2" z="0"/>
+    <constant name="USPolyShield1_z_offset" value="(USPolyShield1_back_thickness - USPolyShield1_front_thickness)/2"/>
+    <position name="boxUSPolyShield1_trans1" unit="mm" x="0" y="-1*USPolyShield1_top_thickness/2 + USPolyShield1_bottom_thickness/2" z="-1*USPolyShield1_back_thickness/2 + USPolyShield1_front_thickness/2"/>
     <position name="boxUSPolyShield1_trans2" unit="mm" x="0" y="-1*USPolyShield1_y_offset" z="0"/>
-    <position name="boxUSPolyShield1_center" unit="mm" x="0" y="USPolyShield1_y_offset" z="5865-UOFFSET-(USShield1_extension-USShield2_extension)/2"/>
+    <position name="boxUSPolyShield1_center" unit="mm" x="0" y="USPolyShield1_y_offset" z="5865-UOFFSET-(USShield1_extension-USShield2_extension)/2+USPolyShield1_z_offset"/>
 
     <constant name="X_ARC" value="COIL_STRAIGHT_L/2"/>
     <constant name="Y1_ARC" value="-INCOILRADIUS-(COIL_ARC_R+XS_H/2)"/>
@@ -718,7 +721,7 @@
     <!-- Neutron Poly Shielding -->
     <!-- PolyShield1 will be outside shielding blocks 2 and 3 -->
     <box lunit="mm" name="boxUSPolyShield1_solid_1" x="USPolyShield1_width" y="USPolyShield1_height" z="USPolyShield1_length"/>
-    <box lunit="mm" name="boxUSPolyShield1_solid_2" x="USPolyShield1_width - 2*USPolyShield1_side_thickness + 1" y="USPolyShield1_height - USPolyShield1_top_thickness - USPolyShield1_bottom_thickness + 1" z="USPolyShield1_length - 2*USPolyShield1_side_thickness + 1"/>
+    <box lunit="mm" name="boxUSPolyShield1_solid_2" x="USPolyShield1_width - 2*USPolyShield1_side_thickness + 1" y="USPolyShield1_height - USPolyShield1_top_thickness - USPolyShield1_bottom_thickness + 1" z="USPolyShield1_length - USPolyShield1_front_thickness - USPolyShield1_back_thickness + 1"/>
     <tube aunit="deg" deltaphi="360" lunit="mm" name="USPolyShield1_beamTube_solid" rmax="boxPolyShield1_beam_bore" rmin="0" startphi="0" z="USPolyShield1_length+10"/>
 
     <subtraction name ="boxUSPolyShield1_solid_3">

--- a/macros/gui.mac
+++ b/macros/gui.mac
@@ -25,6 +25,7 @@
 /gui/addButton geom geometry/mollerMother.gdml               "/remoll/geometry/setfile geometry/mollerMother.gdml"
 /gui/addButton geom geometry/mollerMother_dump.gdml          "/remoll/geometry/setfile geometry/mollerMother_dump.gdml"
 /gui/addButton geom geometry/mollerMother_empty.gdml         "/remoll/geometry/setfile geometry/mollerMother_empty.gdml"
+/gui/addButton geom geometry/mollerMother_merged.gdml        "/remoll/geometry/setfile geometry/mollerMother_merged.gdml"
 /gui/addButton geom geometry/mollerMother_trackingOnly.gdml  "/remoll/geometry/setfile geometry/mollerMother_trackingOnly.gdml"
 /gui/addButton geom geometry/mollerMother_showerMaxOnly.gdml "/remoll/geometry/setfile geometry/mollerMother_showerMaxOnly.gdml"
 /gui/addButton geom geometry/pionDetectorLucite.gdml         "/remoll/geometry/setfile geometry/pionDetectorLucite.gdml"

--- a/src/remollGenBeam.cc
+++ b/src/remollGenBeam.cc
@@ -21,7 +21,7 @@
 
 remollGenBeam::remollGenBeam()
 : remollVEventGen("beam"),
-  fOriginMean(0.0*m,0.0*m,-6.7*m),
+  fOriginMean(0.0*m,0.0*m,-12.787*m),
   fOriginSpread(0.0,0.0,0.0),
   fOriginModelX(kOriginModelFlat),
   fOriginModelY(kOriginModelFlat),
@@ -30,7 +30,7 @@ remollGenBeam::remollGenBeam()
   fCorrelation(0.149*mrad/mm,0.149*mrad/mm,0.0),
   fPolarization(0.0,0.0,0.0),
   fRaster(5*mm,5*mm,0.0),
-  fRasterRefZ(0.5*m),
+  fRasterRefZ(-5.587*m),
   fParticleName("e-")
 {
     fSampType = kNoTargetVolume;

--- a/src/remollGenBeam.cc
+++ b/src/remollGenBeam.cc
@@ -21,7 +21,7 @@
 
 remollGenBeam::remollGenBeam()
 : remollVEventGen("beam"),
-  fOriginMean(0.0*m,0.0*m,-12.787*m),
+  fOriginMean(0.0*m,0.0*m,-11.787*m),
   fOriginSpread(0.0,0.0,0.0),
   fOriginModelX(kOriginModelFlat),
   fOriginModelY(kOriginModelFlat),
@@ -30,7 +30,7 @@ remollGenBeam::remollGenBeam()
   fCorrelation(0.149*mrad/mm,0.149*mrad/mm,0.0),
   fPolarization(0.0,0.0,0.0),
   fRaster(5*mm,5*mm,0.0),
-  fRasterRefZ(-5.587*m),
+  fRasterRefZ(-4.587*m),
   fParticleName("e-")
 {
     fSampType = kNoTargetVolume;


### PR DESCRIPTION
This merges in the updated geometry in https://github.com/JeffersonLab/remoll/projects/12.

1. target goes 1.5 m downstream and is shortened to 1.25 m
2. upstream and hybrid both moved 1 m downstream
3. detectors move 0.5 m upstream

Distance between center of target and detector plane is 26.5 m.

Raster size referenced to center of target. Effective raster magnet position downstream by 1m

There is a remaining (large) volume overlap in mollerMother_merged.gdml. See below:
![image (1)](https://user-images.githubusercontent.com/4656391/57309588-5988b100-70b6-11e9-86cb-854ab83bcf8e.png)
The rest seems ok.
