### PR TITLE
[gdml] rename element to symbol, as name clashes with materials

### DIFF
--- a/geometry/materials.xml
+++ b/geometry/materials.xml
@@ -9,7 +9,7 @@
     <atom type="A" value="2.01"/>
   </isotope>
   
-  <element Z="1" formula="H" name="Hydrogen" >
+  <element Z="1" formula="H" name="H" >
     <fraction ref="H1" n="0.9999" />
     <fraction ref="H2" n="0.0001" />
   </element>
@@ -21,7 +21,7 @@
     <atom type="A" value="13.00"/>
   </isotope>
   
-  <element Z="6" formula="C" name="Carbon" >
+  <element Z="6" formula="C" name="C" >
     <fraction ref="C12" n="0.9893" />
     <fraction ref="C13" n="0.0107" />
   </element>
@@ -33,7 +33,7 @@
     <atom type="A" value="11.01"/>
   </isotope> 
   
-  <element Z="5" formula="B" name="Boron" >
+  <element Z="5" formula="B" name="B" >
     <fraction ref="B10" n="0.1990" />
     <fraction ref="B11" n="0.8010" />
   </element>
@@ -48,13 +48,13 @@
     <atom type="A" value="18.00"/>
   </isotope>
   
-  <element Z="8" formula="O" name="Oxygen" >
+  <element Z="8" formula="O" name="O" >
     <fraction ref="O16" n="0.9976" />
     <fraction ref="O17" n="0.0004" />
     <fraction ref="O18" n="0.0020" />
   </element>
   
-  <element Z="11" formula="Na" name="Sodium" >
+  <element Z="11" formula="Na" name="Na" >
     <atom value="22.99" />
   </element>
   
@@ -68,17 +68,13 @@
     <atom type="A" value="25.98"/>
   </isotope>
   
-  <element Z="12" formula="Mg" name="Magnesium" >
+  <element Z="12" formula="Mg" name="Mg" >
     <fraction ref="Mg24" n="0.7899" />
     <fraction ref="Mg25" n="0.1000" />
     <fraction ref="Mg26" n="0.1101" />
   </element>
   
-  <element Z="13" formula="Al" name="Aluminium" >
-    <atom value="26.98" />
-  </element>
- 
-  <element Z="13" formula="Al" name="Aluminum" >
+  <element Z="13" formula="Al" name="Al" >
     <atom value="26.98" />
   </element>
   
@@ -91,7 +87,7 @@
   <isotope name="Si30" Z="14" N="30">
     <atom type="A" value="29.97"/>
   </isotope>
-  <element Z="14" formula="Si" name="Silicon" >
+  <element Z="14" formula="Si" name="Si" >
     <fraction ref="Si28" n="0.9223" />
     <fraction ref="Si29" n="0.0468" />
     <fraction ref="Si30" n="0.0309" />
@@ -106,7 +102,7 @@
   <isotope name="K41" Z="19" N="41">
     <atom type="A" value="40.96"/>
   </isotope>
-  <element Z="19" formula="K" name="Potassium" >
+  <element Z="19" formula="K" name="K" >
     <fraction ref="K39" n="0.9326" />
     <fraction ref="K40" n="0.0001" />
     <fraction ref="K41" n="0.0673" />
@@ -130,7 +126,7 @@
   <isotope name="Ca48" Z="20" N="48">
     <atom type="A" value="47.95"/>
   </isotope>
-  <element Z="20" formula="Ca" name="Calcium" >
+  <element Z="20" formula="Ca" name="Ca" >
     <fraction ref="Ca40" n="0.9694" />
       <fraction ref="Ca42" n="0.0065" />
       <fraction ref="Ca43" n="0.0014" />
@@ -151,7 +147,7 @@
   <isotope name="Fe58" Z="26" N="58">
     <atom type="A" value="57.93"/>
   </isotope>
