### PR TITLE
Bugfix: Fix event generator to be in the target, not downstream (MAJOR)

### DIFF
--- a/src/remollBeamTarget.cc
+++ b/src/remollBeamTarget.cc
@@ -125,7 +125,7 @@ void remollBeamTarget::UpdateInfo()
     if (!fTargetMother) {
       return;
     }
-    fMotherTargetAbsolutePosition = fTargetMother->GetFrameTranslation().z();
+    fMotherTargetAbsolutePosition = fTargetMother->GetTranslation().z();
 
     for (std::vector<G4VPhysicalVolume *>::iterator
         it = fTargetVolumes.begin(); it != fTargetVolumes.end(); it++) {
@@ -154,7 +154,7 @@ void remollBeamTarget::UpdateInfo()
 	    fActiveTargetEffectiveLength = tubs->GetZHalfLength()*2.0
 		* material->GetDensity();
 
-	    fActiveTargetRelativePosition = (*it)->GetFrameTranslation().z();
+	    fActiveTargetRelativePosition = (*it)->GetTranslation().z();
 
 	    fTotalTargetEffectiveLength += tubs->GetZHalfLength()*2.0
 		* material->GetDensity();
@@ -245,7 +245,7 @@ remollVertex remollBeamTarget::SampleVertex(SampType_t samp)
         it = fTargetVolumes.begin(); it != fTargetVolumes.end() && !found_active_volume; it++ ){
 
         // Relative position of this target volume in mother volume
-        //G4double relative_position = (*it)->GetFrameTranslation().z();
+        G4double volume_relative_position = (*it)->GetTranslation().z();
 
         // Try to cast the target volume into its tubs solid
         G4LogicalVolume* volume = (*it)->GetLogicalVolume();
@@ -304,9 +304,10 @@ remollVertex remollBeamTarget::SampleVertex(SampType_t samp)
 	    // For our own info
 	    fTravelledLength = actual_position_in_volume;
 	    fRadiationLength = cumulative_radiation_length;
-	    fVer    = G4ThreeVector( rasx, rasy, 
-		      actual_position_in_volume - (*it)->GetFrameTranslation().z() + fMotherTargetAbsolutePosition
-		       - tubs->GetZHalfLength() );
+	    fVer    = G4ThreeVector( rasx, rasy,
+		      fMotherTargetAbsolutePosition
+                      + volume_relative_position - tubs->GetZHalfLength()
+                      + actual_position_in_volume );
 
 	    G4double masssum = 0.0;
 	    const G4int *atomvec = material->GetAtomsVector();


### PR DESCRIPTION
Due to a sign error, the events were generated around +4587 mm instead
of around -4587 mm. The call to GetFrameTranslation should have been a
call to GetTranslation, or various equivalent sign changes.

This was not a problem before since the target was centered at zero, and
so -0 is the same...