### PR TITLE
Feature: Ranged detector type cmd

### DIFF
--- a/include/remollGenericDetector.hh
+++ b/include/remollGenericDetector.hh
@@ -131,6 +131,15 @@ class remollGenericDetector : public G4VSensitiveDetector {
       return (left? (right? (left->fDetNo < right->fDetNo): false): true);
     }
 
+    void SetRangeDetectorType(G4String type, G4TwoVector v) {
+      for (std::list<remollGenericDetector*>::iterator
+        it  = fGenericDetectors.begin();
+        it != fGenericDetectors.end();
+        it++) {
+          if ((*it)->fDetNo >= v.x() && (*it)->fDetNo <= v.y())
+            (*it)->SetDetectorType(type);
+      }
+    }
     void SetOneDetectorType(G4String type, G4int det) {
       for (std::list<remollGenericDetector*>::iterator
         it  = fGenericDetectors.begin();

--- a/macros/tests/unit/test_det_enable.mac
+++ b/macros/tests/unit/test_det_enable.mac
@@ -36,4 +36,5 @@
 /remoll/SD/detect lowenergyneutral 4000
 /remoll/SD/detect opticalphoton 4001
 /remoll/SD/detect all 4002
+/remoll/SD/detect_range all 4002 5000
 /remoll/SD/print_all

--- a/src/remollGenericDetector.cc
+++ b/src/remollGenericDetector.cc
@@ -101,6 +101,10 @@ void remollGenericDetector::BuildStaticMessenger()
     "detect",
     &remollGenericDetector::SetOneDetectorType,
     "Set detector type");
+  fStaticMessenger->DeclareMethod(
+    "detect_range",
+    &remollGenericDetector::SetRangeDetectorType,
+    "Set detector type");
 }
 
 void remollGenericDetector::Initialize(G4HCofThisEvent*)


### PR DESCRIPTION
`/remoll/SD/detect_range <type> <range_begin> <range_end>`

This sets the detector type for all detectors within a range.

Example in test macro macros/tests/unit/test_det_enable.mac