### PR TITLE
Feature: Disable materials world sensitive detectors by default

### DIFF
--- a/src/remollDetectorConstruction.cc
+++ b/src/remollDetectorConstruction.cc
@@ -682,6 +682,8 @@ void remollDetectorConstruction::ParseAuxiliarySensDetInfo()
         if (it_detno != list.end()) {
 
           int det_no = atoi(it_detno->value.data());
+          bool enabled = (det_no > 0)? false : true;
+          det_no = std::abs(det_no);
 
           // Construct detector name
           std::stringstream det_name_ss;
@@ -709,6 +711,7 @@ void remollDetectorConstruction::ParseAuxiliarySensDetInfo()
                      <<  G4endl;
 
             remollsd = new remollGenericDetector(det_name, det_no);
+            remollsd->SetEnabled(enabled);
 
             // Register detector with SD manager
             SDman->AddNewDetector(remollsd);


### PR DESCRIPTION
This allows defining sensitive detectors in gdml without having them fill up the ROOT file with lots of hits.

- Any detector in the material world is disabled by default (unless the detector number is entered with a negative sign, which should be used sparingly).
- Any detectors in the parallel world remain enabled by default.