### PR TITLE
Hotfix: remollMagneticField name should be different from filename

### DIFF
--- a/include/remollMagneticField.hh
+++ b/include/remollMagneticField.hh
@@ -64,6 +64,7 @@ class remollMagneticField : public G4MagneticField {
         }
 
     private:
+	G4String fName;
 	G4String fFilename;
 
 	G4int fN[__NDIM];

--- a/src/remollMagneticField.cc
+++ b/src/remollMagneticField.cc
@@ -29,6 +29,7 @@
 
 remollMagneticField::remollMagneticField( G4String filename ){
 
+    fName = filename;
     fFilename = remollSearchPath::resolve(filename);
 
     // Initialize grid variables
@@ -62,12 +63,12 @@ G4String remollMagneticField::GetName(){
 	return G4String("");
     }
 
-    return fFilename;
+    return fName;
 }
 
 void remollMagneticField::SetFieldScale(G4double s){ 
     fFieldScale = s;
-    G4cout << fFilename << " scale set to " << s << G4endl;
+    G4cout << fName << " scale set to " << s << G4endl;
     return;
 }
 
@@ -76,7 +77,7 @@ void remollMagneticField::SetMagnetCurrent(G4double s){
        	SetFieldScale(s/fMagCurrent0);
     } else {
     	G4cerr << "Warning:  " << __FILE__ << " line " << __LINE__ 
-	    << ": Field current not specified in map " << fFilename << " - Ignoring and proceeding " << G4endl;
+	    << ": Field current not specified in map " << fName << " - Ignoring and proceeding " << G4endl;
     }
     return;
 }
@@ -94,7 +95,7 @@ void remollMagneticField::InitializeGrid() {
 	exit(1);
     }
 
-    G4cout << "Initializing field map grid for " << fFilename << G4endl;
+    G4cout << "Initializing field map grid for " << fName << G4endl;
     G4int cidx, ridx, pidx, zidx;
 
     for( cidx = kR; cidx <= kZ; cidx++ ){
@@ -115,7 +116,7 @@ void remollMagneticField::InitializeGrid() {
 	} // end of r
     } // end coordinate index
 
-    G4cout << "Map grid for " << fFilename << " initialized" << G4endl;
+    G4cout << "Map grid for " << fName << " initialized" << G4endl;
 
     return;
 }


### PR DESCRIPTION
With the new search path resolution, the sequence went about like this, for master thread and each worker thread (i.e. n_cores + 1):

1. /remoll/field/add requests to load map_directory/segmentedJLAB_v2.txt
2. remollGlobalField checks if field with **name** map_directory/segmentedJLAB_v2.txt is already loaded
3. if not loaded yet, remollMagneticField finds the map by that name in the search path, and **sets the name to the absolute path**.

This approach leads to the same field being loaded multiple times, and fields being 3 times too large.

With this bug fix, we make sure that the name of the field is the name it was originally requested by, not the filename.