### PR TITLE
Bugfix: Reduce run output

### DIFF
--- a/include/remollGenericDetector.hh
+++ b/include/remollGenericDetector.hh
@@ -162,30 +162,45 @@ class remollGenericDetector : public G4VSensitiveDetector {
 
       virtual void SetDetectorType(G4String det_type) {
         if (det_type.compareTo("charged", G4String::ignoreCase) == 0) {
-          G4cout << GetName() << " detects charged particles" << G4endl;
           fDetectOpticalPhotons = false;
           fDetectLowEnergyNeutrals = false;
         }
         if (det_type.compareTo("all", G4String::ignoreCase) == 0) {
-          G4cout << GetName() << " detects all particles" << G4endl;
           fDetectSecondaries = true;
           fDetectLowEnergyNeutrals = true;
         }
         if (det_type.compareTo("lowenergyneutral", G4String::ignoreCase) == 0) {
-          G4cout << GetName() << " detects low energy neutrals" << G4endl;
           fDetectLowEnergyNeutrals = true;
         }
         if (det_type.compareTo("opticalphoton", G4String::ignoreCase) == 0) {
-          G4cout << GetName() << " detects optical photons" << G4endl;
           fDetectOpticalPhotons = true;
         }
         if (det_type.compareTo("boundaryhits", G4String::ignoreCase) == 0) {
-          G4cout << GetName() << " detects hits only on entry boundary" << G4endl;
           fDetectBoundaryHits = true;
         }
         if (det_type.compareTo("secondaries", G4String::ignoreCase) == 0) {
-          G4cout << GetName() << " detects secondaries" << G4endl;
           fDetectSecondaries = true;
+        }
+      }
+
+      virtual void PrintDetectorType() {
+        if (fDetectOpticalPhotons == false && fDetectLowEnergyNeutrals == false) {
+          G4cout << GetName() << " detects charged particles" << G4endl;
+        }
+        if (fDetectSecondaries == true && fDetectLowEnergyNeutrals == true) {
+          G4cout << GetName() << " detects all particles" << G4endl;
+        }
+        if (fDetectLowEnergyNeutrals == true) {
+          G4cout << GetName() << " detects low energy neutrals" << G4endl;
+        }
+        if (fDetectOpticalPhotons == true) {
+          G4cout << GetName() << " detects optical photons" << G4endl;
+        }
+        if (fDetectBoundaryHits == true) {
+          G4cout << GetName() << " detects hits only on entry boundary" << G4endl;
+        }
+        if (fDetectSecondaries == true) {
+          G4cout << GetName() << " detects secondaries" << G4endl;
         }
       }
 

--- a/include/remollGlobalField.hh
+++ b/include/remollGlobalField.hh
@@ -46,6 +46,9 @@ class remollGlobalField : public G4MagneticField {
         void SetChordFinder();
 
     public:
+        /// Set verbose level
+        void SetVerboseLevel(G4int i) { fVerboseLevel = i; }
+
         /// Set the stepper types
         void SetEquationType(G4int i) { fEquationType = i; SetEquation(); }
 
@@ -102,6 +105,8 @@ class remollGlobalField : public G4MagneticField {
 
         G4GenericMessenger* fMessenger;
         G4GenericMessenger* fGlobalFieldMessenger;
+
+        G4int fVerboseLevel;
 
 };
 

--- a/remoll.cc
+++ b/remoll.cc
@@ -102,7 +102,6 @@ int main(int argc, char** argv) {
     //-------------------------------
     // Initialization of Run manager
     //-------------------------------
-    G4cout << "RunManager construction starting...." << G4endl;
     RunManager* runManager = new RunManager;
     #ifdef G4MULTITHREADED
     if (threads > 0) runManager->SetNumberOfThreads(threads);

--- a/src/remollDetectorConstruction.cc
+++ b/src/remollDetectorConstruction.cc
@@ -724,6 +724,10 @@ void remollDetectorConstruction::ParseAuxiliarySensDetInfo()
         // Set detector type
         if (remollsd) remollsd->SetDetectorType(it_dettype->value);
 
+        // Print detector type
+        if (fVerboseLevel > 0)
+          if (remollsd) remollsd->PrintDetectorType();
+
       }
 
   } // end of loop over volumes

--- a/src/remollDetectorConstruction.cc
+++ b/src/remollDetectorConstruction.cc
@@ -458,8 +458,9 @@ void remollDetectorConstruction::ParseAuxiliaryTargetInfo()
 
         // Found target mother logical volume
         G4LogicalVolume* mother_logical_volume = logical_volume;
-        G4cout << "Found target mother logical volume "
-               << mother_logical_volume->GetName() << "." << G4endl;
+        if (fVerboseLevel > 0)
+          G4cout << "Found target mother logical volume "
+                 << mother_logical_volume->GetName() << "." << G4endl;
 
         // Now find target mother physical volume
         G4VPhysicalVolume* mother_physical_volume = 0;
@@ -473,8 +474,9 @@ void remollDetectorConstruction::ParseAuxiliaryTargetInfo()
           remollBeamTarget::ResetTargetVolumes();
           remollBeamTarget::SetMotherVolume(mother_physical_volume);
 
-          G4cout << "Found target mother physical volume "
-                 << mother_physical_volume->GetName() << "." << G4endl;
+          if (fVerboseLevel > 0)
+            G4cout << "Found target mother physical volume "
+                   << mother_physical_volume->GetName() << "." << G4endl;
         } else {
           G4cout << "Target mother logical volume does not occur "
                  << "*exactly once* as a physical volume." << G4endl;

--- a/src/remollGenExternal.cc
+++ b/src/remollGenExternal.cc
@@ -32,7 +32,6 @@ remollGenExternal::remollGenExternal()
   fThisGenMessenger->DeclareMethod("zOffset",&remollGenExternal::SetGenExternalZOffset,"External generator zOffset");
   fThisGenMessenger->DeclareMethod("detid",&remollGenExternal::SetGenExternalDetID,"External generator detector ID");
   fThisGenMessenger->DeclareMethod("startEvent",&remollGenExternal::SetGenExternalEntry,"External generator starting event: -1 starts random,  n starts at n (default n=0)");
-  G4cout << "Constructed remollGenExternal" << G4endl;
 }
 
 remollGenExternal::~remollGenExternal()