-  <element Z="26" formula="Fe" name="Iron" >
+  <element Z="26" formula="Fe" name="Fe" >
     <fraction ref="Fe54" n="0.0584" />
     <fraction ref="Fe56" n="0.9175" />
     <fraction ref="Fe54" n="0.0212" />
@@ -159,7 +155,7 @@
   </element>
 
 
-  <element Z="15" formula="P" name="Phosphorus" >
+  <element Z="15" formula="P" name="P" >
     <atom value="30.97" />
   </element>
 
@@ -178,7 +174,7 @@
   <isotope name="Ti50" Z="22" N="50">
     <atom type="A" value="49.94"/>
   </isotope>
-  <element Z="22" formula="Ti" name="Titanium" >
+  <element Z="22" formula="Ti" name="Ti" >
     <fraction ref="Ti46" n="0.0825" />
     <fraction ref="Ti47" n="0.0744" />
     <fraction ref="Ti48" n="0.7372" />
@@ -186,7 +182,7 @@
     <fraction ref="Ti50" n="0.0518" />
   </element>
 
-  <element Z="25" formula="P" name="Manganese" >
+  <element Z="25" formula="P" name="Mn" >
     <atom value="54.94" />
   </element>
 
@@ -196,7 +192,7 @@
   <isotope name="V51" Z="23" N="51">
     <atom type="A" value="50.94"/>
   </isotope>
-  <element Z="23" formula="V" name="Vanadium" >
+  <element Z="23" formula="V" name="V" >
     <fraction ref="V50" n="0.0025" />
     <fraction ref="V51" n="0.9975" />
   </element>
@@ -213,7 +209,7 @@
   <isotope name="S36" Z="16" N="36">
     <atom type="A" value="35.97"/>
   </isotope>
-  <element Z="16" formula="S" name="Sulfur" >
+  <element Z="16" formula="S" name="S" >
     <fraction ref="S32" n="0.9493" />
     <fraction ref="S33" n="0.0076" />
     <fraction ref="S34" n="0.0429" />
@@ -226,7 +222,7 @@
   <isotope name="N15" Z="7" N="15">
     <atom type="A" value="15.00"/>
   </isotope>
-  <element Z="7" formula="N" name="Nitrogen" >
+  <element Z="7" formula="N" name="N" >
     <fraction ref="N14" n="0.9963" />
     <fraction ref="N15" n="0.0037" />
   </element>
@@ -272,8 +268,8 @@
     -->
   <material name="Polythene" state="solid">
     <D value="0.940" unit="g/cm3"/>
-    <fraction n="0.1437" ref="Hydrogen"/>
-    <fraction n="0.8563" ref="Carbon"/>
+    <fraction n="0.1437" ref="H"/>
+    <fraction n="0.8563" ref="C"/>
   </material>
 
   <!--
@@ -281,44 +277,44 @@
     -->
   <material name="Borated_Polythene" state="solid">
     <D value="1.190" unit="g/cm3"/>
-    <fraction n="0.3000" ref="Boron"/>
-    <fraction n="0.1006" ref="Hydrogen"/>
-    <fraction n="0.5994" ref="Carbon"/>
+    <fraction n="0.3000" ref="B"/>
+    <fraction n="0.1006" ref="H"/>
+    <fraction n="0.5994" ref="C"/>
   </material>
 
   <!--
      Based on Material:  Borated_Concrete    density:  2.420 g/cm3   RadL:  15.095 cm   Nucl.Int.Length:  34.629 cm   Imean:  94.872 eV from PREX geometry
   -->
   <material name="Borated_Concrete" state="solid">
