### PR TITLE
Bugfix: Activate the aux tag TargetSamplingVolume for Al US and DS windows

### DIFF
--- a/geometry/target/subTargetRegion.gdml
+++ b/geometry/target/subTargetRegion.gdml
@@ -192,14 +192,14 @@
   <volume name="USAlTarg">
     <materialref ref="Aluminum"/>
     <solidref ref="AlWindow"/>
-    <!-- <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/> -->
+    <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     <auxiliary auxtype="Color" auxvalue="white"/>
   </volume>
 
   <volume name="DSAlTarg">
     <materialref ref="Aluminum"/>
     <solidref ref="AlWindow"/>
-    <!-- <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/> -->
+    <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     <auxiliary auxtype="Color" auxvalue="white"/>
   </volume>
 

--- a/geometry/target/targetDaughter_Clamshell_Optimized.gdml
+++ b/geometry/target/targetDaughter_Clamshell_Optimized.gdml
@@ -379,13 +379,13 @@
    <volume name="USAlTarg">
      <materialref ref="Aluminum"/>
      <solidref ref="AlWindow"/>
-     <!-- <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/> -->
+     <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
    </volume>
 
    <volume name="DSAlTarg">
      <materialref ref="Aluminum"/>
      <solidref ref="AlWindow"/>
-     <!-- <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/> -->
+     <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
    </volume>
 
    <volume name="TargShield_topdisk_logic">

--- a/geometry/target/targetDaughter_acceptanceDefinition.gdml
+++ b/geometry/target/targetDaughter_acceptanceDefinition.gdml
@@ -379,13 +379,13 @@
    <volume name="USAlTarg">
      <materialref ref="Aluminum"/>
      <solidref ref="AlWindow"/>
-     <!-- <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/> -->
+     <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
    </volume>
 
    <volume name="DSAlTarg">
      <materialref ref="Aluminum"/>
      <solidref ref="AlWindow"/>
-     <!-- <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/> -->
+     <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
    </volume>
 
    <volume name="TargShield_topdisk_logic">


### PR DESCRIPTION
The auxiliary tag TargetSamplingVolume indicates that that volume
can be *selected* as a primary vertex sampling volume, not that it
will be used as a sampling volume. You still have to select the
actual volume used with e.g. `/remoll/targname USAlTarg`. If you
pick a logical volume that does not have the TargetSamplingVolume
auxiliary tag in `targname` that will fail. Somehow the tag had
gotten removed in some target geometry, preventing them from being
used with the aluminum generator without gdml edits.

Here are the only steps that should be necessary for an aluminum
simulation (see `macros/tests/commit/test_elasticAl_DS.mac`):
```
/remoll/evgen/set elasticAl
/remoll/targname DSAlTarg
```
though you may want to tighten the generated angles for efficiency
as well.