### PR TITLE
Feature: store random state to event by default

### DIFF
--- a/README.replay.md
+++ b/README.replay.md
@@ -4,9 +4,9 @@ These instructions explain how to replay exactly some previously simulated event
 
 ### Run the original large-N simulations
 
-Not every simulation output file can automatically be used to replay certian events.
+Not every simulation output file can automatically be used to replay certain events.
 
-You must enable storing the random seed status for each event with the following flag enabled:
+You must enable storing the random seed status for each event. This is done by default on recent versions of remoll, but on older versions you will need to run with the following flag enabled:
 ```
 /run/storeRndmStatToEvent 1
 ```

--- a/macros/tests/unit/test_rng_engine.mac
+++ b/macros/tests/unit/test_rng_engine.mac
@@ -1,5 +1,5 @@
-# Store random state to events
-/run/storeRndmStatToEvent 1
+# Disable storing random state to events to fail this test
+#/run/storeRndmStatToEvent 0
 
 # Ensure rndm1 directory exists
 /control/shell mkdir -p rndm1

--- a/src/remollRunAction.cc
+++ b/src/remollRunAction.cc
@@ -33,6 +33,9 @@ remollRunAction::remollRunAction()
 
   // Create timer
   fTimer = new G4Timer();
+
+  // Store random status before primary particle generation
+  G4RunManager::GetRunManager()->StoreRandomNumberStatusToG4Event(1);
 }
 
 remollRunAction::~remollRunAction()


### PR DESCRIPTION
`/run/storeRndmStatToEvent 1` is now the default (seed is stored before primary event generation).

Unit test and documentation updated.