-	<D value="2.42" unit="g/cm3"/>
-	<fraction n="0.5500" ref="Boron"/>
-	<fraction n="0.0045" ref="Hydrogen"/>
-	<fraction n="0.0005" ref="Carbon"/>
-	<fraction n="0.2381" ref="Oxygen"/>
-	<fraction n="0.0072" ref="Sodium"/>
-	<fraction n="0.0009" ref="Magnesium"/>
-	<fraction n="0.0152" ref="Aluminium"/>
-	<fraction n="0.1517" ref="Silicon"/>
-	<fraction n="0.0058" ref="Potassium"/>
-	<fraction n="0.0198" ref="Calcium"/>	
-	<fraction n="0.0063" ref="Iron"/>
+        <D value="2.42" unit="g/cm3"/>
+        <fraction n="0.5500" ref="B"/>
+        <fraction n="0.0045" ref="H"/>
+        <fraction n="0.0005" ref="C"/>
+        <fraction n="0.2381" ref="O"/>
+        <fraction n="0.0072" ref="Na"/>
+        <fraction n="0.0009" ref="Mg"/>
+        <fraction n="0.0152" ref="Al"/>
+        <fraction n="0.1517" ref="Si"/>
+        <fraction n="0.0058" ref="K"/>
+        <fraction n="0.0198" ref="Ca"/>
+        <fraction n="0.0063" ref="Fe"/>
   </material>
 
   <!--
      Based on Material:  Polycrete    density:  3.750 g/cm3   RadL:   8.462 cm   Nucl.Int.Length:  21.814 cm   Imean:  87.486 eV from PREX geometry
     -->
   <material name="Poly_Concrete" state="solid">
-	<D value="2.42" unit="g/cm3"/>
-	<fraction n="0.0635" ref="Hydrogen"/>
-	<fraction n="0.3431" ref="Carbon"/>
-	<fraction n="0.3175" ref="Oxygen"/>
-	<fraction n="0.0096" ref="Sodium"/>
-	<fraction n="0.0012" ref="Magnesium"/>
-	<fraction n="0.0203" ref="Aluminium"/>
-	<fraction n="0.2022" ref="Silicon"/>
-	<fraction n="0.0078" ref="Potassium"/>
-	<fraction n="0.0264" ref="Calcium"/>	
-	<fraction n="0.0084" ref="Iron"/>
+        <D value="2.42" unit="g/cm3"/>
+        <fraction n="0.0635" ref="H"/>
+        <fraction n="0.3431" ref="C"/>
+        <fraction n="0.3175" ref="O"/>
+        <fraction n="0.0096" ref="Na"/>
+        <fraction n="0.0012" ref="Mg"/>
+        <fraction n="0.0203" ref="Al"/>
+        <fraction n="0.2022" ref="Si"/>
+        <fraction n="0.0078" ref="K"/>
+        <fraction n="0.0264" ref="Ca"/>
+        <fraction n="0.0084" ref="Fe"/>
   </material>
 
   <!--
@@ -326,16 +322,16 @@
     -->
   <material name="Concrete" state="solid">
     <D value="2.3" unit="g/cm3"/>
-    <fraction n="0.010" ref="Hydrogen"/>
-    <fraction n="0.001" ref="Carbon"/>
-    <fraction n="0.529" ref="Oxygen"/>
-    <fraction n="0.016" ref="Sodium"/>
-    <fraction n="0.002" ref="Magnesium"/>
-    <fraction n="0.034" ref="Aluminium"/>
-    <fraction n="0.337" ref="Silicon"/>
-    <fraction n="0.013" ref="Potassium"/>
-    <fraction n="0.044" ref="Calcium"/>
-    <fraction n="0.014" ref="Iron"/>
+    <fraction n="0.010" ref="H"/>
+    <fraction n="0.001" ref="C"/>
+    <fraction n="0.529" ref="O"/>
+    <fraction n="0.016" ref="Na"/>
+    <fraction n="0.002" ref="Mg"/>
+    <fraction n="0.034" ref="Al"/>
+    <fraction n="0.337" ref="Si"/>
+    <fraction n="0.013" ref="K"/>
+    <fraction n="0.044" ref="Ca"/>
+    <fraction n="0.014" ref="Fe"/>
   </material>
 
   <!--
@@ -343,21 +339,21 @@
     -->
   <material name="HD_Concrete" state="solid">
     <D value="3.9" unit="g/cm3"/>
