### PR TITLE
Enhancement: Don't add "..." after filename. Makes copy & paste easier.

### DIFF
--- a/src/remollIO.cc
+++ b/src/remollIO.cc
@@ -138,7 +138,7 @@ void remollIO::WriteTree()
         exit(1);
     }
 
-    G4cout << "Writing output to " << fFile->GetName() << "... ";
+    G4cout << "Writing output to " << fFile->GetName() << " ... ";
 
     fFile->cd();
 
@@ -154,7 +154,7 @@ void remollIO::WriteTree()
     delete fFile;
     fFile = NULL;
 
-    G4cout << "written" << G4endl;
+    G4cout << "done" << G4endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Instead of ending with
```
Writing output to remollout.root... written
```
we'll now get
```
Writing output to remollout.root ... done
```
which makes it easier to just double-click the filename.