### PR TITLE
[gdml] reference to defined position needs `positionref` tag

### DIFF
--- a/geometry/hybrid/hybridDaughter_merged.gdml
+++ b/geometry/hybrid/hybridDaughter_merged.gdml
@@ -255,7 +255,7 @@
     <subtraction name ="boxDSShield1_local_solid">
       <first ref="boxDSShield1_local_solid_1"/>
       <second ref="DSShield_local_opening_solid"/>
-      <position ref="boxDSShield_local_trans"/>
+      <positionref ref="boxDSShield_local_trans"/>
     </subtraction>
 
     <!--collar solids -->


### PR DESCRIPTION
This does not affect the simulation since `boxDSShield_local_trans` was anyway defined as zero. But that's only until someone decides to change it...

@rahmans1 Is this file generated from something? Does it need to be changed upstream somewhere?