### PR TITLE
Fix #288 checkoverlap.mac to use `/remoll/geometry/printoverlaps`

### DIFF
--- a/macros/checkoverlap.mac
+++ b/macros/checkoverlap.mac
@@ -4,4 +4,4 @@
 # This must be explicitly called
 /run/initialize
 
-/remoll/printgeometry false
+/remoll/geometry/printoverlaps


### PR DESCRIPTION
Fixes issue #288 related to having messenger commands with boolean arguments, which have to be entered, confusingly, as integers.

Now `/remoll/geometry/printoverlaps` basically calls `/remoll/geometry/printgeometry true` without the need for parsing.