### PR TITLE
Feature mod2 bshield

### DIFF
--- a/geometry/upstream/upstreamBeampipe.gdml
+++ b/geometry/upstream/upstreamBeampipe.gdml
@@ -17,16 +17,16 @@
 
 
      <polycone name="solid_shield_US_beampipe_l" aunit="deg" startphi="0" deltaphi="360" lunit="mm">
-      <zplane rmin="15" rmax="24" z="-1945/2"/>
+      <zplane rmin="16" rmax="24" z="-1945/2"/>
       <zplane rmin="19" rmax="27" z="-1945/2+950"/>
-      <zplane rmin="22" rmax="27" z="-1945/2+1945"/>
+      <zplane rmin="23" rmax="28" z="-1945/2+1945"/>
      </polycone>
 
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_shield_US_beampipe_mother">
       <zplane rmin="0" rmax="24" z="-1945/2"/>
       <zplane rmin="0" rmax="27" z="-1945/2+950"/>
-      <zplane rmin="0" rmax="27" z="-1945/2+1945"/>
+      <zplane rmin="0" rmax="28" z="-1945/2+1945"/>
      </polycone>
 
 

--- a/geometry/upstream/upstreamBeampipe.gdml
+++ b/geometry/upstream/upstreamBeampipe.gdml
@@ -28,7 +28,7 @@
       <zplane rmin="0" rmax="27" z="-1945/2+950"/>
       <zplane rmin="0" rmax="27" z="-1945/2+1945"/>
      </polycone>
-p
+
 
     
 </solids>

--- a/geometry/upstream/upstreamBeampipe.gdml
+++ b/geometry/upstream/upstreamBeampipe.gdml
@@ -5,13 +5,6 @@
 
 
 <define>
-<!--CAD based shielding beampipe for col-1 to end of US magnet -->
-    <constant name="shield_US_beampipe_length" value="1945"/>
-    <constant name="shield_US_beampipe_thickness" value="3"/>
-    <constant name="shield_US_beampipe_US_rmin" value="25.5"/>
-    <constant name="shield_US_beampipe_DS_rmin" value="28.5"/>
-    <constant name="shield_US_beampipe_US_rmax" value="shield_US_beampipe_US_rmin+shield_US_beampipe_thickness"/>
-    <constant name="shield_US_beampipe_DS_rmax" value="shield_US_beampipe_DS_rmin+shield_US_beampipe_thickness"/>
 </define>
 
 
@@ -20,24 +13,38 @@
 
 
 <solids>
-<!-- inner photon collimating beampipe near collimator 1 -->
-    <cone aunit="deg" deltaphi="360" lunit="mm" name="solid_shield_US_beampipe_1" rmax1="shield_US_beampipe_US_rmax" rmax2="shield_US_beampipe_DS_rmax" rmin1="shield_US_beampipe_US_rmin" rmin2="shield_US_beampipe_DS_rmin" startphi="0" z="shield_US_beampipe_length"/>
-    <cone aunit="deg" deltaphi="360" lunit="mm" name="solid_shield_US_beampipe_mother" rmax1="shield_US_beampipe_US_rmax" rmax2="shield_US_beampipe_DS_rmax" rmin1="0" rmin2="0" startphi="0" z="shield_US_beampipe_length"/>
 
+
+
+     <polycone name="solid_shield_US_beampipe_l" aunit="deg" startphi="0" deltaphi="360" lunit="mm">
+      <zplane rmin="15" rmax="24" z="-1945/2"/>
+      <zplane rmin="19" rmax="27" z="-1945/2+950"/>
+      <zplane rmin="22" rmax="27" z="-1945/2+1945"/>
+     </polycone>
+
+
+    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_shield_US_beampipe_mother">
+      <zplane rmin="0" rmax="24" z="-1945/2"/>
+      <zplane rmin="0" rmax="27" z="-1945/2+950"/>
+      <zplane rmin="0" rmax="27" z="-1945/2+1945"/>
+     </polycone>
+p
+
+    
 </solids>
 
 
 <structure>
  <volume name="shield_US_beampipe_1_logic">
-      <materialref ref="Tungsten"/>
-      <solidref ref="solid_shield_US_beampipe_1"/>
+      <materialref ref="G4_W"/>
+      <solidref ref="solid_shield_US_beampipe_l"/>
       <auxiliary auxtype="Color" auxvalue="blue"/>
       <auxiliary auxtype="SensDet" auxvalue="planeDet"/>
       <auxiliary auxtype="DetNo" auxvalue="55"/>
  </volume>
  
   <volume name="logicUpstreamBeampipe">
-      <materialref ref="Vacuum"/>
+      <materialref ref="G4_Galactic"/>
       <solidref ref="solid_shield_US_beampipe_mother"/> 
 
       <physvol name="shield_US_beampipe">

--- a/geometry/upstream/upstreamDaughter_merged.gdml
+++ b/geometry/upstream/upstreamDaughter_merged.gdml
@@ -584,13 +584,11 @@
         <volumeref ref="boxUSShieldColl1_logic"/>
         <position name="bosUSShieldColl1_pos" unit="mm" x="0" y="0" z="- USBoxmothersubtract_length/2"/>
       </physvol>
-      
-      <!--
+
       <physvol>
         <file name="upstream/upstreamBeampipe.gdml"/>
         <positionref ref="shield_US_beampipe_center"/>
       </physvol>
-      -->
    </volume>
 </structure>
 

--- a/geometry/upstream/upstreamDaughter_merged.gdml
+++ b/geometry/upstream/upstreamDaughter_merged.gdml
@@ -584,11 +584,13 @@
         <volumeref ref="boxUSShieldColl1_logic"/>
         <position name="bosUSShieldColl1_pos" unit="mm" x="0" y="0" z="- USBoxmothersubtract_length/2"/>
       </physvol>
-
+      
+      <!--
       <physvol>
         <file name="upstream/upstreamBeampipe.gdml"/>
         <positionref ref="shield_US_beampipe_center"/>
       </physvol>
+      -->
    </volume>
 </structure>
 


### PR DESCRIPTION
1) Changing the definition of upstream 2 bounce shield to be thicker temporarily. This needs to be optimized. The hotspot at the upstream toroid nose needs mitigation from beamline backgrounds only at the upstream end. So, the 2 bounce shield does not need to be thick all the way along.