### PR TITLE
Bugfix: Remove the explicit GeV^-2 units in A_PV(Al) generator

### DIFF
--- a/src/remollGenAl.cc
+++ b/src/remollGenAl.cc
@@ -207,7 +207,7 @@ void remollGenAl::GenQuasiElastic(G4double beamE,G4double theta,
   effectiveXsection = xsect;
 
   ///~~~ Aymmetry calculation
-  asym= -GF/(4.*pi*fine_structure_const*sqrt(2.)) * Q2/GeV/GeV * (QWp);
+  asym= -GF/(4.*pi*fine_structure_const*sqrt(2.)) * Q2 * (QWp);
 }
 
 void remollGenAl::GenElastic(G4double beamE,G4double theta,
@@ -252,5 +252,5 @@ void remollGenAl::GenElastic(G4double beamE,G4double theta,
   fWeight = effectiveXsection*sin(theta);  
   
   ///~~~ Aymmetry calculation
-  asym= -GF/(4.*pi*fine_structure_const*sqrt(2.)) * Q2/GeV/GeV * (QWp + QWn*(A-Z)/Z);
+  asym= -GF/(4.*pi*fine_structure_const*sqrt(2.)) * Q2 * (QWp + QWn*(A-Z)/Z);
 }


### PR DESCRIPTION
When we moved to a single G_F definition (in units GeV^-2) instead
of a magical number without units, I forgot to remove the GeV^-2
from the asymmetry formula.

Double checked that this is not affecting any other places where
G_F is used.

@cipriangal Please test to see if this fixes the issue discussed
in the comments of 0c3fe73beefd38d04239a09ac33f5d911427173c