### PR TITLE
Add local momentum to output

### DIFF
--- a/include/remollGenericDetectorHit.hh
+++ b/include/remollGenericDetectorHit.hh
@@ -30,9 +30,13 @@ class remollGenericDetectorHit : public G4VHit {
 
 	// Position and momentum in lab coordinates
 	G4ThreeVector f3X;
-	G4ThreeVector f3Xl;
 	G4ThreeVector f3P;
 	G4ThreeVector f3S;
+
+	// Position and momentum in local volume coordinate system
+	G4ThreeVector f3Pl; 
+	G4ThreeVector f3Xl;
+
         // Global time
         G4double fTime;
         // direction
@@ -75,6 +79,9 @@ class remollGenericDetectorHit : public G4VHit {
         hit.px  = f3P.x();
         hit.py  = f3P.y();
         hit.pz  = f3P.z();
+        hit.pxl  = f3Pl.x();
+        hit.pyl  = f3Pl.y();
+        hit.pzl  = f3Pl.z();
         hit.sx  = f3S.x();
         hit.sy  = f3S.y();
         hit.sz  = f3S.z();

--- a/src/remollGenericDetector.cc
+++ b/src/remollGenericDetector.cc
@@ -282,9 +282,13 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
     G4ThreeVector local_position = point->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(global_position);
     hit->f3X  = global_position;
     hit->f3Xl = local_position;
-
     hit->f3V  = track->GetVertexPosition();
-    hit->f3P  = track->GetMomentum();
+    
+    G4ThreeVector global_momentum = track->GetMomentum();
+    //just do the rotation without the translation
+    hit->f3Pl = point->GetTouchable()->GetHistory()->GetTopTransform().TransformAxis(global_momentum);
+    hit->f3P  = global_momentum;
+
     hit->f3S  = track->GetPolarization();
 
     hit->fTime = point->GetGlobalTime();

--- a/src/remollGenericDetectorHit.cc
+++ b/src/remollGenericDetectorHit.cc
@@ -7,11 +7,12 @@ G4ThreadLocal G4Allocator<remollGenericDetectorHit>* remollGenericDetectorHitAll
 remollGenericDetectorHit::remollGenericDetectorHit(G4int det, G4int copy)
 : fDetID(det),fCopyID(copy)
 {
-  f3X = G4ThreeVector(-1e9, -1e9, -1e9);
+  f3X  = G4ThreeVector(-1e9, -1e9, -1e9);
   f3Xl = G4ThreeVector(-1e9, -1e9, -1e9);
-  f3P = G4ThreeVector(-1e9, -1e9, -1e9);
-  f3S = G4ThreeVector(-1e9, -1e9, -1e9);
-  f3V = G4ThreeVector(-1e9, -1e9, -1e9);
+  f3P  = G4ThreeVector(-1e9, -1e9, -1e9);
+  f3Pl = G4ThreeVector(-1e9, -1e9, -1e9);
+  f3S  = G4ThreeVector(-1e9, -1e9, -1e9);
+  f3V  = G4ThreeVector(-1e9, -1e9, -1e9);
 
   fTime = 0.0;
 
@@ -45,6 +46,7 @@ remollGenericDetectorHit::remollGenericDetectorHit(const remollGenericDetectorHi
   f3X     = right.f3X;
   f3Xl    = right.f3Xl;
   f3P     = right.f3P;
+  f3Pl    = right.f3Pl;
   f3S     = right.f3S;
   f3V     = right.f3V;
 


### PR DESCRIPTION
I think this commit adds output that will allow one to calculate the angle between the momentum and the volume where the hit occurs. The momentum vector is not translated but only rotated. 