-    <fraction n="0.608" ref="Iron"/>
-    <fraction n="0.313" ref="Oxygen"/>
-    <fraction n="0.044" ref="Calcium"/>
-    <fraction n="0.019" ref="Silicon"/>
-    <fraction n="0.004" ref="Hydrogen"/>
-    <fraction n="0.004" ref="Magnesium"/>
-    <fraction n="0.003" ref="Phosphorus"/>
-    <fraction n="0.002" ref="Titanium"/>
-    <fraction n="0.0017" ref="Aluminium"/>
-    <fraction n="0.0006" ref="Potassium"/>
-    <fraction n="0.0006" ref="Manganese"/>
-    <fraction n="0.0005" ref="Vanadium"/>
-    <fraction n="0.0004" ref="Carbon"/>
-    <fraction n="0.0001" ref="Sulfur"/>
-    <fraction n="0.00003" ref="Nitrogen"/>
+    <fraction n="0.608" ref="Fe"/>
+    <fraction n="0.313" ref="O"/>
+    <fraction n="0.044" ref="Ca"/>
+    <fraction n="0.019" ref="Si"/>
+    <fraction n="0.004" ref="H"/>
+    <fraction n="0.004" ref="Mg"/>
+    <fraction n="0.003" ref="P"/>
+    <fraction n="0.002" ref="Ti"/>
+    <fraction n="0.0017" ref="Al"/>
+    <fraction n="0.0006" ref="K"/>
+    <fraction n="0.0006" ref="Mn"/>
+    <fraction n="0.0005" ref="V"/>
+    <fraction n="0.0004" ref="C"/>
+    <fraction n="0.0001" ref="S"/>
+    <fraction n="0.00003" ref="N"/>
   </material>
 
   <material Z="1" name="VacuumColl" state="gas">
@@ -426,8 +422,8 @@
   <!-- Defined for the next material "Water-CW" for Col1 water channel -->
   <material name="Water" state="liquid">
     <D value="1.0" unit="g/cm3"/>
-    <fraction n="0.667" ref="Hydrogen"/>
-    <fraction n="0.333" ref="Oxygen"/>
+    <fraction n="0.667" ref="H"/>
+    <fraction n="0.333" ref="O"/>
   </material>
 
   <!--The following material is defined to aviod complicated coll1 design
@@ -441,8 +437,8 @@
   <material name="Tyvek" state="solid">
     <MEE unit="eV" value="56.5182975271737"/> 
     <D unit="g/cm3" value="0.96"/>
-    <fraction n="0.14396693036847" ref="Hydrogen"/>
-    <fraction n="0.85603306963153" ref="Carbon"/>
+    <fraction n="0.14396693036847" ref="H"/>
+    <fraction n="0.85603306963153" ref="C"/>
   </material>
 
   <material name="Quartz" state="solid">
@@ -451,8 +447,8 @@
     <MEE unit="eV" value="125.663004061076"/>
 
     <D unit="g/cm3" value="2.2"/>
-    <fraction n="0.467465468463971" ref="Silicon"/>
-    <fraction n="0.532534531536029" ref="Oxygen"/>
+    <fraction n="0.467465468463971" ref="Si"/>
+    <fraction n="0.532534531536029" ref="O"/>
   </material>
 
   <material name="Air" state="gas">
@@ -466,8 +462,8 @@
     <property name="YIELDRATIO" ref="General_Const_YIELDRATIO"/>  
     <MEE unit="eV" value="85.7030667332999"/>
     <D unit="g/cm3" value="0.00129"/>
-    <fraction n="0.7" ref="Nitrogen"/>
-    <fraction n="0.3" ref="Oxygen"/>
+    <fraction n="0.7" ref="N"/>
+    <fraction n="0.3" ref="O"/>
   </material>
 
   <material Z="19" name="Photocathode" state="solid">


### PR DESCRIPTION
In particular relevant for "Aluminum", which was both an element and a material. Will not have made a difference up to this point, but might when someone decides to make the aluminum more realistic by adding the 10% Cu, Zn, Mg alloy elements...