### PR TITLE
Feature: strong reproducibility and random states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ G4Worker?_run*evt*.rndm
 run*evt*.rndm
 currentEvent.rndm
 currentRun.rndm
+*.state
+*.rndm
 
 # output from createHTML
 _remoll_*.html

--- a/README.replay.md
+++ b/README.replay.md
@@ -1,0 +1,52 @@
+## Replaying simulated events
+
+These instructions explain how to replay exactly some previously simulated events.
+
+### Run the original large-N simulations
+
+Not every simulation output file can automatically be used to replay certian events.
+
+You must enable storing the random seed status for each event with the following flag enabled:
+```
+/run/storeRndmStatToEvent 1
+```
+
+### Select events of interest
+
+Now, we select a small-ish number of events in the ROOT tree. You will need to use `reroot` for this.
+
+Example:
+
+Suppose you have identified that all events in the following histogram are of interest for replaying:
+```
+T->Draw("hit.r","hit.det==8001 && hit.pid!=22 && hit.trid>2 && hit.r<1100*mm")
+```
+You can now tell ROOT to write out the random engine state files for those events:
+```
+T->Draw("hit.r*seed.Save()","hit.det==8001 && hit.pid!=22 && hit.trid>2 && hit.r<1100*mm")
+```
+The `seed.Save()` function always just returns 1, and writes the random engine state files.
+
+You should end up with a bunch of files with names like `run0evt118.state`.
+
+### Convert random state file format
+
+Next, we convert the state files into a different file format and set them up to go to individual runs. This will allow you to click through them one by one.
+```
+scripts/convert-mixmaxrng-states-to-runs.sh run0evt*.state
+```
+You should end up with a bunch of files with names like `run0evt0.rndm`, `run1evt0.rndm`, etc. They will all be event number 0 in consecutive runs.
+
+Note that the wildcard will sort alphabetically, not by event number, so it will sort `run0evt225.state` before `run0evt31.state`. That is the order that the `run0evt0.rndm`, `run1evt0.rndm` files will be in.
+
+### Replay the events in remoll
+
+Finally, start remoll interactively and execute exactly the same setup as in the first step: same geometry, physics list, etc.
+
+Before starting an actual event simulation, tell it to load the `run0evt0.rndm`, `run1evt0.rndm` files with
+```
+/random/resetEngineFromEachEvent 1
+```
+Now you can rerun each event again with `/run/beamOn 1`, or the play button on the graphical interface. Whenever it is starting a new run (of 1 event, in this case) and a new event, it will first check for the `run0evt0.rndm`, `run1evt0.rndm` files.
+
+Note: If you click play beyond the end of any stored events, it will just generate regular random events (and it will not warn you about this).

--- a/include/remollIO.hh
+++ b/include/remollIO.hh
@@ -65,7 +65,7 @@ class remollSeed_t: public TObject {
       name << "run" << fRunNo << "evt" << fEvtNo << ".state";
       std::ofstream file(name.str());
       file << fSeed;
-      return fSeed.Length();
+      return 1;
     };
   ClassDef(remollSeed_t,1);
 };

