### PR TITLE
Feature: Save full random state to ROOT file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
 images
 
+# random seed files
+G4Master_run*.rndm
+G4Worker?_run*.rndm
+G4Worker?_run*evt*.rndm
+run*evt*.rndm
+currentEvent.rndm
+currentRun.rndm
+
 # output from createHTML
 _remoll_*.html
 

--- a/include/remollEventAction.hh
+++ b/include/remollEventAction.hh
@@ -35,9 +35,6 @@ class remollEventAction : public G4UserEventAction
       fPrimaryGeneratorAction = action;
     }
 
-  private:
-    // Random seed at begin of event
-    G4String fEventSeed;
 };
 
 #endif

--- a/include/remollIO.hh
+++ b/include/remollIO.hh
@@ -48,7 +48,7 @@ class remollSeed_t: public TObject {
     TString fSeed; //< random engine state, a.k.a. seed (but not really)
   public:
     // Default constructor
-    remollSeed_t(): TObject() { };
+    remollSeed_t(): TObject() { fRunNo = 0; fEvtNo = 0; fSeed = ""; };
     // Copy constructor (not implemented)
     remollSeed_t(const remollSeed_t& orig);
     // Virtual destructor

--- a/include/remollIO.hh
+++ b/include/remollIO.hh
@@ -14,6 +14,7 @@
 #include "G4String.hh"
 
 #include <vector>
+#include <fstream>
 
 class TFile;
 class TTree;
@@ -38,6 +39,35 @@ class DOMElement;
 XERCES_CPP_NAMESPACE_END
 
 #define __FILENAMELEN 255
+
+// Helper class to save seed and provide Save functionality
+class remollSeed_t: public TObject {
+  private:
+    Int_t fRunNo; //< run number
+    Int_t fEvtNo; //< evt number
+    TString fSeed; //< random engine state, a.k.a. seed (but not really)
+  public:
+    // Default constructor
+    remollSeed_t(): TObject() { };
+    // Copy constructor (not implemented)
+    remollSeed_t(const remollSeed_t& orig);
+    // Virtual destructor
+    virtual ~remollSeed_t() { };
+    // Setter for run, evt, seed
+    void SetSeed(const Int_t& run, const Int_t& evt, const TString& seed)
+    { fRunNo = run; fEvtNo = evt; fSeed = seed; };
+    // Assignment operator (not implemented)
+    remollSeed_t& operator=(const remollSeed_t& orig);
+    // Save function for use in ROOT tree
+    int Save() const {
+      std::stringstream name;
+      name << "run" << fRunNo << "evt" << fEvtNo << ".rndm";
+      std::ofstream file(name.str());
+      file << fSeed;
+      return fSeed.Length();
+    };
+  ClassDef(remollSeed_t,1);
+};
 
 class remollIO {
     private:

--- a/include/remollIO.hh
+++ b/include/remollIO.hh
@@ -104,8 +104,8 @@ class remollIO {
         G4String fDetSDNames;
 
 	// Event data
-	Double_t fEvRate;
 	TString fEvSeed;
+	Double_t fRate;
 	remollEvent_t fEv;
 	remollBeamTarget_t fBm;
 

--- a/include/remollIO.hh
+++ b/include/remollIO.hh
@@ -121,7 +121,10 @@ class remollIO {
 
 	// Event data
     public:
-	void SetEventSeed(const G4String& seed);
+	void SetEventSeed(const Int_t& run, const Int_t& evt, const G4String& seed) {
+          fSeed.SetSeed(run, evt, seed);
+        }
+
 	void SetEventData(const remollEvent *);
     private:
 
@@ -134,8 +137,8 @@ class remollIO {
         G4String fDetSDNames;
 
 	// Event data
-	TString fEvSeed;
 	Double_t fRate;
+	remollSeed_t fSeed;
 	remollEvent_t fEv;
 	remollBeamTarget_t fBm;
 

--- a/include/remollLinkDef.hh
+++ b/include/remollLinkDef.hh
@@ -10,6 +10,7 @@
 
 #pragma link C++ struct remollUnits_t+;
 
+#pragma link C++ struct remollSeed_t+;
 #pragma link C++ struct remollEvent_t+;
 #pragma link C++ struct remollBeamTarget_t+;
 #pragma link C++ struct remollEventParticle_t+;

--- a/src/remollEventAction.cc
+++ b/src/remollEventAction.cc
@@ -7,6 +7,8 @@
 #include "G4HCofThisEvent.hh"
 #include "G4VHitsCollection.hh"
 
+#include "G4RunManager.hh"
+
 #include "remollIO.hh"
 #include "remollEvent.hh"
 #include "remollTrackReconstruct.hh"
@@ -16,7 +18,7 @@
 namespace { G4Mutex remollEventActionMutex = G4MUTEX_INITIALIZER; }
 
 remollEventAction::remollEventAction()
-  : fPrimaryGeneratorAction(0),fEventSeed("") { }
+  : fPrimaryGeneratorAction(0) { }
 
 remollEventAction::~remollEventAction() { }
 
@@ -33,8 +35,12 @@ void remollEventAction::EndOfEventAction(const G4Event* aEvent)
   remollIO* io = remollIO::GetInstance();
 
   // Store random seed
-  //fEventSeed = aEvent->GetRandomNumberStatus();
-  io->SetEventSeed(fEventSeed);
+  static G4RunManager* run_manager = G4RunManager::GetRunManager();
+  if (run_manager->GetFlagRandomNumberStatusToG4Event() % 2 == 1) {
+    Int_t run = run_manager->GetCurrentRun()->GetRunID();
+    Int_t evt = aEvent->GetEventID();
+    io->SetEventSeed(run, evt, aEvent->GetRandomNumberStatus());
+  }
 
   // Get primary event action information
   const remollEvent* event = fPrimaryGeneratorAction->GetEvent();

--- a/src/remollIO.cc
+++ b/src/remollIO.cc
@@ -88,7 +88,7 @@ void remollIO::InitializeTree()
     fTree->Branch("dets.lv",  &fDetNos, fDetLVNames);
 
     // Event information
-    fTree->Branch("rate",     &fEvRate,   "rate/D");
+    fTree->Branch("rate",     &fRate,   "rate/D");
     fTree->Branch("ev",       &fEv);
     fTree->Branch("bm",       &fBm);
     fTree->Branch("part",     &fEvPart);
@@ -173,7 +173,7 @@ void remollIO::SetEventData(const remollEvent *ev)
 {
   if (! ev) return;
 
-  fEvRate   = ev->fRate*s;
+  fRate   = ev->fRate*s;
 
   // Event variables
   fEv     = ev->GetEventIO();

--- a/src/remollIO.cc
+++ b/src/remollIO.cc
@@ -27,6 +27,8 @@
 #include <xercesc/dom/DOMNodeList.hpp>
 #include <xercesc/dom/DOMNode.hpp>
 
+ClassImp(remollSeed_t)
+
 // Singleton
 remollIO* remollIO::gInstance = 0;
 remollIO* remollIO::GetInstance() {

--- a/src/remollIO.cc
+++ b/src/remollIO.cc
@@ -90,6 +90,7 @@ void remollIO::InitializeTree()
     fTree->Branch("dets.lv",  &fDetNos, fDetLVNames);
 
     // Event information
+    fTree->Branch("seed",     &fSeed);
     fTree->Branch("rate",     &fRate,   "rate/D");
     fTree->Branch("ev",       &fEv);
     fTree->Branch("bm",       &fBm);
@@ -161,13 +162,6 @@ void remollIO::WriteTree()
 
 ///////////////////////////////////////////////////////////////////////////////
 // Interfaces to output section ///////////////////////////////////////////////
-
-// Event seed
-void remollIO::SetEventSeed(const G4String& seed)
-{
-  fEvSeed = seed;
-}
-
 
 // Event Data
 


### PR DESCRIPTION
Sometimes you want to inspect (or be able to repeat) specific events that you find in a ROOT file. This branch enables (optional) saving of the full random engine state for each event.

By telling geant4 to store the random state for each event with `/run/storeRndmStatToEvent 1` it will automatically be stored to the tree as the variable `seed`. With reroot or (ld pre-)loading libremoll.so you can then use things like:
```
T->Draw("seed.Save()","ev.A>-10")
```
which will save the random state for every event that has an asymmetry with magnitude less than 10 ppb to a file run[runno]evt[evtno].rndm. Arbitrary selection possible.

The files can be turned into input for /random/resetEngineFrom <filename>. See below for comments on file format.

### Seed != state
The seed determines the random state uniquely but is in a significantly smaller space than the random state itself. Not every random state can be associate with a seed.

### File formats
The ROOT tree Save() command produce the following file 
```
MixMaxRng-begin 97588365
1906709568702062078
1140743473972090589
1823734812527682176
692017379249797100
1447898696895639102
636884972592620537
2152014336500572859
1570012997546763742
1959162295989761165
84311882159462073
355167662739815000
1006438779200467577
834618078282138689
2207380892026575602
1613299806778549612
205787593014985317
1060740182943464238
1
2250179337412895848
MixMaxRng-end
```
but the input for /random/resetEngineFrom requires the following format:
```
mixmax state, file version 1.0
N=17; V[N]={1906709568702062078, 1140743473972090589, 1823734812527682176, 692017379249797100, 1447898696895639102, 636884972592620537, 2152014336500572859, 1570012997546763742, 1959162295989761165, 84311882159462073, 355167662739815000, 1006438779200467577, 834618078282138689, 2207380892026575602, 1613299806778549612, 205787593014985317, 1060740182943464238}; counter=1; sumtot=2250179337412895848;
```
Some massaging is necessary...

You can get the correspondence by comparing the output of running with
```
/random/setSavingFlag 1
/random/saveEachEventFlag 1
```
(which will create random state file for every event, clutter your directory, and slow down disk access) with the format stored with the Save() command.

### Impact on running and file size
Below the benchmarks on runexample.mac with 1000 events with and without saving random state. First with saving state to the output file:
```
/run/storeRndmStatToEvent 1
running time 51.7981 s
output size 10802014 b
```
versus default option of not storing to file:
```
/run/storeRndmStatToEvent 0
running time 52.4119 s
output size 10588667 b
```