### PR TITLE
Enhancement: geometry in upstream should avoid subtraction

### DIFF
--- a/geometry/upstream/upstreamDaughter_merged.gdml
+++ b/geometry/upstream/upstreamDaughter_merged.gdml
@@ -147,6 +147,8 @@
     </subtraction>
 
     <!-- New merged col-1 -->
+    <!--fully enclosing volume, no overlaps with fins -->
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="col1_0_enc" rmax="COLL1_R4_U-COLL1_remove_Ring1_DeltaR" rmin="0" startphi="0" z="COLL1_THICK"/>
     <!--R max will be same as before, I'm starting with bore radius of the exit bore for whole col-1 and then subtract appropriately -->
     <tube aunit="deg" deltaphi="360" lunit="mm" name="col1_0" rmax="COLL1_R4_U" rmin="0" startphi="0" z="COLL1_THICK"/>
     <!-- Subtract the reverese tapered bore (this was the first design of merged col1) from front face till 40 cm (leaving last 10 cm with R of  COLL1_Ring4_R_D -->
@@ -321,7 +323,6 @@
 	<position name="col1fin_15_pos" x="0" y="0" z="-1/2*col1fin_Length + 30/2" unit="mm"/>
     </subtraction>
 
-
     <box lunit="mm" name="COLL_BOX"  x="1000" y="1000" z="1000"/>
 
     <cone aunit="deg" deltaphi="360" lunit="mm" name="uscyl_2" rmax1="COLL2_R4_U" rmax2="COLL2_R4_D" rmin1="COLL2_R1_U" rmin2="COLL2_R1_D" startphi="0" z="COLL2_THICK"/>
@@ -383,6 +384,7 @@
       <auxiliary auxtype="SensDet" auxvalue="planeDet"/>
       <auxiliary auxtype="DetNo" auxvalue="91"/>
     </volume>
+
     <volume name="logicUScoll_1">
       <!-- <materialref ref="Tungsten"/> -->
       <materialref ref="CW95"/>
@@ -392,7 +394,15 @@
       <auxiliary auxtype="DetType" auxvalue="secondaries"/>
       <auxiliary auxtype="DetNo" auxvalue="2001"/>
     </volume>
-
+    <volume name="logicUScoll_2">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="col1_0_enc"/>
+      <auxiliary auxtype="Alpha" auxvalue="0.5"/>
+      <physvol name="logicUScoll_1_pv">
+        <volumeref ref="logicUScoll_1"/>
+      </physvol>
+    </volume>
+      
     <volume name="logicUScol1fin_1">
       <materialref ref="CW95"/>
       <solidref ref="col1fin_15"/>
@@ -402,11 +412,13 @@
       <auxiliary auxtype="DetType" auxvalue="secondaries"/>
       <auxiliary auxtype="DetNo" auxvalue="2006"/>
     </volume>
-
     <volume name="logicUScol1fin_2">
       <materialref ref="G4_Galactic"/>
-      <solidref ref="col1fin_15"/>
+      <solidref ref="col1fin_0"/>
       <auxiliary auxtype="Alpha" auxvalue="0.0"/>
+      <physvol name="logicUScol1fin_1_pv">
+        <volumeref ref="logicUScol1fin_1"/>
+      </physvol>
     </volume>
 
     <volume name="uscyl_inner_ring_lv">
@@ -476,13 +488,13 @@
       <materialref ref="VacuumColl"/>
       <solidref ref="boxUpstream"/>
 
-      <physvol name="UScoll_1">
-        <volumeref ref="logicUScoll_1"/>
+      <physvol name="UScoll_2">
+        <volumeref ref="logicUScoll_2"/>
         <positionref ref="posCOLL1"/>
       </physvol>
 
-      <physvol name="UScol1fin_1">
-        <volumeref ref="logicUScol1fin_1"/>
+      <physvol name="UScol1fin_2">
+        <volumeref ref="logicUScol1fin_2"/>
         <positionref ref="poscol1fin"/>
       </physvol>
 

--- a/geometry/upstream/upstreamDaughter_merged.gdml
+++ b/geometry/upstream/upstreamDaughter_merged.gdml
@@ -455,7 +455,7 @@
       <physvol name="uscyl_outer_ring_pv">
         <volumeref ref="uscyl_outer_ring_lv"/>
       </physvol>
-      <loop for="i_septant" to="6" step="1">
+      <loop for="i_septant" from="0" to="6" step="1">
         <physvol name="uscyl_slice_pv[i_septant]">
           <volumeref ref="uscyl_slice_lv"/>
           <rotation z="SEPTANT*(i_septant)" unit="deg"/>

--- a/geometry/upstream/upstreamDaughter_merged.gdml
+++ b/geometry/upstream/upstreamDaughter_merged.gdml
@@ -324,14 +324,6 @@
 
     <box lunit="mm" name="COLL_BOX"  x="1000" y="1000" z="1000"/>
 
-    <cone aunit="deg" deltaphi="360" lunit="mm" name="uscyl_1" rmax1="COLL1_R4_U" rmax2="COLL1_R4_D" rmin1="COLL1_R1_U" rmin2="COLL1_R1_D" startphi="0" z="COLL1_THICK"/>
-
-    <cone aunit="deg" deltaphi="SEPTANT/2" lunit="mm" name="cons_1" 
-          rmax1="COLL2_R3_U-DELTAT*((COLL2_R3_D-COLL2_R3_U)/COLL2_THICK)" 
-          rmax2="COLL2_R3_D+DELTAT*((COLL2_R3_D-COLL2_R3_U)/COLL2_THICK)" 
-          rmin1="COLL2_R2_U-DELTAT*((COLL2_R2_D-COLL2_R2_U)/COLL2_THICK)" 
-          rmin2="COLL2_R2_D+DELTAT*((COLL2_R2_D-COLL2_R2_U)/COLL2_THICK)" startphi="-SEPTANT/4" z="COLL2_THICK+DELTAT*2"/>
-
     <cone aunit="deg" deltaphi="360" lunit="mm" name="uscyl_2" rmax1="COLL2_R4_U" rmax2="COLL2_R4_D" rmin1="COLL2_R1_U" rmin2="COLL2_R1_D" startphi="0" z="COLL2_THICK"/>
 
     <cone aunit="deg" deltaphi="360" lunit="mm" name="uscyl_inner_ring_sol" 
@@ -350,52 +342,15 @@
           startphi="0"
           z="COLL2_THICK"/>
     
-    <cone aunit="deg" deltaphi="SEPTANT/2" lunit="mm" name="uscyl_slice_sol" 
-          rmax1="COLL2_R3_U-DELTAT*((COLL2_R3_D-COLL2_R3_U)/COLL2_THICK)" 
-          rmax2="COLL2_R3_D+DELTAT*((COLL2_R3_D-COLL2_R3_U)/COLL2_THICK)" 
-          rmin1="COLL2_R2_U-DELTAT*((COLL2_R2_D-COLL2_R2_U)/COLL2_THICK)" 
+    <cone aunit="deg" deltaphi="SEPTANT/2" lunit="mm" name="uscyl_slice_sol"
+          rmax1="COLL2_R3_U-DELTAT*((COLL2_R3_D-COLL2_R3_U)/COLL2_THICK)"
+          rmax2="COLL2_R3_D+DELTAT*((COLL2_R3_D-COLL2_R3_U)/COLL2_THICK)"
+          rmin1="COLL2_R2_U-DELTAT*((COLL2_R2_D-COLL2_R2_U)/COLL2_THICK)"
           rmin2="COLL2_R2_D+DELTAT*((COLL2_R2_D-COLL2_R2_U)/COLL2_THICK)"
           startphi="-SEPTANT/4"
           z="COLL2_THICK"/>
     
     <cone aunit="deg" deltaphi="360" lunit="mm" name="coll2trap" rmax1="COLL2_R4_U+1000" rmax2="COLL2_R4_D+1000" rmin1="0.0" rmin2="0.0" startphi="0" z="1"/>
-
-
-    <subtraction name ="uscoll2_union_0">
-        <first ref="uscyl_2"/>
-        <second ref="cons_1"/>
-        <rotation name="uscoll_rot1" x="0" y="0" z="SEPTANT*(0+0.5)" unit="deg"/>
-    </subtraction>
-    <subtraction name ="uscoll2_union_1">
-        <first ref="uscoll2_union_0"/>
-        <second ref="cons_1"/>
-        <rotation name="uscoll_rot2" x="0" y="0" z="SEPTANT*(1+0.5)" unit="deg"/>
-    </subtraction>
-    <subtraction name ="uscoll2_union_2">
-        <first ref="uscoll2_union_1"/>
-        <second ref="cons_1"/>
-        <rotation name="uscoll_rot3" x="0" y="0" z="SEPTANT*(2+0.5)" unit="deg"/>
-    </subtraction>
-    <subtraction name ="uscoll2_union_3">
-        <first ref="uscoll2_union_2"/>
-        <second ref="cons_1"/>
-        <rotation name="uscoll_rot4" x="0" y="0" z="SEPTANT*(3+0.5)" unit="deg"/>
-    </subtraction>
-    <subtraction name ="uscoll2_union_4">
-        <first ref="uscoll2_union_3"/>
-        <second ref="cons_1"/>
-        <rotation name="uscoll_rot5" x="0" y="0" z="SEPTANT*(4+0.5)" unit="deg"/>
-    </subtraction>
-    <subtraction name ="uscoll2_union_5">
-        <first ref="uscoll2_union_4"/>
-        <second ref="cons_1"/>
-        <rotation name="uscoll_rot6" x="0" y="0" z="SEPTANT*(5+0.5)" unit="deg"/>
-    </subtraction>
-    <subtraction name ="uscoll2_union_6">
-        <first ref="uscoll2_union_5"/>
-        <second ref="cons_1"/>
-        <rotation name="uscoll_rot7" x="0" y="0" z="SEPTANT*(6+0.5)" unit="deg"/>
-    </subtraction>
 
     <!--
        Shielding collimators
@@ -452,15 +407,6 @@
       <materialref ref="G4_Galactic"/>
       <solidref ref="col1fin_15"/>
       <auxiliary auxtype="Alpha" auxvalue="0.0"/>
-    </volume>
-
-    <volume name="logicUScollunion_1">
-      <materialref ref="CW95"/>
-      <solidref ref="uscoll2_union_6"/>
-      <auxiliary auxtype="SensDet" auxvalue="collDet"/>
-      <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
-      <auxiliary auxtype="DetType" auxvalue="secondaries"/>
-      <auxiliary auxtype="DetNo" auxvalue="2002"/>
     </volume>
 
     <volume name="uscyl_inner_ring_lv">

--- a/geometry/upstream/upstreamDaughter_merged.gdml
+++ b/geometry/upstream/upstreamDaughter_merged.gdml
@@ -9,6 +9,8 @@
 
 <define>
     &matrices;
+    
+    <variable name="i_septant" value="0"/>
 
     <constant name="PI" value="1.*pi"/>
     <constant name="UOFFSET" value="7000.00"/>
@@ -332,6 +334,30 @@
 
     <cone aunit="deg" deltaphi="360" lunit="mm" name="uscyl_2" rmax1="COLL2_R4_U" rmax2="COLL2_R4_D" rmin1="COLL2_R1_U" rmin2="COLL2_R1_D" startphi="0" z="COLL2_THICK"/>
 
+    <cone aunit="deg" deltaphi="360" lunit="mm" name="uscyl_inner_ring_sol" 
+          rmax1="COLL2_R2_U-DELTAT*((COLL2_R2_D-COLL2_R2_U)/COLL2_THICK)" 
+          rmax2="COLL2_R2_D+DELTAT*((COLL2_R2_D-COLL2_R2_U)/COLL2_THICK)" 
+          rmin1="COLL2_R1_U" 
+          rmin2="COLL2_R1_D" 
+          startphi="0"
+          z="COLL2_THICK"/>
+
+    <cone aunit="deg" deltaphi="360" lunit="mm" name="uscyl_outer_ring_sol" 
+          rmax1="COLL2_R4_U" 
+          rmax2="COLL2_R4_D" 
+          rmin1="COLL2_R3_U-DELTAT*((COLL2_R3_D-COLL2_R3_U)/COLL2_THICK)" 
+          rmin2="COLL2_R3_D+DELTAT*((COLL2_R3_D-COLL2_R3_U)/COLL2_THICK)" 
+          startphi="0"
+          z="COLL2_THICK"/>
+    
+    <cone aunit="deg" deltaphi="SEPTANT/2" lunit="mm" name="uscyl_slice_sol" 
+          rmax1="COLL2_R3_U-DELTAT*((COLL2_R3_D-COLL2_R3_U)/COLL2_THICK)" 
+          rmax2="COLL2_R3_D+DELTAT*((COLL2_R3_D-COLL2_R3_U)/COLL2_THICK)" 
+          rmin1="COLL2_R2_U-DELTAT*((COLL2_R2_D-COLL2_R2_U)/COLL2_THICK)" 
+          rmin2="COLL2_R2_D+DELTAT*((COLL2_R2_D-COLL2_R2_U)/COLL2_THICK)"
+          startphi="-SEPTANT/4"
+          z="COLL2_THICK"/>
+    
     <cone aunit="deg" deltaphi="360" lunit="mm" name="coll2trap" rmax1="COLL2_R4_U+1000" rmax2="COLL2_R4_D+1000" rmin1="0.0" rmin2="0.0" startphi="0" z="1"/>
 
 
@@ -422,7 +448,13 @@
       <auxiliary auxtype="DetNo" auxvalue="2006"/>
     </volume>
 
-   <volume name="logicUScollunion_1">
+    <volume name="logicUScol1fin_2">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="col1fin_15"/>
+      <auxiliary auxtype="Alpha" auxvalue="0.0"/>
+    </volume>
+
+    <volume name="logicUScollunion_1">
       <materialref ref="CW95"/>
       <solidref ref="uscoll2_union_6"/>
       <auxiliary auxtype="SensDet" auxvalue="collDet"/>
@@ -431,7 +463,49 @@
       <auxiliary auxtype="DetNo" auxvalue="2002"/>
     </volume>
 
-   <volume name="logiccoll2trap">
+    <volume name="uscyl_inner_ring_lv">
+      <materialref ref="CW95"/>
+      <solidref ref="uscyl_inner_ring_sol"/>
+      <auxiliary auxtype="SensDet" auxvalue="collDet"/>
+      <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+      <auxiliary auxtype="DetType" auxvalue="secondaries"/>
+      <auxiliary auxtype="DetNo" auxvalue="2002"/>
+      </volume>
+    <volume name="uscyl_outer_ring_lv">
+      <materialref ref="CW95"/>
+      <solidref ref="uscyl_outer_ring_sol"/>
+      <auxiliary auxtype="SensDet" auxvalue="collDet"/>
+      <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+      <auxiliary auxtype="DetType" auxvalue="secondaries"/>
+      <auxiliary auxtype="DetNo" auxvalue="2002"/>
+    </volume>
+    <volume name="uscyl_slice_lv">
+      <materialref ref="CW95"/>
+      <solidref ref="uscyl_slice_sol"/>
+      <auxiliary auxtype="SensDet" auxvalue="collDet"/>
+      <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+      <auxiliary auxtype="DetType" auxvalue="secondaries"/>
+      <auxiliary auxtype="DetNo" auxvalue="2002"/>
+    </volume>
+    <volume name="logicUScollunion_2">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="uscyl_2"/>
+      <auxiliary auxtype="Alpha" auxvalue="0.0"/>
+      <physvol name="uscyl_inner_ring_pv">
+        <volumeref ref="uscyl_inner_ring_lv"/>
+      </physvol>
+      <physvol name="uscyl_outer_ring_pv">
+        <volumeref ref="uscyl_outer_ring_lv"/>
+      </physvol>
+      <loop for="i_septant" to="6" step="1">
+        <physvol name="uscyl_slice_pv[i_septant]">
+          <volumeref ref="uscyl_slice_lv"/>
+          <rotation z="SEPTANT*(i_septant)" unit="deg"/>
+        </physvol>
+      </loop>
+    </volume>
+
+    <volume name="logiccoll2trap">
       <materialref ref="VacuumColl"/>
       <solidref ref="coll2trap"/>
       <auxiliary auxtype="SensDet" auxvalue="collDet"/>
@@ -466,8 +540,8 @@
         <positionref ref="poscol1fin"/>
       </physvol>
 
-      <physvol name="UScollunion_1">
-        <volumeref ref="logicUScollunion_1"/>
+      <physvol name="UScollunion_2">
+        <volumeref ref="logicUScollunion_2"/>
         <positionref ref="posCOLL2"/>
       </physvol>
 

--- a/geometry/upstream/upstreamDaughter_merged.gdml
+++ b/geometry/upstream/upstreamDaughter_merged.gdml
@@ -205,6 +205,15 @@
      <!--Fins for col-1 -->
      <tube aunit="deg" deltaphi="360" lunit="mm" name="col1fin_0" rmax="col1fin_RMax" rmin="col1fin_RMin" startphi="0" z="col1fin_Length"/>
 
+     <tube name="col1fin_0_slice"
+           aunit="deg"
+           deltaphi="(SEPTANT - col1fin_Delta_SEPTANT)/2" 
+           startphi="-(SEPTANT - col1fin_Delta_SEPTANT)/4"
+           lunit="mm" 
+           rmax="col1fin_RMax" 
+           rmin="col1fin_RMin" 
+           z="col1fin_Length"/>
+
      <cone aunit="deg" deltaphi="col1fin_SEPTANT/2" lunit="mm" name="col1fin_cons_1" 
           rmax1="COLL2_R3_U-DELTAT*((COLL2_R3_D-COLL2_R3_U)/COLL2_THICK)" 
           rmax2="COLL2_R3_D+DELTAT*((COLL2_R3_D-COLL2_R3_U)/COLL2_THICK)" 
@@ -265,7 +274,10 @@
 	<positionref ref="trans_col1fin"/>
      </union>
 
-
+    <subtraction name ="col1fin_0_slice_sub_1">
+        <first ref="col1fin_0_slice"/>
+        <second ref="sub_col1fin_cons_2"/>
+    </subtraction>
 
     <subtraction name ="col1fin_8">
         <first ref="col1fin_7"/>
@@ -316,6 +328,12 @@
            rmax2="col1fin_RMax+2" 
 	   startphi="0" z="31"
 	   />
+
+     <subtraction name ="col1fin_0_slice_sub_2">
+        <first ref="col1fin_0_slice_sub_1"/>
+        <second ref="sub_col1fin_cons_3"/>
+	<position z="-1/2*col1fin_Length + 30/2" unit="mm"/>
+     </subtraction>
 
      <subtraction name ="col1fin_15">
         <first ref="col1fin_14"/>
@@ -412,13 +430,33 @@
       <auxiliary auxtype="DetType" auxvalue="secondaries"/>
       <auxiliary auxtype="DetNo" auxvalue="2006"/>
     </volume>
+    <volume name="col1fin_0_slice_sub_lv">
+      <materialref ref="CW95"/>
+      <solidref ref="col1fin_0_slice_sub_2"/>
+      <auxiliary auxtype="Color" auxvalue="red"/>
+      <auxiliary auxtype="SensDet" auxvalue="collDet"/>
+      <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+      <auxiliary auxtype="DetType" auxvalue="secondaries"/>
+      <auxiliary auxtype="DetNo" auxvalue="2006"/>
+    </volume>
+    <volume name="col1fin_0_slice_lv">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="col1fin_0_slice"/>
+      <physvol name="col1fin_0_slice_sub_pv[i_septant]">
+        <volumeref ref="col1fin_0_slice_sub_lv"/>
+        <rotation z="SEPTANT*(i_septant)" unit="deg"/>
+      </physvol>
+    </volume>
     <volume name="logicUScol1fin_2">
       <materialref ref="G4_Galactic"/>
       <solidref ref="col1fin_0"/>
       <auxiliary auxtype="Alpha" auxvalue="0.0"/>
-      <physvol name="logicUScol1fin_1_pv">
-        <volumeref ref="logicUScol1fin_1"/>
-      </physvol>
+      <loop for="i_septant" from="0" to="6" step="1">
+        <physvol name="col1fin_0_slice_pv[i_septant]">
+          <volumeref ref="col1fin_0_slice_lv"/>
+          <rotation z="SEPTANT*(i_septant)" unit="deg"/>
+        </physvol>
+      </loop>
     </volume>
 
     <volume name="uscyl_inner_ring_lv">


### PR DESCRIPTION
Motivation: How you code the geometry matters in geant4. I've never seen a case where the main drag on the simulation (single highest nail) is the navigator in the geometry tree, yet here we are...

# How does geant4 do geometry navigation?
As tracks are stepped through the geometry, which is structured like a tree of nested volumes, the following operations are evaluated at every new step endpoint:
- Is the new endpoint still inside the current volume, and is it inside any daughter volumes of the current volume? G4VSolid::Inside(p)
- What is the distance of the new endpoint to the outside of the current volume along the current track direction? G4VSolid::DistanceToOut(p,dp)
- What is the distance of the new endpoint to the inside of any daughter volumes of the current volume along the current track direction? G4VSolid::DistanceToIn(p,dp)

Each volume type implements these 3 functions. For some, e.g. G4Box, the inside status and distances are trivial to calculate and very quick (points are passed as cartesian coordinates). For some, e.g. G4Tube (tube) with full deltaphi, they take longer since geant4 needs to calculate r<sup>2</sup>. For others, e.g. G4Cons (cone segment) without full deltaphi, they take literally pages and pages of code with trig functions and matrix inversions. Finally, for boolean solids and poly-volumes, it has to be passed to all underlying volumes: subtractions of subtractions could result in a point flipping back and forth between inside and outside, and there are no shortcuts possible because volume compactness is not guaranteed.

# Why do we care?
So, regions with lots of tracks (inside acceptance), small steps (dense materials), with lots of daughter volumes, using boolean subtraction, and using cone segments are going to take long.

That is exactly what happens for collimator 1: a 15-times nested subtraction of partial cone segments as a daughter of the entire 6.5m long upstream volume in a region with high number of tracks and short steps on account of non-zero magnetic field.

**The simulation in develop for the moller generally spends 30% (!) of the time just deciding whether the track is inside collimator 1.** Yes, you can read that again. (Note: this number is based on the speedup after fixing it. remoll did originally spend 25% of the time just evaluating atan2 calls in the G4Cons class. Results obtained with callgrind.)

There is no reason why a track that is near the end (but still inside) of the upstream region needs to be evaluating individually if it is going to be hitting each one of the fins of the collimator. All that's needed is a test of whether it's anywhere close. That's exactly what simple, easy to evaluate enclosing volumes are for. They make it trivial to tell whether tracks are near a complicated part of the geometry, and only for tracks inside the enclosing volume do we spend time evaluating the details.

# This PR doesn't change any geometry; it just adds enclosing volumes
'Fortunately' the serial subtractions have a trivial enclosing volume: the first solid we start subtracting from. This PR only adds that intermediate layer of enclosure, as a simple full deltaphi tube object which is quick to evaluate.

# Does it help?
This speeds up the simulation by over 30% (on 100 events; unchanged startup overhead is about 7 second realtime).

Timing test of a test macro on develop:
```
===> multitime results
1: -qq build/remoll macros/tests/callgrind/test_moller.mac
            Mean        Std.Dev.    Min         Median      Max
real        71.791      1.366       70.481      71.255      75.322      
user        126.008     2.284       124.181     125.364     132.426     
sys         1.477       0.130       1.342       1.457       1.844       
```

Timing test of a test macro in this PR:
```
===> multitime results
1: -qq build/remoll macros/tests/callgrind/test_moller.mac
            Mean        Std.Dev.    Min         Median      Max
real        53.178      0.308       52.789      53.062      53.979      
user        85.566      0.475       85.035      85.465      86.622      
sys         1.418       0.038       1.347       1.419       1.483       
```

# Show me the geometry differences
Before:
![image](https://user-images.githubusercontent.com/4656391/80922745-b14b0e00-8d44-11ea-9524-6cc899411bc3.png)
After:
![image](https://user-images.githubusercontent.com/4656391/80922756-bd36d000-8d44-11ea-905d-08c0b93500e7.png)

Before:
![image](https://user-images.githubusercontent.com/4656391/80923203-d1300100-8d47-11ea-9bf0-201d24748850.png)
After:
![image](https://user-images.githubusercontent.com/4656391/80923208-d9883c00-8d47-11ea-837b-cf439d2496c8.png)

# Who else should care?
Everyone who is writing geometry! This is not a matter of premature optimization; it's a matter of modularity and maintainability. If this matters for 1 volume in collimator 1, you can bet that adding 13000 solids (2000 of which are subtrations) in the main detector on a single level is going to slow things down more than just 30%. Hopefully we can go back to the good ol' days when simulations were slow because of magnetic field tracking.

# Disclaimer
I wish I could say this does not affect the hit distribution at the detector plane bit-by-bit. I had expected that the absence of mass geometry changes would result in exactly the same tracking trajectories, but there seems to be some difference bit-by-bit. The distributions are the same with the exception of maybe a bit more 'grass' in the case of develop. This is under investigation.