--- a/include/remollIO.hh
+++ b/include/remollIO.hh
@@ -62,7 +62,7 @@ class remollSeed_t: public TObject {
     // Save function for use in ROOT tree
     int Save() const {
       std::stringstream name;
-      name << "run" << fRunNo << "evt" << fEvtNo << ".rndm";
+      name << "run" << fRunNo << "evt" << fEvtNo << ".state";
       std::ofstream file(name.str());
       file << fSeed;
       return fSeed.Length();

--- a/macros/gui.mac
+++ b/macros/gui.mac
@@ -90,6 +90,7 @@
 #
 # Run menu :
 /gui/addMenu   run "7. Run"
+/gui/addButton run "Load from files" "/random/resetEngineFromEachEvent 1"
 /gui/addButton run "beamOn 1"    "/run/beamOn 1"
 /gui/addButton run "beamOn 2"    "/run/beamOn 2"
 /gui/addButton run "beamOn 5"    "/run/beamOn 5"

--- a/macros/tests/unit/test_rng_engine.C
+++ b/macros/tests/unit/test_rng_engine.C
@@ -1,0 +1,4 @@
+{
+  TFile f("remollout.root");
+  T->Scan("seed.Save()");
+}

--- a/macros/tests/unit/test_rng_engine.mac
+++ b/macros/tests/unit/test_rng_engine.mac
@@ -1,0 +1,57 @@
+# Store random state to events
+/run/storeRndmStatToEvent 1
+
+# Ensure rndm1 directory exists
+/control/shell mkdir -p rndm1
+/random/setDirectoryName rndm1
+# Store random state to files
+/random/setSavingFlag 1
+/random/saveEachEventFlag 1
+
+# Run 10 events
+/run/initialize
+/run/beamOn 10
+
+# Write all random states for run 1
+/control/shell build/reroot -l -q macros/tests/unit/test_rng_engine.C
+
+# Ensure rndm1 directory exists
+/control/shell mkdir -p rndm2
+/random/setDirectoryName rndm2
+
+# Convert random state for event 5
+# Note: resetEngineFromEachEvent reads from current directory
+/control/shell scripts/convert-mixmaxrng-state.sh run0evt9.state > run1evt0.rndm
+/control/shell scripts/convert-mixmaxrng-state.sh run0evt8.state > run1evt1.rndm
+/control/shell scripts/convert-mixmaxrng-state.sh run0evt7.state > run1evt2.rndm
+/control/shell scripts/convert-mixmaxrng-state.sh run0evt6.state > run1evt3.rndm
+/control/shell scripts/convert-mixmaxrng-state.sh run0evt5.state > run1evt4.rndm
+/control/shell scripts/convert-mixmaxrng-state.sh run0evt4.state > run1evt5.rndm
+/control/shell scripts/convert-mixmaxrng-state.sh run0evt3.state > run1evt6.rndm
+/control/shell scripts/convert-mixmaxrng-state.sh run0evt2.state > run1evt7.rndm
+/control/shell scripts/convert-mixmaxrng-state.sh run0evt1.state > run1evt8.rndm
+/control/shell scripts/convert-mixmaxrng-state.sh run0evt0.state > run1evt9.rndm
+
+# Reset engine for each event
+/random/resetEngineFromEachEvent 1
+
+# Run 10 events
+/run/beamOn 10
+
+# Write all random states for run 1
+/control/shell build/reroot -l -q macros/tests/unit/test_rng_engine.C
+
+# Compare random states on all events
+/control/shell diff --ignore-matching-lines ^MixMaxRng-begin run0evt0.state run1evt9.state
+/control/shell diff --ignore-matching-lines ^MixMaxRng-begin run0evt1.state run1evt8.state
+/control/shell diff --ignore-matching-lines ^MixMaxRng-begin run0evt2.state run1evt7.state
+/control/shell diff --ignore-matching-lines ^MixMaxRng-begin run0evt3.state run1evt6.state
+/control/shell diff --ignore-matching-lines ^MixMaxRng-begin run0evt4.state run1evt5.state
+/control/shell diff --ignore-matching-lines ^MixMaxRng-begin run0evt5.state run1evt4.state
+/control/shell diff --ignore-matching-lines ^MixMaxRng-begin run0evt6.state run1evt3.state
+/control/shell diff --ignore-matching-lines ^MixMaxRng-begin run0evt7.state run1evt2.state
+/control/shell diff --ignore-matching-lines ^MixMaxRng-begin run0evt8.state run1evt1.state
+/control/shell diff --ignore-matching-lines ^MixMaxRng-begin run0evt9.state run1evt0.state
+
+# Clean up
+# rm -rf *.rndm *.state rndm1 rndm2

--- a/scripts/convert-mixmaxrng-state.sh
+++ b/scripts/convert-mixmaxrng-state.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+if [ $# -lt 1 ] ; then
+	echo "Convert the MixMaxRNG engine state stream format into rndm file format."
+	echo "Usage (to stdout): `basename $0` [infile]"
+	exit
+fi
+
+# Convert file format like
+#
+#MixMaxRng-begin 30331785
+#58933861902009719
+#1785835428502820402
+#1423853375428307990
+#177508786414027104
+#605196243949405736
+#861701010447754611
+#2250242789326832084
+#1084033761752659819
+#1855444124088891051
+#242731982633356449
+#808181319309293506
+#1276833616859972515
+#632930668351273437
+#1854356059141373284
+#1573087033096440666
+#1508189008866546922
+#2274580468617938516
+#1
+#1826895464979352203
+#MixMaxRng-end
+#
+# written by
+#
+#std::ostream & MixMaxRng::put ( std::ostream& os ) const
+#{
+#   char beginMarker[] = "MixMaxRng-begin";
+#   char endMarker[]   = "MixMaxRng-end";
+#
+#   int pr = os.precision(24);
+#   os << beginMarker << " ";
+#   os << theSeed << "\n";
+#   for (int i=0; i<rng_get_N(); ++i) {
+#      os <<  S.V[i] << "\n";
+#   }
+#   os << S.counter << "\n";
+#   os << S.sumtot << "\n";
+#   os << endMarker << "\n";
+#   os.precision(pr);
+#   return os;
+#}
+#
+# to file format like
+#
+#mixmax state, file version 1.0
+#N=17; V[N]={428696617498718304, 2003704315588530340, 7947374056829315, 2067466587362700185, 1326222523634245003, 1332396546628397551, 1896238309733840482, 1762831144035715774, 1107589152016452107, 695071895453953411, 38056132400761332, 367356884968403023, 280167416724960677, 1069286741314982869, 1528898768234620464, 1682222665550640926, 96744019811349342}; counter=5; sumtot=1549996030519243448;
+#
+# written by
+#
+#     int j;
+#     fprintf(fh, "mixmax state, file version 1.0\n" );
+#     fprintf(fh, "N=%u; V[N]={", rng_get_N() );
+#     for (j=0; (j< (rng_get_N()-1) ); j++) {
+#         fprintf(fh, "%llu, ", S.V[j] );
+#     }
+#     fprintf(fh, "%llu", S.V[rng_get_N()-1] );
+#     fprintf(fh, "}; " );
+#     fprintf(fh, "counter=%u; ", S.counter );
+#     fprintf(fh, "sumtot=%llu;\n", S.sumtot );
+#
+
+# header line
+echo "mixmax state, file version 1.0"
+# remove begin/end markers
+grep -v "MixMaxRng" $1 | \
+	xargs | \
+	gawk '{print("N="NF-2"; V[N]={"$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9", "$10", "$11", "$12", "$13", "$14", "$15", "$16", "$17"}; counter="$18"; sumtot="$19";")}'

--- a/scripts/convert-mixmaxrng-states-to-runs.sh
+++ b/scripts/convert-mixmaxrng-states-to-runs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+dir=`dirname $0`
+dir=`realpath $dir`
+
+run=0
+while [ $# -gt 0 ] ; do
+	$dir/convert-mixmaxrng-state.sh $1 > run${run}evt0.rndm
+	let run=run+1
+	shift
+done


### PR DESCRIPTION
This is a bit technical, but hopefully leads to something useful: visualizing events selected from the ROOT file.

The main issue is of course that geant4 is doing its very best to simulate events that are as random as possible. How can you then visualize a single event in a run of 10M events that you are curious about? 

Some of the issues:
- Random engine state is not stored by default in the remoll output ROOT tree: an internal geant4 command exists and is used by remoll to store the `seed` variable, but documentation could be better (or we could enable this by default at about a 1% file size hit).
- CLHEP (which is the random engine that is used) writes the random engine status in a different format to a string stream compared to a file. What is stored in the ROOT tree is therefore not immediately useful but needs to be converted. This PR introduces a converter script.

Anyway, there's now a unit test that simulates 10 events, then simulates them once more in backwards order. The unit test checks that all events indeed have the correct random engine states stored in the ROOT tree.

Next, this needs a bit of docs to aid in visualizing that one event.