### PR TITLE
Bugfix: use G4_lH2 instead of LiquidHydrogen

### DIFF
--- a/geometry/target/subTargetRegion.gdml
+++ b/geometry/target/subTargetRegion.gdml
@@ -183,7 +183,7 @@
 <structure>
 
   <volume name="h2Targ">
-    <materialref ref="LiquidHydrogen"/>
+    <materialref ref="G4_lH2"/>
     <solidref ref="target_solid"/>
     <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     <auxiliary auxtype="Color" auxvalue="blue"/>

--- a/geometry/target/subTargetRegion.gdml
+++ b/geometry/target/subTargetRegion.gdml
@@ -190,14 +190,14 @@
   </volume>
 
   <volume name="USAlTarg">
-    <materialref ref="Aluminum"/>
+    <materialref ref="G4_Al"/>
     <solidref ref="AlWindow"/>
     <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     <auxiliary auxtype="Color" auxvalue="white"/>
   </volume>
 
   <volume name="DSAlTarg">
-    <materialref ref="Aluminum"/>
+    <materialref ref="G4_Al"/>
     <solidref ref="AlWindow"/>
     <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     <auxiliary auxtype="Color" auxvalue="white"/>

--- a/geometry/target/targetDaughter.gdml
+++ b/geometry/target/targetDaughter.gdml
@@ -33,13 +33,13 @@
     </volume>
  
     <volume name="USAlTarg">
-      <materialref ref="Aluminum"/>
+      <materialref ref="G4_Al"/>
       <solidref ref="AlWindow"/>
       <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     </volume>
 
     <volume name="DSAlTarg">
-      <materialref ref="Aluminum"/>
+      <materialref ref="G4_Al"/>
       <solidref ref="AlWindow"/>
       <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     </volume>

--- a/geometry/target/targetDaughter.gdml
+++ b/geometry/target/targetDaughter.gdml
@@ -1,31 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE gdml [
+<!ENTITY matrices SYSTEM "../matrices.xml">
+<!ENTITY materials SYSTEM "../materials.xml">
+]>
+
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
 
 <define>
+  &matrices;
+
   <constant name="targetCenterZ" value="0"/>
   <constant name="tubeTarget_rmax" value="40"/>
   <constant name="tubeTarget_length" value="1250"/>
   <constant name="AlWindowTarget_length" value="0.127"/>
 </define>
 
-  <materials>
-    <material Z="1" name="VacuumTarg" state="gas">
-      <T unit="K" value="2.73"/>
-      <P unit="pascal" value="3e-18"/>
-      <D unit="g/cm3" value="1e-25"/>
-      <atom unit="g/mole" value="1.01"/>
-    </material>
-    <material Z="1" name="LiquidHydrogen" state="liquid">
-      <T unit="K" value="20.27"/>
-      <D unit="g/cm3" value="0.0708"/>
-      <atom unit="g/mole" value="1.00794"/>
-    </material>
-    <material Z="13" name="Aluminum" state="solid">
-      <T unit="K" value="20.27"/>
-      <D unit="g/cm3" value="2.7"/>
-      <atom unit="g/mole" value="26.98"/>
-    </material>
-  </materials>
+&materials;
 
 <solids>
     <tube aunit="deg" deltaphi="360" lunit="mm" name="tubeTargetMother" rmax="1000" rmin="0" startphi="0" z="2400"/>
@@ -36,7 +27,7 @@
 <structure>
 
     <volume name="h2Targ">
-      <materialref ref="LiquidHydrogen"/>
+      <materialref ref="G4_lH2"/>
       <solidref ref="tubeTarget"/>
       <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     </volume>

--- a/geometry/target/targetDaughter_Clamshell_Optimized.gdml
+++ b/geometry/target/targetDaughter_Clamshell_Optimized.gdml
@@ -371,7 +371,7 @@
  <structure>
 
    <volume name="h2Targ">
-     <materialref ref="LiquidHydrogen"/>
+     <materialref ref="G4_lH2"/>
      <solidref ref="tubeTarget"/>
      <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
    </volume>

--- a/geometry/target/targetDaughter_Clamshell_Optimized.gdml
+++ b/geometry/target/targetDaughter_Clamshell_Optimized.gdml
@@ -377,13 +377,13 @@
    </volume>
 
    <volume name="USAlTarg">
-     <materialref ref="Aluminum"/>
+     <materialref ref="G4_Al"/>
      <solidref ref="AlWindow"/>
      <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
    </volume>
 
    <volume name="DSAlTarg">
-     <materialref ref="Aluminum"/>
+     <materialref ref="G4_Al"/>
      <solidref ref="AlWindow"/>
      <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
    </volume>

--- a/geometry/target/targetDaughter_acceptanceDefinition.gdml
+++ b/geometry/target/targetDaughter_acceptanceDefinition.gdml
@@ -371,7 +371,7 @@
  <structure>
 
    <volume name="h2Targ">
-     <materialref ref="LiquidHydrogen"/>
+     <materialref ref="G4_lH2"/>
      <solidref ref="tubeTarget"/>
      <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
    </volume>

--- a/geometry/target/targetDaughter_acceptanceDefinition.gdml
+++ b/geometry/target/targetDaughter_acceptanceDefinition.gdml
@@ -377,13 +377,13 @@
    </volume>
 
    <volume name="USAlTarg">
-     <materialref ref="Aluminum"/>
+     <materialref ref="G4_Al"/>
      <solidref ref="AlWindow"/>
      <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
    </volume>
 
    <volume name="DSAlTarg">
-     <materialref ref="Aluminum"/>
+     <materialref ref="G4_Al"/>
      <solidref ref="AlWindow"/>
      <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
    </volume>

