### PR TITLE
Feature: added hybridJLAB_v2, segmentedJLAB_v2, upstreamJLAB_v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,10 @@ set(REMOLL_LOCATION /group/halla/www/hallaweb/html/12GeV/Moller/downloads/remoll
 set(REMOLL_DOWNLOADS http://hallaweb.jlab.org/12GeV/Moller/downloads/remoll/)
 set(REMOLL_MAP_DIR ${PROJECT_SOURCE_DIR}/map_directory)
 if(EXISTS ${REMOLL_LOCATION})
+  message(STATUS "Copying files directly from directory...")
   set(REMOLL_DOWNLOADS file://${REMOLL_LOCATION})
+else()
+  message(STATUS "Fieldmaps will be downloaded from web...")
 endif()
 file(DOWNLOAD
      ${REMOLL_DOWNLOADS}/hybridJLAB.txt
@@ -318,23 +321,39 @@ file(DOWNLOAD
      EXPECTED_MD5 af06ed35516c17640e89ba3aa0f5b200
      )
 file(DOWNLOAD
-     ${REMOLL_DOWNLOADS}/blockyUpstream_rm_1.1.txt
-     ${REMOLL_MAP_DIR}/blockyUpstream_rm_1.1.txt
-     EXPECTED_MD5 3e2338e1ba74b03da37545e98931f5f3
+     ${REMOLL_DOWNLOADS}/hybridJLAB_v2.txt
+     ${REMOLL_MAP_DIR}/hybridJLAB_v2.txt
+     EXPECTED_MD5 4a0d1abc9b80cf5f2c3dd495a1133e26
      )
 file(DOWNLOAD
-     ${REMOLL_DOWNLOADS}/blockyHybrid_rm_3.0.txt
-     ${REMOLL_MAP_DIR}/blockyHybrid_rm_3.0.txt
-     EXPECTED_MD5 b4bfef8f362e0df66f166b4e76a6847e
+     ${REMOLL_DOWNLOADS}/segmentedJLAB_v2.txt
+     ${REMOLL_MAP_DIR}/segmentedJLAB_v2.txt
+     EXPECTED_MD5 2a21b540f6496e3f554302f369646bbb
+     )
+file(DOWNLOAD
+     ${REMOLL_DOWNLOADS}/upstreamJLAB_v2.txt
+     ${REMOLL_MAP_DIR}/upstreamJLAB_v2.txt
+     EXPECTED_MD5 bed73f2ea44135c52222bc8e767e1954
      )
 install(FILES
      ${REMOLL_MAP_DIR}/hybridJLAB.txt
      ${REMOLL_MAP_DIR}/upstreamJLAB_1.25.txt
-     ${REMOLL_MAP_DIR}/blockyHybrid_rm_3.0.txt
-     ${REMOLL_MAP_DIR}/blockyUpstream_rm_1.1.txt
+     ${REMOLL_MAP_DIR}/hybridJLAB_v2.txt
+     ${REMOLL_MAP_DIR}/segmentedJLAB_v2.txt
+     ${REMOLL_MAP_DIR}/upstreamJLAB_v2.txt
      DESTINATION ${CMAKE_INSTALL_DATADIR}/remoll)
 if(ADDITIONAL_FIELDS)
   message(STATUS "Ensuring additional fields are available")
+  file(DOWNLOAD
+     ${REMOLL_DOWNLOADS}/blockyUpstream_rm_1.1.txt
+     ${REMOLL_MAP_DIR}/blockyUpstream_rm_1.1.txt
+     EXPECTED_MD5 3e2338e1ba74b03da37545e98931f5f3
+     )
+  file(DOWNLOAD
+     ${REMOLL_DOWNLOADS}/blockyHybrid_rm_3.0.txt
+     ${REMOLL_MAP_DIR}/blockyHybrid_rm_3.0.txt
+     EXPECTED_MD5 b4bfef8f362e0df66f166b4e76a6847e
+     )
   file(DOWNLOAD
      ${REMOLL_DOWNLOADS}/upstreamSymmetric_sensR_0.1.txt
      ${REMOLL_MAP_DIR}/upstreamSymmetric_sensR_0.1.txt
@@ -346,6 +365,8 @@ if(ADDITIONAL_FIELDS)
      EXPECTED_MD5 78fad2ffa5b5ae129df11bdf0ce25333
      )
   install(FILES
+     ${REMOLL_MAP_DIR}/blockyHybrid_rm_3.0.txt
+     ${REMOLL_MAP_DIR}/blockyUpstream_rm_1.1.txt
      ${REMOLL_MAP_DIR}/upstreamSymmetric_sensR_0.1.txt
      ${REMOLL_MAP_DIR}/hybridSymmetric_sensR_0.1.txt
      DESTINATION ${CMAKE_INSTALL_DATADIR}/remoll)

--- a/macros/load_magnetic_fieldmaps.mac
+++ b/macros/load_magnetic_fieldmaps.mac
@@ -1,0 +1,8 @@
+# These are the current reference magnetic field maps
+#
+# Instead of including magnetic field maps directly in your macros,
+# consider loading this macro with
+#   /control/execute macros/load_magnetic_field.mac
+
+/remoll/addfield map_directory/segmentedJLAB_v2.txt
+/remoll/addfield map_directory/upstreamJLAB_v2.txt

--- a/macros/runbatch_eAlelastic_down.mac
+++ b/macros/runbatch_eAlelastic_down.mac
@@ -4,8 +4,8 @@
 # This must be explicitly called
 /run/initialize
 
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+# Load magnetic fieldmaps
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/runbatch_eAlelastic_up.mac
+++ b/macros/runbatch_eAlelastic_up.mac
@@ -4,8 +4,8 @@
 # This must be explicitly called
 /run/initialize
 
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+# Load magnetic fieldmaps
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/runbatch_eAlinelastic_down.mac
+++ b/macros/runbatch_eAlinelastic_down.mac
@@ -4,8 +4,8 @@
 # This must be explicitly called
 /run/initialize
 
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+# Load magnetic fieldmaps
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/runbatch_eAlinelastic_up.mac
+++ b/macros/runbatch_eAlinelastic_up.mac
@@ -4,8 +4,8 @@
 # This must be explicitly called
 /run/initialize
 
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+# Load magnetic fieldmaps
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/runbatch_eAlquasielastic_down.mac
+++ b/macros/runbatch_eAlquasielastic_down.mac
@@ -4,8 +4,8 @@
 # This must be explicitly called
 /run/initialize
 
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+# Load magnetic fieldmaps
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/runbatch_eAlquasielastic_up.mac
+++ b/macros/runbatch_eAlquasielastic_up.mac
@@ -4,8 +4,8 @@
 # This must be explicitly called
 /run/initialize
 
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+# Load magnetic fieldmaps
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/runexample.mac
+++ b/macros/runexample.mac
@@ -18,11 +18,7 @@
 
 /remoll/printgeometry true
 
-/remoll/addfield map_directory/hybridJLAB.txt
-/remoll/addfield map_directory/upstreamJLAB_1.25.txt
-
-#/remoll/field/scale map_directory/blockyHybrid_rm_3.0.txt 1.0
-#/remoll/field/current map_directory/blockyHybrid_rm_3.0.txt 1000.0
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/runexample_C12.mac
+++ b/macros/runexample_C12.mac
@@ -6,11 +6,7 @@
 # This must be explicitly called
 /run/initialize
 
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
-
-#/remoll/scalefield map_directory/blockyHybrid_rm_3.0.txt 1.0
-#/remoll/magcurrent map_directory/blockyHybrid_rm_3.0.txt 1000.0 A
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/rasx 0 mm

--- a/macros/tests/commit/test_beam.mac
+++ b/macros/tests/commit/test_beam.mac
@@ -7,8 +7,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/tests/commit/test_elastic.mac
+++ b/macros/tests/commit/test_elastic.mac
@@ -7,8 +7,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/tests/commit/test_elasticAl.mac
+++ b/macros/tests/commit/test_elasticAl.mac
@@ -7,8 +7,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/tests/commit/test_elasticAl_DS.mac
+++ b/macros/tests/commit/test_elasticAl_DS.mac
@@ -7,8 +7,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/tests/commit/test_elasticAl_US.mac
+++ b/macros/tests/commit/test_elasticAl_US.mac
@@ -7,8 +7,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/tests/commit/test_inelastic.mac
+++ b/macros/tests/commit/test_inelastic.mac
@@ -7,8 +7,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/tests/commit/test_inelasticAl.mac
+++ b/macros/tests/commit/test_inelasticAl.mac
@@ -7,8 +7,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/tests/commit/test_moller.mac
+++ b/macros/tests/commit/test_moller.mac
@@ -7,8 +7,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/tests/commit/test_pion.mac
+++ b/macros/tests/commit/test_pion.mac
@@ -8,8 +8,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/tests/commit/test_power.mac
+++ b/macros/tests/commit/test_power.mac
@@ -7,8 +7,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Beam energy
 /remoll/evgen/set beam

--- a/macros/tests/commit/test_raster.mac
+++ b/macros/tests/commit/test_raster.mac
@@ -7,8 +7,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/tests/release/test_moller.mac
+++ b/macros/tests/release/test_moller.mac
@@ -7,8 +7,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true

--- a/macros/tests/unit/test_fields.mac
+++ b/macros/tests/unit/test_fields.mac
@@ -5,28 +5,8 @@
 /remoll/field/value 0.0 -0.16 9.55
 /remoll/field/value +0.16 0.0 9.55
 /remoll/field/value -0.16 0.0 9.55
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 /remoll/field/value 0.0 +0.16 9.55
 /remoll/field/value 0.0 -0.16 9.55
 /remoll/field/value +0.16 0.0 9.55
 /remoll/field/value -0.16 0.0 9.55
-
-/remoll/field/value +0.00037 +0.014 9.55
-/remoll/field/value +0.00037 -0.014 9.55
-/remoll/field/value +0.014 +0.00037 9.55
-/remoll/field/value -0.014 +0.00037 9.55
-/remoll/field/value -0.00037 +0.014 9.55
-/remoll/field/value -0.00037 -0.014 9.55
-/remoll/field/value +0.014 -0.00037 9.55
-/remoll/field/value -0.014 -0.00037 9.55
-#/remoll/addfield map_directory/hybridSymmetric_sensR_0.0.txt
-#/remoll/addfield map_directory/upstreamSymmetric_sensR_0.0.txt
-/remoll/field/value +0.00037 +0.014 9.55
-/remoll/field/value +0.00037 -0.014 9.55
-/remoll/field/value +0.014 +0.00037 9.55
-/remoll/field/value -0.014 +0.00037 9.55
-/remoll/field/value -0.00037 +0.014 9.55
-/remoll/field/value -0.00037 -0.014 9.55
-/remoll/field/value +0.014 -0.00037 9.55
-/remoll/field/value -0.014 -0.00037 9.55

--- a/macros/tests/unit/test_polarization.mac
+++ b/macros/tests/unit/test_polarization.mac
@@ -2,8 +2,7 @@
 
 /control/execute macros/kryptonite.mac
 
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 /remoll/gen moller
 

--- a/macros/tests/valgrind/test_moller.mac
+++ b/macros/tests/valgrind/test_moller.mac
@@ -5,8 +5,7 @@
 /run/initialize
 
 # Field maps
-/remoll/addfield map_directory/blockyHybrid_rm_3.0.txt
-/remoll/addfield map_directory/blockyUpstream_rm_1.1.txt
+/control/execute macros/load_magnetic_fieldmaps.mac
 
 # Raster and initial angle stuff
 /remoll/oldras true


### PR DESCRIPTION
This also changes somewhat the method of loading magnetic field maps,
for easier maintenance. The current 'official' magnetic field maps are
loaded by the macros/load_magnetic_fieldmaps.mac macro. You are
encouraged to use `/control/execute macros/load_magnetic_fieldmaps.mac`
in your macros so you always have the latest field maps.

Current 'official' field maps:
```
/remoll/addfield map_directory/segmentedJLAB_v2.txt
/remoll/addfield map_directory/upstreamJLAB_v2.txt
```
(per discussion with @rahmans1) 

Since these are new fieldmaps, they will be downloaded for you when you run the next make or cmake.