### PR TITLE
Feature: Make daughter volumes transparent for improved visualization

### DIFF
--- a/geometry/electronics/subSBSbunker.gdml
+++ b/geometry/electronics/subSBSbunker.gdml
@@ -90,6 +90,7 @@
     <volume name="sbsbunker">
       <materialref ref="G4_AIR"/>
       <solidref ref="sbsBunkerRegion_s"/>
+      <auxiliary auxtype="Alpha" auxvalue="0.1"/>
 
       <physvol>
         <volumeref ref="IronShieldType1_l"/>

--- a/geometry/huts/lefthut.gdml
+++ b/geometry/huts/lefthut.gdml
@@ -65,6 +65,7 @@
   <volume name="lefthut_Det_inside_logic">
     <materialref ref="Vacuum"/>
     <solidref ref="lefthut_Det_inside_solid"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
     <auxiliary auxtype="SensDet" auxvalue="hutDet"/>
     <auxiliary auxtype="DetNo" auxvalue="6666"/>
@@ -76,6 +77,7 @@
     <materialref ref="Vacuum"/>
     <solidref ref="lefthut_Det_outside_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="hutDet"/>
     <auxiliary auxtype="DetNo" auxvalue="6667"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>
@@ -85,6 +87,7 @@
   <volume name="lefthut">
     <materialref ref="G4_Galactic"/>
     <solidref ref="lefthut_world_solid"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.1"/>
     
     <physvol name="lefthut_front_pv">
       <volumeref ref="lefthut_front_logic"/>

--- a/geometry/huts/righthut.gdml
+++ b/geometry/huts/righthut.gdml
@@ -66,6 +66,7 @@
     <materialref ref="Vacuum"/>
     <solidref ref="righthut_Det_inside_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="hutDet"/>
     <auxiliary auxtype="DetNo" auxvalue="6668"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>
@@ -76,6 +77,7 @@
     <materialref ref="Vacuum"/>
     <solidref ref="righthut_Det_outside_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="hutDet"/>
     <auxiliary auxtype="DetNo" auxvalue="6669"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>
@@ -85,6 +87,7 @@
   <volume name="righthut">
     <materialref ref="G4_Galactic"/>
     <solidref ref="righthut_world_solid"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.1"/>
     
     <physvol name="righthut_front_pv">
       <volumeref ref="righthut_front_logic"/>

--- a/geometry/target/subTargetRegion.gdml
+++ b/geometry/target/subTargetRegion.gdml
@@ -305,6 +305,7 @@
     <materialref ref="VacuumDet"/>
     <solidref ref="skyshineVacuumDet1_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="shyshineVacuumDet_1"/>
     <auxiliary auxtype="DetNo" auxvalue="5555"/>
   </volume>
@@ -313,6 +314,7 @@
     <materialref ref="VacuumDet"/>
     <solidref ref="skyshineVacuumDet2_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="shyshineVacuumDet_2"/>
     <auxiliary auxtype="DetNo" auxvalue="5556"/>
   </volume>
@@ -321,6 +323,7 @@
     <materialref ref="VacuumDet"/>
     <solidref ref="tgtOuterDetyz_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="tgtOuterDet0"/>
     <auxiliary auxtype="DetNo" auxvalue="5540"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>
@@ -331,6 +334,7 @@
     <materialref ref="VacuumDet"/>
     <solidref ref="tgtOuterDetyz_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="tgtOuterDet0"/>
     <auxiliary auxtype="DetNo" auxvalue="5541"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>
@@ -342,6 +346,7 @@
     <materialref ref="VacuumDet"/>
     <solidref ref="tgtOuterDetxy_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="tgtOuterDet0"/>
     <auxiliary auxtype="DetNo" auxvalue="5542"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>
@@ -352,6 +357,7 @@
     <materialref ref="VacuumDet"/>
     <solidref ref="tgtOuterDetxy_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="tgtOuterDet0"/>
     <auxiliary auxtype="DetNo" auxvalue="5543"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>
@@ -362,6 +368,7 @@
     <materialref ref="VacuumDet"/>
     <solidref ref="tgtInnerDetyz_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="tgtInnerDet0"/>
     <auxiliary auxtype="DetNo" auxvalue="5544"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>
@@ -372,6 +379,7 @@
     <materialref ref="VacuumDet"/>
     <solidref ref="tgtInnerDetyz_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="tgtInnerDet0"/>
     <auxiliary auxtype="DetNo" auxvalue="5545"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>
@@ -383,6 +391,7 @@
     <materialref ref="VacuumDet"/>
     <solidref ref="tgtInnerDetxy_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="tgtInnerDet0"/>
     <auxiliary auxtype="DetNo" auxvalue="5546"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>
@@ -393,6 +402,7 @@
     <materialref ref="VacuumDet"/>
     <solidref ref="tgtInnerDetxy_solid"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.5"/>
     <auxiliary auxtype="SensDet" auxvalue="tgtInnerDet0"/>
     <auxiliary auxtype="DetNo" auxvalue="5547"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>


### PR DESCRIPTION
This makes the non-physical daughter volumes transparent with alpha = 0.1. All physical volumes (shielding etc) are still opaque.

![image](https://user-images.githubusercontent.com/4656391/93685948-a507e900-fa78-11ea-9723-5f9074ddd8f0.png)