--- a/geometry/target/targetDaughter_merged.gdml
+++ b/geometry/target/targetDaughter_merged.gdml
@@ -224,13 +224,13 @@
     </volume>
 
     <volume name="USAlTarg">
-      <materialref ref="Aluminum"/>
+      <materialref ref="G4_Al"/>
       <solidref ref="AlWindow"/>
       <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     </volume>
 
     <volume name="DSAlTarg">
-      <materialref ref="Aluminum"/>
+      <materialref ref="G4_Al"/>
       <solidref ref="AlWindow"/>
       <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     </volume>

--- a/geometry/target/targetDaughter_merged.gdml
+++ b/geometry/target/targetDaughter_merged.gdml
@@ -218,7 +218,7 @@
 <structure>
 
     <volume name="h2Targ">
-      <materialref ref="LiquidHydrogen"/>
+      <materialref ref="G4_lH2"/>
       <solidref ref="tubeTarget"/>
       <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     </volume>

--- a/geometry/target/targetDaughter_noShlds.gdml
+++ b/geometry/target/targetDaughter_noShlds.gdml
@@ -224,13 +224,13 @@
     </volume>
 
     <volume name="USAlTarg">
-      <materialref ref="Aluminum"/>
+      <materialref ref="G4_Al"/>
       <solidref ref="AlWindow"/>
       <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     </volume>
 
     <volume name="DSAlTarg">
-      <materialref ref="Aluminum"/>
+      <materialref ref="G4_Al"/>
       <solidref ref="AlWindow"/>
       <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     </volume>

--- a/geometry/target/targetDaughter_noShlds.gdml
+++ b/geometry/target/targetDaughter_noShlds.gdml
@@ -218,7 +218,7 @@
 <structure>
 
     <volume name="h2Targ">
-      <materialref ref="LiquidHydrogen"/>
+      <materialref ref="G4_lH2"/>
       <solidref ref="tubeTarget"/>
       <auxiliary auxtype="TargetSamplingVolume" auxvalue=""/>
     </volume>

--- a/src/remollBeamTarget.cc
+++ b/src/remollBeamTarget.cc
@@ -315,14 +315,10 @@ remollVertex remollBeamTarget::SampleVertex(SampType_t samp)
 	    const G4double *fracvec = material->GetFractionVector();
 
 	    for( unsigned int i = 0; i < elvec->size(); i++ ){
-		// FIXME:  Not sure why AtomsVector would ever return null
-		// but it does - SPR 2/5/13.  Just going to assume unit
-		// weighting for now if that is the case
-		if( atomvec ){
-		    masssum += (*elvec)[i]->GetA()*atomvec[i];
-		} else {
-		    masssum += (*elvec)[i]->GetA();
-		}
+		// Not sure why AtomsVector would ever return null
+		// but it does - SPR 2/5/13.
+		assert( atomvec );
+		masssum += (*elvec)[i]->GetA()*atomvec[i];
 		msthick[nmsmat] = material->GetDensity()*actual_position_in_volume*fracvec[i];
 		msA[nmsmat] = (*elvec)[i]->GetA()*mole/g;
 		msZ[nmsmat] = (*elvec)[i]->GetZ();

--- a/src/remollBeamTarget.cc
+++ b/src/remollBeamTarget.cc
@@ -363,7 +363,7 @@ remollVertex remollBeamTarget::SampleVertex(SampType_t samp)
     }
     assert( !std::isnan(msth) && !std::isnan(msph) );
     assert( !std::isinf(msth) && !std::isinf(msph) );
-    assert( msth==-1e9 && msph==-1e9 );
+    assert( msth!=-1e9 && msph!=-1e9 );
 
     // Sample raster angles
     G4double bmth = 0, bmph = 0;

--- a/src/remollBeamTarget.cc
+++ b/src/remollBeamTarget.cc
@@ -362,7 +362,8 @@ remollVertex remollBeamTarget::SampleVertex(SampType_t samp)
 	msph = fMS->GenerateMSPlane();
     }
     assert( !std::isnan(msth) && !std::isnan(msph) );
-
+    assert( !std::isinf(msth) && !std::isinf(msph) );
+    assert( msth==-1e9 && msph==-1e9 );
 
     // Sample raster angles
     G4double bmth = 0, bmph = 0;

--- a/src/remollGenpElastic.cc
+++ b/src/remollGenpElastic.cc
@@ -45,10 +45,10 @@ void remollGenpElastic::SamplePhysics(remollVertex *vert, remollEvent *evt){
 
     std::vector<G4VPhysicalVolume *>::iterator it = targVols.begin();
     if( targVols.size() > 0 ){
-	while( (*it)->GetLogicalVolume()->GetMaterial()->GetName() != "LiquidHydrogen" 
+	while( (*it)->GetLogicalVolume()->GetMaterial()->GetName() != "G4_lH2" 
 		&& it != targVols.end() ){ it++; }
 
-	if( (*it)->GetLogicalVolume()->GetMaterial()->GetName() != "LiquidHydrogen" ){
+	if( (*it)->GetLogicalVolume()->GetMaterial()->GetName() != "G4_lH2" ){
 	    G4cerr << __FILE__ << " line " << __LINE__ << ": WARNING could not find target" << G4endl;
 	    bypass_target = true;
 	}


### PR DESCRIPTION
Addresses #322, it was the custom definition of LiquidHydrogen that failed the FIXME. With this fix, only properly formed materials are used in the target (for hydrogen and aluminum, still using an explicit 12C isotope).

Additional benefit, this now defines the proper ionisation energy of hydrogen in the target.