### PR TITLE
Feature: Use JLabCE environment 2.3 with multi-threading in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jeffersonlab/jlabce:2.3
+FROM jeffersonlab/jlabce:2.3-mt
 
 # Install libgcj and pdftk
 RUN wget https://copr.fedorainfracloud.org/coprs/robert/gcj/repo/epel-7/robert-gcj-epel-7.repo -P /etc/yum.repos.d && \


### PR DESCRIPTION
The docker container now inherits from jlabce:2.3-mt at https://hub.docker.com/r/jeffersonlab/jlabce/tags for running on HPC clusters.