--- a/src/remollGlobalField.cc
+++ b/src/remollGlobalField.cc
@@ -47,7 +47,8 @@ remollGlobalField::remollGlobalField()
   fEpsMin(1.0e-5*mm),fEpsMax(1.0e-4*mm),
   fEquation(0),fEquationDoF(0),
   fFieldManager(0),fFieldPropagator(0),
-  fStepper(0),fChordFinder(0)
+  fStepper(0),fChordFinder(0),
+  fVerboseLevel(0)
 {
     // Get field propagator and managers
     G4TransportationManager* transportationmanager = G4TransportationManager::GetTransportationManager();
@@ -82,6 +83,7 @@ remollGlobalField::remollGlobalField()
     fGlobalFieldMessenger->DeclareMethod("scale",&remollGlobalField::SetFieldScale,"Scale magnetic field by factor");
     fGlobalFieldMessenger->DeclareMethod("current",&remollGlobalField::SetMagnetCurrent,"Scale magnetic field by current");
     fGlobalFieldMessenger->DeclareMethod("value",&remollGlobalField::PrintFieldValue,"Print the field value at a given point (in m)");
+    fGlobalFieldMessenger->DeclareProperty("verbose",fVerboseLevel,"Set the verbose level");
 }
 
 remollGlobalField::~remollGlobalField()
