### PR TITLE
Bugfix: Reduce build output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,22 +311,22 @@ file(DOWNLOAD
      ${REMOLL_DOWNLOADS}/hybridJLAB.txt
      ${REMOLL_MAP_DIR}/hybridJLAB.txt
      EXPECTED_MD5 c2da18fd7ab80cc4abe7eafc487963dc
-     SHOW_PROGRESS)
+     )
 file(DOWNLOAD
      ${REMOLL_DOWNLOADS}/upstreamJLAB_1.25.txt
      ${REMOLL_MAP_DIR}/upstreamJLAB_1.25.txt
      EXPECTED_MD5 af06ed35516c17640e89ba3aa0f5b200
-     SHOW_PROGRESS)
+     )
 file(DOWNLOAD
      ${REMOLL_DOWNLOADS}/blockyUpstream_rm_1.1.txt
      ${REMOLL_MAP_DIR}/blockyUpstream_rm_1.1.txt
      EXPECTED_MD5 3e2338e1ba74b03da37545e98931f5f3
-     SHOW_PROGRESS)
+     )
 file(DOWNLOAD
      ${REMOLL_DOWNLOADS}/blockyHybrid_rm_3.0.txt
      ${REMOLL_MAP_DIR}/blockyHybrid_rm_3.0.txt
      EXPECTED_MD5 b4bfef8f362e0df66f166b4e76a6847e
-     SHOW_PROGRESS)
+     )
 install(FILES
      ${REMOLL_MAP_DIR}/hybridJLAB.txt
      ${REMOLL_MAP_DIR}/upstreamJLAB_1.25.txt
@@ -339,12 +339,12 @@ if(ADDITIONAL_FIELDS)
      ${REMOLL_DOWNLOADS}/upstreamSymmetric_sensR_0.1.txt
      ${REMOLL_MAP_DIR}/upstreamSymmetric_sensR_0.1.txt
      EXPECTED_MD5 849d9dc5abab0842fc13fef7f4918648
-     SHOW_PROGRESS)
+     )
   file(DOWNLOAD
      ${REMOLL_DOWNLOADS}/hybridSymmetric_sensR_0.1.txt
      ${REMOLL_MAP_DIR}/hybridSymmetric_sensR_0.1.txt
      EXPECTED_MD5 78fad2ffa5b5ae129df11bdf0ce25333
-     SHOW_PROGRESS)
+     )
   install(FILES
      ${REMOLL_MAP_DIR}/upstreamSymmetric_sensR_0.0.txt
      ${REMOLL_MAP_DIR}/hybridSymmetric_sensR_0.0.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM jeffersonlab/jlabce:2.3-mt
 
 # Install libgcj and pdftk
-RUN wget https://copr.fedorainfracloud.org/coprs/robert/gcj/repo/epel-7/robert-gcj-epel-7.repo -P /etc/yum.repos.d && \
-    wget https://copr.fedorainfracloud.org/coprs/robert/pdftk/repo/epel-7/robert-pdftk-epel-7.repo -P /etc/yum.repos.d && \
-    yum install -y pdftk ghostscript
+RUN wget -q https://copr.fedorainfracloud.org/coprs/robert/gcj/repo/epel-7/robert-gcj-epel-7.repo -P /etc/yum.repos.d && \
+    wget -q https://copr.fedorainfracloud.org/coprs/robert/pdftk/repo/epel-7/robert-pdftk-epel-7.repo -P /etc/yum.repos.d && \
+    yum install -q -y pdftk ghostscript
 
 ENV JLAB_VERSION=2.3
 ENV JLAB_ROOT=/jlab

--- a/src/remollBeamTarget.cc
+++ b/src/remollBeamTarget.cc
@@ -287,6 +287,9 @@ remollVertex remollBeamTarget::SampleVertex(SampType_t samp)
 		    cumulative_effective_length += effective_length;
 		}
 		break;
+            case kNoTargetVolume:
+                // nothing to do, just avoid compilation warning
+                break;
 	}
 
 	if( material->GetBaseMaterial() ){

--- a/src/remollGenTF1.cc
+++ b/src/remollGenTF1.cc
@@ -453,11 +453,9 @@ double remollGenTF1::elasticFit(double *x, double *par){
 }
 
 double remollGenTF1::inelasticFit(double *x, double *par){
-    double g;
-    double e;
-
     double arg = (fabs(par[2])>1e-6)? (x[0] - (par[1]))/par[2] : 0.0;
-    g = par[0]*exp(-0.5*arg*arg)/(par[2]*sqrt(2.0*TMath::Pi()));
+    double g = par[0]*exp(-0.5*arg*arg)/(par[2]*sqrt(2.0*TMath::Pi()));
+    double e = 0;
     if (x[0] > (par[1]))
         e = par[3]/TMath::Power(x[0],par[4]);/* + par[5];*/
     if (g > e){


### PR DESCRIPTION
When looking through travis build logs for errors there are about 1300 lines of build logs which should fit in 200 or so. This makes it more difficult to find the actual continuous integration output from unit test macros, and therefore more likely that errors are overlooked.