### PR TITLE
Feature: /remoll/kryptonite/volume <logical_volume_name>

### DIFF
--- a/include/remollDetectorConstruction.hh
+++ b/include/remollDetectorConstruction.hh
@@ -94,6 +94,7 @@ class remollDetectorConstruction : public G4VUserDetectorConstruction
     void DisableKryptonite();
     void AddKryptoniteCandidate(G4String name);
     void ListKryptoniteCandidates();
+    void EnableKryptoniteVolume(G4String name);
 
   private:
 

--- a/src/remollDetectorConstruction.cc
+++ b/src/remollDetectorConstruction.cc
@@ -196,6 +196,10 @@ remollDetectorConstruction::remollDetectorConstruction(const G4String& name, con
       "list",
       &remollDetectorConstruction::ListKryptoniteCandidates,
       "List kryptonite candidate materials");
+  fKryptoniteMessenger->DeclareMethod(
+      "volume",
+      &remollDetectorConstruction::EnableKryptoniteVolume,
+      "Treat volume as kryptonite");
 }
 
 void remollDetectorConstruction::EnableKryptonite()
@@ -216,6 +220,16 @@ void remollDetectorConstruction::DisableKryptonite()
   fKryptoniteEnable = false;
 
   SetKryptoniteUserLimits(fWorldVolume);
+}
+
+void remollDetectorConstruction::EnableKryptoniteVolume(G4String name)
+{
+  if (fKryptoniteVerbose > 0)
+    G4cout << "Enabling kryptonite on volume" << name << "." << G4endl;
+
+  fKryptoniteEnable = true;
+
+  SetUserLimits("maxallowedstep",name,"0.0*mm");
 }
 
 void remollDetectorConstruction::AddKryptoniteCandidate(G4String name)

--- a/src/remollDetectorConstruction.cc
+++ b/src/remollDetectorConstruction.cc
@@ -227,9 +227,16 @@ void remollDetectorConstruction::EnableKryptoniteVolume(G4String name)
   if (fKryptoniteVerbose > 0)
     G4cout << "Enabling kryptonite on volume" << name << "." << G4endl;
 
+  // Find volume
+  G4LogicalVolume* logical_volume = G4LogicalVolumeStore::GetInstance()->GetVolume(name);
+  if (! logical_volume) {
+    G4cerr << __FILE__ << " line " << __LINE__ << ": Warning volume " << name << " unknown" << G4endl;
+    return;
+  }
+
   fKryptoniteEnable = true;
 
-  SetUserLimits("maxallowedstep",name,"0.0*mm");
+  logical_volume->SetUserLimits(fKryptoniteUserLimits);
 }
 
 void remollDetectorConstruction::AddKryptoniteCandidate(G4String name)


### PR DESCRIPTION
This sets the logical volume to kryptonite by name.

This avoids the need to do all the kryptonite by material type.