### PR TITLE
Feature change magnet z offset

### DIFF
--- a/src/remollMagneticField.cc
+++ b/src/remollMagneticField.cc
@@ -42,7 +42,7 @@ remollMagneticField::remollMagneticField( G4String filename ){
 
     // Default offset for field maps in reference frame with
     // the hall pivot at z = 0.
-    fZoffset = -5000.0;
+    fZoffset = 0.0;
 
     fInit = false;
     fMagCurrent0 = -1e9;


### PR DESCRIPTION
With this pull request, all prior field maps will be unusable as default since they use the old target center (5m upstream of hall center) as reference. New field maps will be provided that use the hall center as reference 0. 