### PR TITLE
Bugfix: Messenger for field z offsets

### DIFF
--- a/include/remollGlobalField.hh
+++ b/include/remollGlobalField.hh
@@ -27,6 +27,7 @@ class remollGlobalField : public G4MagneticField {
 
         void AddNewField(G4String& name);
 
+        void SetZOffset(const G4String& name, G4double offset);
         void SetFieldScale(const G4String& name, G4double scale);
         void SetMagnetCurrent(const G4String& name, G4double current);
 

--- a/include/remollGlobalField.hh
+++ b/include/remollGlobalField.hh
@@ -27,11 +27,8 @@ class remollGlobalField : public G4MagneticField {
 
         void AddNewField(G4String& name);
 
-        void SetFieldScaleByString(G4String& name_scale);
         void SetFieldScale(const G4String& name, G4double scale);
-
-        void SetMagnetCurrentByString(G4String& name_scale);
-        void SetMagnetCurrent(const G4String& name, G4double scale);
+        void SetMagnetCurrent(const G4String& name, G4double current);
 
         void PrintFieldValue(const G4ThreeVector&);
 

--- a/macros/runexample.mac
+++ b/macros/runexample.mac
@@ -21,8 +21,8 @@
 /remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
 /remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
 
-#/remoll/scalefield map_directory/blockyHybrid_rm_3.0.txt 1.0
-#/remoll/magcurrent map_directory/blockyHybrid_rm_3.0.txt 1000.0 A
+#/remoll/field/scale map_directory/blockyHybrid_rm_3.0.txt 1.0
+#/remoll/field/current map_directory/blockyHybrid_rm_3.0.txt 1000.0
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/runexample.mac
+++ b/macros/runexample.mac
@@ -21,9 +21,6 @@
 /remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
 /remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
 
-/remoll/field/zoffset map_directory/blockyHybrid_rm_3.0.txt -5087.
-/remoll/field/zoffset map_directory/blockyUpstream_rm_1.1.txt -5087.
-
 #/remoll/field/scale map_directory/blockyHybrid_rm_3.0.txt 1.0
 #/remoll/field/current map_directory/blockyHybrid_rm_3.0.txt 1000.0
 

--- a/macros/runexample.mac
+++ b/macros/runexample.mac
@@ -21,6 +21,9 @@
 /remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
 /remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
 
+/remoll/field/zoffset map_directory/blockyHybrid_rm_3.0.txt -5087.
+/remoll/field/zoffset map_directory/blockyUpstream_rm_1.1.txt -5087.
+
 #/remoll/field/scale map_directory/blockyHybrid_rm_3.0.txt 1.0
 #/remoll/field/current map_directory/blockyHybrid_rm_3.0.txt 1000.0
 

--- a/src/remollGlobalField.cc
+++ b/src/remollGlobalField.cc
@@ -78,6 +78,7 @@ remollGlobalField::remollGlobalField()
     fGlobalFieldMessenger->DeclareProperty("deltachord",fDeltaChord,"Set delta chord for the chord finder");
     fGlobalFieldMessenger->DeclareProperty("deltaonestep",fDeltaOneStep,"Set delta one step for the field manager");
     fGlobalFieldMessenger->DeclareProperty("deltaintersection",fMinStep,"Set delta intersection for the field manager");
+    fGlobalFieldMessenger->DeclareMethod("zoffset",&remollGlobalField::SetZOffset,"Set magnetic field z offset");
     fGlobalFieldMessenger->DeclareMethod("scale",&remollGlobalField::SetFieldScale,"Scale magnetic field by factor");
     fGlobalFieldMessenger->DeclareMethod("current",&remollGlobalField::SetMagnetCurrent,"Scale magnetic field by current");
     fGlobalFieldMessenger->DeclareMethod("value",&remollGlobalField::PrintFieldValue,"Print the field value at a given point (in m)");
@@ -271,7 +272,16 @@ void remollGlobalField::GetFieldValue(const G4double p[], G4double *resB) const
     }
 }
 
+void remollGlobalField::SetZOffset(const G4String& name, G4double offset)
 {
+  remollMagneticField *field = GetFieldByName(name);
+  if (field) {
+    G4AutoLock lock(&remollGlobalFieldMutex);
+    field->SetZoffset(offset);
+  } else {
+    G4cerr << "WARNING " << __FILE__ << " line " << __LINE__
+           << ": field " << name << " offset failed" << G4endl;
+  }
 }
 
 void remollGlobalField::SetFieldScale(const G4String& name, G4double scale)

