### PR TITLE
Feature: default parallel world to mollerParallel instead of blank

### DIFF
--- a/macros/gui.mac
+++ b/macros/gui.mac
@@ -28,6 +28,7 @@
 /gui/addButton geom geometry/pionDetectorLucite.gdml         "/remoll/geometry/setfile geometry/pion/Lucite/pionDetectorLucite_world.gdml"
 /gui/addButton geom geometry/showerMaxDetector.gdml          "/remoll/geometry/setfile geometry/showerMaxDetector.gdml"
 /gui/addButton geom geometry/mollerParallel.gdml             "/remoll/parallel/setfile geometry/mollerParallel.gdml"
+/gui/addButton geom "No parallel"             "/remoll/parallel/setfile "
 #
 # Initialize menu :
 /gui/addMenu   phys "2. Physics"

--- a/src/remollParallelConstruction.cc
+++ b/src/remollParallelConstruction.cc
@@ -16,7 +16,7 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 remollParallelConstruction::remollParallelConstruction(const G4String& name, const G4String& gdmlfile)
 : G4VUserParallelWorld(name),
-  fGDMLPath("geometry"),fGDMLFile(""),
+  fGDMLPath("geometry"),fGDMLFile("mollerParallel.gdml"),
   fGDMLParser(0),
   fGDMLValidate(false),
   fGDMLOverlapCheck(false),

--- a/src/remollParallelConstruction.cc
+++ b/src/remollParallelConstruction.cc
@@ -39,7 +39,9 @@ remollParallelConstruction::remollParallelConstruction(const G4String& name, con
       "setfile",
       &remollParallelConstruction::SetGDMLFile,
       "Set parallel geometry GDML file")
-      .SetStates(G4State_PreInit);
+          .SetStates(G4State_PreInit)
+          .SetDefaultValue("")
+          .command->GetParameter(0)->SetOmittable(true);
   fParallelMessenger->DeclareProperty(
       "verbose",
       fVerboseLevel,


### PR DESCRIPTION
Default to a parallel world given by geometry/mollerParallel.gdml instead of blank. This will cause regular `build/remoll` to automatically show parallel world planes as well in visualization.