### PR TITLE
Feature: smaller world: x="75000" y="50000" z="125000" lunit="mm"

### DIFF
--- a/geometry/hall/hallDaughter_acceptanceDefinition.gdml
+++ b/geometry/hall/hallDaughter_acceptanceDefinition.gdml
@@ -11,8 +11,8 @@
 <define>
   &matrices;
 
-  <constant name="width_mother" value="90000."/>
-  <constant name="height_mother" value="90000."/>
+  <constant name="width_mother" value="75000."/>
+  <constant name="height_mother" value="50000."/>
   <constant name="length_mother" value="90000."/>
 
   <!-- Hall - wall, floor and "dump" -->

--- a/geometry/hall/hallDaughter_dump.gdml
+++ b/geometry/hall/hallDaughter_dump.gdml
@@ -12,9 +12,9 @@
   &matrices;
 
   <constant name="i2cm" value="2.54"/>
-  <constant name="width_mother" value="190000."/>
-  <constant name="height_mother" value="190000."/>
-  <constant name="length_mother" value="190000."/>
+  <constant name="width_mother" value="75000."/>
+  <constant name="height_mother" value="50000."/>
+  <constant name="length_mother" value="125000."/>
 
   <constant name="radius_of_cylwall" value="26517.6"/><!--25460."/>-->
   <constant name="hall_cylwall_radius" value="radius_of_cylwall/10"/>

--- a/geometry/hall/hallDaughter_merged.gdml
+++ b/geometry/hall/hallDaughter_merged.gdml
@@ -11,8 +11,8 @@
 <define>
   &matrices;
 
-  <constant name="width_mother" value="90000."/>
-  <constant name="height_mother" value="90000."/>
+  <constant name="width_mother" value="75000."/>
+  <constant name="height_mother" value="50000."/>
   <constant name="length_mother" value="90000."/>
 
   <!-- Hall - wall, floor and "dump" -->

--- a/geometry/hall/hallDaughter_noShlds.gdml
+++ b/geometry/hall/hallDaughter_noShlds.gdml
@@ -11,8 +11,8 @@
 <define>
   &matrices;
 
-  <constant name="width_mother" value="90000."/>
-  <constant name="height_mother" value="90000."/>
+  <constant name="width_mother" value="75000."/>
+  <constant name="height_mother" value="50000."/>
   <constant name="length_mother" value="90000."/>
 
   <!-- Hall - wall, floor and "dump" -->

--- a/geometry/solids/world.xml
+++ b/geometry/solids/world.xml
@@ -1,8 +1,8 @@
 <!-- Physical world extent: 200 m cube around the origin of the world,
      which is picked at the center of the MOLLER target -->
-<box lunit="mm" name="world_solid"    x="200000" y="200000" z="200000"/>
+<box lunit="mm" name="world_solid"    x="75000" y="50000" z="125000"/>
 
 <!-- Parallel world must be smaller than the physical world,
      private communcation with Makoto Asai -->
-<box lunit="mm" name="parallel_solid" x="199999" y="199999" z="199999"/>
+<box lunit="mm" name="parallel_solid" x="74999" y="49999" z="124999"/>
 


### PR DESCRIPTION
Until now the world was 200 m cubed; this reduces this to 125 m in the z direction only, 75 m left/right, and 50 m up/down.

All particles are tracked all the way to the edge of the world (which is filled with G4_AIR, not vacuum). This probably won't speed up your simulations by enormous factors, but no need to waste cycles either :-)