--- a/src/remollGlobalField.cc
+++ b/src/remollGlobalField.cc
@@ -66,8 +66,6 @@ remollGlobalField::remollGlobalField()
     // Create generic messenger
     fMessenger = new G4GenericMessenger(this,"/remoll/","Remoll properties");
     fMessenger->DeclareMethod("addfield",&remollGlobalField::AddNewField,"Add magnetic field");
-    fMessenger->DeclareMethod("scalefield",&remollGlobalField::SetFieldScaleByString,"Scale magnetic field");
-    fMessenger->DeclareMethod("magcurrent",&remollGlobalField::SetMagnetCurrentByString,"Scale magnetic field by current");
 
     // Create global field messenger
     fGlobalFieldMessenger = new G4GenericMessenger(this,"/remoll/field/","Remoll global field properties");
@@ -80,6 +78,8 @@ remollGlobalField::remollGlobalField()
     fGlobalFieldMessenger->DeclareProperty("deltachord",fDeltaChord,"Set delta chord for the chord finder");
     fGlobalFieldMessenger->DeclareProperty("deltaonestep",fDeltaOneStep,"Set delta one step for the field manager");
     fGlobalFieldMessenger->DeclareProperty("deltaintersection",fMinStep,"Set delta intersection for the field manager");
+    fGlobalFieldMessenger->DeclareMethod("scale",&remollGlobalField::SetFieldScale,"Scale magnetic field by factor");
+    fGlobalFieldMessenger->DeclareMethod("current",&remollGlobalField::SetMagnetCurrent,"Scale magnetic field by current");
     fGlobalFieldMessenger->DeclareMethod("value",&remollGlobalField::PrintFieldValue,"Print the field value at a given point (in m)");
 }
 
@@ -271,16 +271,7 @@ void remollGlobalField::GetFieldValue(const G4double p[], G4double *resB) const
     }
 }
 
-void remollGlobalField::SetFieldScaleByString(G4String& name_scale)
 {
-  std::istringstream iss(name_scale);
-
-  G4String name, scalestr;
-  iss >> name;
-  iss >> scalestr;
-
-  G4double scaleval = atof(scalestr);
-  SetFieldScale(name, scaleval);
 }
 
 void remollGlobalField::SetFieldScale(const G4String& name, G4double scale)
@@ -295,31 +286,12 @@ void remollGlobalField::SetFieldScale(const G4String& name, G4double scale)
   }
 }
 
-void remollGlobalField::SetMagnetCurrentByString(G4String& name_scale)
-{
-  std::istringstream iss(name_scale);
-
-  G4String name, scalestr, scaleunit;
-  iss >> name;
-  iss >> scalestr;
-  iss >> scaleunit;
-
-  if (scaleunit != "A") {
-    // FIXME: less snark and more functionality?
-    G4cerr << __FILE__ << " line " << __LINE__ <<  ":\n\tGraaaah - just put the current for " <<  name <<  " in amps..." << G4endl;
-    exit(1);
-  }
-
-  G4double scaleval = atof(scalestr);
-  SetMagnetCurrent(name, scaleval);
-}
-
-void remollGlobalField::SetMagnetCurrent(const G4String& name, G4double scale)
+void remollGlobalField::SetMagnetCurrent(const G4String& name, G4double current)
 {
   remollMagneticField *field = GetFieldByName(name);
   if (field) {
     G4AutoLock lock(&remollGlobalFieldMutex);
-    field->SetMagnetCurrent(scale);
+    field->SetMagnetCurrent(current);
   } else {
     G4cerr << "WARNING " << __FILE__ << " line " << __LINE__
            << ": field " << name << " scaling failed" << G4endl;

--- a/src/remollMagneticField.cc
+++ b/src/remollMagneticField.cc
@@ -38,7 +38,10 @@ remollMagneticField::remollMagneticField( G4String filename ){
 
     fPhi0 = -1e9;
 
-    fZoffset = 0.0;
+    // Default offset for field maps in reference frame with
+    // the hall pivot at z = 0.
+    fZoffset = -5087.0;
+
     fInit = false;
     fMagCurrent0 = -1e9;
 


### PR DESCRIPTION
Instead of changing the fieldmaps, filenames, md5 checksum etc, we're just going to shift the field in the macro for now. This introduces that functionality.