### PR TITLE
Bugfix: Remove all signed-unsigned warnings by using decltype

### DIFF
--- a/src/remollDetectorConstruction.cc
+++ b/src/remollDetectorConstruction.cc
@@ -301,7 +301,8 @@ void remollDetectorConstruction::SetKryptoniteUserLimits(G4VPhysicalVolume* volu
   }
 
   // Descend down the tree
-  for (int i = 0; i < logical_volume->GetNoDaughters(); i++) {
+  auto n = logical_volume->GetNoDaughters();
+  for (decltype(n) i = 0; i < n; i++) {
     G4VPhysicalVolume* daughter = logical_volume->GetDaughter(i);
     SetKryptoniteUserLimits(daughter);
   }
@@ -484,7 +485,8 @@ void remollDetectorConstruction::ParseAuxiliaryTargetInfo()
         }
 
         // Loop over target mother logical volume daughters
-        for (int i = 0; i < mother_logical_volume->GetNoDaughters(); i++) {
+        auto n = mother_logical_volume->GetNoDaughters();
+        for (decltype(n) i = 0; i < n; i++) {
 
           // Get daughter physical and logical volumes
           G4VPhysicalVolume* target_physical_volume = mother_logical_volume->GetDaughter(i);
@@ -648,7 +650,8 @@ void remollDetectorConstruction::ParseAuxiliaryVisibilityInfo()
   // Set all immediate daughters of the world volume to wireframe
   G4VisAttributes* daughterVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,1.0));
   daughterVisAtt->SetForceWireframe(true);
-  for (int i = 0; i < fWorldVolume->GetLogicalVolume()->GetNoDaughters(); i++) {
+  auto n = fWorldVolume->GetLogicalVolume()->GetNoDaughters();
+  for (decltype(n) i = 0; i < n; i++) {
     fWorldVolume->GetLogicalVolume()->GetDaughter(i)->GetLogicalVolume()->SetVisAttributes(daughterVisAtt);
   }
 }
@@ -876,7 +879,8 @@ G4int remollDetectorConstruction::UpdateCopyNo(G4VPhysicalVolume* aVolume,G4int 
       }
       index++;
       //}else {
-    for(int i=0;i<aVolume->GetLogicalVolume()->GetNoDaughters();i++){
+    auto n = aVolume->GetLogicalVolume()->GetNoDaughters();
+    for(decltype(n) i=0;i<n;i++){
       index = UpdateCopyNo(aVolume->GetLogicalVolume()->GetDaughter(i),index);
     }
     //}
@@ -907,7 +911,8 @@ std::vector<G4VPhysicalVolume*> remollDetectorConstruction::GetPhysicalVolumes(
   }
 
   // Descend down the tree
-  for (int i = 0; i < physical_volume->GetLogicalVolume()->GetNoDaughters(); i++)
+  auto n = physical_volume->GetLogicalVolume()->GetNoDaughters();
+  for (decltype(n) i = 0; i < n; i++)
   {
     // Get results for daughter volumes
     std::vector<G4VPhysicalVolume*> daughter_list =
@@ -955,7 +960,8 @@ void remollDetectorConstruction::PrintGeometryTree(
   if (surfchk) aVolume->CheckOverlaps(1000,1.0*mm,false);
 
   // Descend down the tree
-  for (int i = 0; i < aVolume->GetLogicalVolume()->GetNoDaughters(); i++) {
+  auto n = aVolume->GetLogicalVolume()->GetNoDaughters();
+  for (decltype(n) i = 0; i < n; i++) {
     PrintGeometryTree(aVolume->GetLogicalVolume()->GetDaughter(i),depth+1,surfchk,print);
   }
 }

--- a/src/remollEvent.cc
+++ b/src/remollEvent.cc
@@ -73,17 +73,20 @@ std::vector<remollEventParticle_t> remollEvent::GetEventParticleIO() const {
 
     if(trajectoryContainer==0){
     }
-    else for(G4int i = 0; i < trajectoryContainer->entries(); i++){
-      //Only store trajectories of primary particles
-      if(((*trajectoryContainer)[i]->GetParentID() == 0) && ((*trajectoryContainer)[i]->GetTrackID() == G4int(idx+1))){
-        //Store each point in the container in the remollEventParticle_t structure
-        for(int j = 0; j<(*trajectoryContainer)[i]->GetPointEntries(); j++){
-          G4TrajectoryPoint* point = (G4TrajectoryPoint*)((*trajectoryContainer)[i]->GetPoint(j));
-          part.tjx.push_back(point->GetPosition()[0]);
-          part.tjy.push_back(point->GetPosition()[1]);
-          part.tjz.push_back(point->GetPosition()[2]);
+    else {
+      auto n = trajectoryContainer->entries();
+      for(decltype(n) i = 0; i < n; i++) {
+        //Only store trajectories of primary particles
+        if(((*trajectoryContainer)[i]->GetParentID() == 0) && ((*trajectoryContainer)[i]->GetTrackID() == G4int(idx+1))){
+          //Store each point in the container in the remollEventParticle_t structure
+          for(int j = 0; j<(*trajectoryContainer)[i]->GetPointEntries(); j++){
+            G4TrajectoryPoint* point = (G4TrajectoryPoint*)((*trajectoryContainer)[i]->GetPoint(j));
+            part.tjx.push_back(point->GetPosition()[0]);
+            part.tjy.push_back(point->GetPosition()[1]);
+            part.tjz.push_back(point->GetPosition()[2]);
+          }
+          break;
         }
-        break;
       }
     }
     parts.push_back(part);

--- a/src/remollEventAction.cc
+++ b/src/remollEventAction.cc
@@ -51,7 +51,8 @@ void remollEventAction::EndOfEventAction(const G4Event* aEvent)
 
   // Traverse all hit collections, sort by output type
   G4HCofThisEvent *HCE = aEvent->GetHCofThisEvent();
-  for (int hcidx = 0; hcidx < HCE->GetCapacity(); hcidx++) {
+  auto n = HCE->GetCapacity();
+  for (decltype(n) hcidx = 0; hcidx < n; hcidx++) {
     G4VHitsCollection* thiscol = HCE->GetHC(hcidx);
     if (thiscol){ // This is NULL if nothing is stored
 

--- a/src/remollParallelConstruction.cc
+++ b/src/remollParallelConstruction.cc
@@ -270,7 +270,8 @@ void remollParallelConstruction::ParseAuxiliaryVisibilityInfo()
   // Set all immediate daughters of the world volume to wireframe
   G4VisAttributes* daughterVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,1.0));
   daughterVisAtt->SetForceWireframe(true);
-  for (int i = 0; i < fWorldVolume->GetLogicalVolume()->GetNoDaughters(); i++) {
+  auto n = fWorldVolume->GetLogicalVolume()->GetNoDaughters();
+  for (decltype(n) i = 0; i < n; i++) {
     fWorldVolume->GetLogicalVolume()->GetDaughter(i)->GetLogicalVolume()->SetVisAttributes(daughterVisAtt);
   }
 }


### PR DESCRIPTION
For some we could have used ranged-for but that is not possible for the majority which are daughter volume lookups.