@@ -125,12 +127,12 @@ void remollGlobalField::SetEquation()
   switch (fEquationType)
   {
     case 0:
-      G4cout << "G4Mag_UsualEqRhs is called with 6 dof" << G4endl;
+      if (fVerboseLevel > 0) G4cout << "G4Mag_UsualEqRhs is called with 6 dof" << G4endl;
       fEquation = new G4Mag_UsualEqRhs(this);
       fEquationDoF = 6;
       break;
     case 2:
-      G4cout << "G4Mag_SpinEqRhs is called with 12 dof" << G4endl;
+      if (fVerboseLevel > 0) G4cout << "G4Mag_SpinEqRhs is called with 12 dof" << G4endl;
       fEquation = new G4Mag_SpinEqRhs(this);
       fEquationDoF = 12;
       break;
@@ -148,27 +150,27 @@ void remollGlobalField::SetStepper()
   {
     case 0:
       fStepper = new G4ExplicitEuler(fEquation, fEquationDoF);
-      G4cout << "G4ExplicitEuler is called" << G4endl;
+      if (fVerboseLevel > 0) G4cout << "G4ExplicitEuler is called" << G4endl;
       break;
     case 1:
       fStepper = new G4ImplicitEuler(fEquation, fEquationDoF);
-      G4cout << "G4ImplicitEuler is called" << G4endl;
+      if (fVerboseLevel > 0) G4cout << "G4ImplicitEuler is called" << G4endl;
       break;
     case 2:
       fStepper = new G4SimpleRunge(fEquation, fEquationDoF);
-      G4cout << "G4SimpleRunge is called" << G4endl;
+      if (fVerboseLevel > 0) G4cout << "G4SimpleRunge is called" << G4endl;
       break;
     case 3:
       fStepper = new G4SimpleHeum(fEquation, fEquationDoF);
-      G4cout << "G4SimpleHeum is called" << G4endl;
+      if (fVerboseLevel > 0) G4cout << "G4SimpleHeum is called" << G4endl;
       break;
     case 4:
       fStepper = new G4ClassicalRK4(fEquation, fEquationDoF);
-      G4cout << "G4ClassicalRK4 (default) is called" << G4endl;
+      if (fVerboseLevel > 0) G4cout << "G4ClassicalRK4 (default) is called" << G4endl;
       break;
     case 5:
       fStepper = new G4CashKarpRKF45(fEquation, fEquationDoF);
-      G4cout << "G4CashKarpRKF45 is called" << G4endl;
+      if (fVerboseLevel > 0) G4cout << "G4CashKarpRKF45 is called" << G4endl;
       break;
     default: fStepper = 0;
   }
@@ -198,7 +200,8 @@ void remollGlobalField::AddNewField(G4String& name)
   if (thisfield->IsInit()) {
     fFields.push_back(thisfield);
 
-    G4cout << __FUNCTION__ << ": field " << name << " was added." << G4endl;
+    if (fVerboseLevel > 0)
+      G4cout << __FUNCTION__ << ": field " << name << " was added." << G4endl;
 
     // Add file data to output data stream
 
@@ -222,7 +225,8 @@ void remollGlobalField::AddNewField(G4String& name)
     stat(name.data(), &fs);
     fdata.timestamp = TTimeStamp( fs.st_mtime );
 
-    G4cout << __FUNCTION__ << ": field timestamp = " << fdata.timestamp << G4endl;
+    if (fVerboseLevel > 0)
+      G4cout << __FUNCTION__ << ": field timestamp = " << fdata.timestamp << G4endl;
 
     rd->AddMagData(fdata);
 

--- a/src/remollParallelConstruction.cc
+++ b/src/remollParallelConstruction.cc
@@ -19,7 +19,7 @@ remollParallelConstruction::remollParallelConstruction(const G4String& name, con
   fGDMLPath("geometry"),fGDMLFile(""),
   fGDMLParser(0),
   fGDMLValidate(false),
-  fGDMLOverlapCheck(true),
+  fGDMLOverlapCheck(false),
   fVerboseLevel(0),
   fParallelMessenger(0),
   fWorldVolume(0),
@@ -143,7 +143,11 @@ G4VPhysicalVolume* remollParallelConstruction::ParseGDMLFile()
 
   // Parse GDML file
   fGDMLParser->SetOverlapCheck(fGDMLOverlapCheck);
+  // hide output if not validating or checking ovelaps
+  if (! fGDMLOverlapCheck && ! fGDMLValidate)
+    G4cout.setstate(std::ios_base::failbit);
   fGDMLParser->Read(fGDMLFile,fGDMLValidate);
+  G4cout.clear();
   G4VPhysicalVolume* parallelvolume = fGDMLParser->GetWorldVolume();
   G4LogicalVolume* parallellogical = parallelvolume->GetLogicalVolume();
 

--- a/src/remollPhysicsList.cc
+++ b/src/remollPhysicsList.cc
@@ -131,9 +131,11 @@ void remollPhysicsList::SetVerboseLevel(G4int level)
   G4VModularPhysicsList::SetVerboseLevel(level);
 
   // Set verbose level of precompound deexcitation
+  #if G4VERSION_NUMBER >= 1060
   if (auto nuclearleveldata = G4NuclearLevelData::GetInstance())
     if (auto param = nuclearleveldata->GetParameters())
       param->SetVerbose(level);
+  #endif
 
   // Set verbose level of HadronicProcessStore
   G4HadronicProcessStore::Instance()->SetVerbose(level);

--- a/src/remollPhysicsList.cc
+++ b/src/remollPhysicsList.cc
@@ -5,6 +5,7 @@
 #include "G4OpticalPhysics.hh"
 #include "G4GenericMessenger.hh"
 #include "G4RunManager.hh"
+#include "G4NuclearLevelData.hh"
 #include "G4HadronicProcessStore.hh"
 #include "G4ParticleHPManager.hh"
 
@@ -128,6 +129,11 @@ void remollPhysicsList::SetVerboseLevel(G4int level)
 {
   // Let upstream handle this first
   G4VModularPhysicsList::SetVerboseLevel(level);
+
+  // Set verbose level of precompound deexcitation
+  if (auto nuclearleveldata = G4NuclearLevelData::GetInstance())
+    if (auto param = nuclearleveldata->GetParameters())
+      param->SetVerbose(level);
 
   // Set verbose level of HadronicProcessStore
   G4HadronicProcessStore::Instance()->SetVerbose(level);


### PR DESCRIPTION
Remove 'unhelpful' output during running will make the unusual output stand out more. This removes some output that has low information content and moves other output behind level one verbose flags.