### PR TITLE
Bugfix: CMake project requires C support when geant4 has HDF5 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Setup the project
 #
 cmake_minimum_required(VERSION 3.5)
-project(remoll VERSION 0.1 LANGUAGES CXX)
+project(remoll VERSION 0.1 LANGUAGES CXX C)
 
 # Disallow in-source builds
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
When geant4 is compiled with HDF5 support, the cmake test fails to
compile if the remoll project only includes CXX language. With also
C language included, the test succeeds.

This includes commits in #306, so that PR must be merged before this PR.