### PR TITLE
Feature: make rate variable work with beam generator

### DIFF
--- a/include/remollBeamTarget.hh
+++ b/include/remollBeamTarget.hh
@@ -62,7 +62,7 @@ class remollBeamTarget {
         remollBeamTarget();
 	virtual ~remollBeamTarget();
 
-	G4double GetEffLumin();
+	G4double GetEffLumin(SamplingType_t);
 
 	remollVertex SampleVertex(SamplingType_t);
 

--- a/include/remollBeamTarget.hh
+++ b/include/remollBeamTarget.hh
@@ -64,8 +64,7 @@ class remollBeamTarget {
 
 	G4double GetEffLumin();
 
-
-	remollVertex SampleVertex(SampType_t);
+	remollVertex SampleVertex(SamplingType_t);
 
 	G4double fBeamEnergy;
 	G4double fBeamCurrent;

--- a/include/remollVEventGen.hh
+++ b/include/remollVEventGen.hh
@@ -44,7 +44,9 @@ class remollVEventGen {
 	  fBeamTarg = bt;
 	}
 
-	void SetSampType( SampType_t st ) { fSampType = st; }
+	void SetSamplingType(SamplingType_t type) { fSamplingType = type; }
+	SamplingType_t GetSamplingType() const { return fSamplingType; }
+
 	void SetDoMultScatt( G4bool multscatt ){ fApplyMultScatt = multscatt; }
 
         void SetEmin(double emin) { fE_min = emin; }
@@ -90,7 +92,7 @@ public:
 
     protected:
 
-	SampType_t fSampType;
+	SamplingType_t fSamplingType;
 	G4bool     fApplyMultScatt;
 
     private:

--- a/include/remolltypes.hh
+++ b/include/remolltypes.hh
@@ -17,7 +17,11 @@
 
 #include "TTimeStamp.h"
 
-enum SampType_t { kNoTargetVolume, kActiveTargetVolume, kAllTargetVolumes };
+enum SamplingType_t {
+    kNoTargetVolume,
+    kActiveTargetVolume,
+    kAllTargetVolumes
+};
 
 struct filedata_t {
     char filename[__RUNSTR_LEN];

--- a/src/remollBeamTarget.cc
+++ b/src/remollBeamTarget.cc
@@ -176,13 +176,13 @@ void remollBeamTarget::SetActiveTargetVolume(G4String name)
 ////////////////////////////////////////////////////////////////////////////////////////////
 //  Sampling functions
 
-remollVertex remollBeamTarget::SampleVertex(SampType_t samp)
+remollVertex remollBeamTarget::SampleVertex(SamplingType_t sampling_type)
 {
     // Create vertex
     remollVertex vertex;
 
     // No sampling required
-    if (samp == kNoTargetVolume) {
+    if (sampling_type == kNoTargetVolume) {
       return vertex;
     }
 
@@ -208,7 +208,7 @@ remollVertex remollBeamTarget::SampleVertex(SampType_t samp)
 
     // Figure out how far along the target we got
     G4double total_effective_length = 0;
-    switch( samp ){
+    switch (sampling_type) {
         case kActiveTargetVolume:
             total_effective_length = fActiveTargetEffectiveLength;
             break;
@@ -257,7 +257,7 @@ remollVertex remollBeamTarget::SampleVertex(SampType_t samp)
         // Find position in this volume (if we are in it)
         G4double effective_position_in_volume;
         G4double actual_position_in_volume;
-        switch( samp ){
+        switch (sampling_type) {
 	    case kActiveTargetVolume:
 	        if ((*it)->GetLogicalVolume()->GetName() == fActiveTargetVolume ){
 	            // This is the active volume, and we only sample here

--- a/src/remollBeamTarget.cc
+++ b/src/remollBeamTarget.cc
@@ -82,8 +82,12 @@ remollBeamTarget::~remollBeamTarget()
     delete fMS;
 }
 
-G4double remollBeamTarget::GetEffLumin(){
-    return fEffectiveMaterialLength*fBeamCurrent/(e_SI*coulomb);
+G4double remollBeamTarget::GetEffLumin(SamplingType_t sampling_type)
+{
+    if (sampling_type == kNoTargetVolume)
+        return fBeamCurrent / (e_SI*coulomb); // no length, just frequency
+    else
+        return fBeamCurrent / (e_SI*coulomb) * fEffectiveMaterialLength;
 }
 
 void remollBeamTarget::PrintTargetInfo()

--- a/src/remollGenBeam.cc
+++ b/src/remollGenBeam.cc
@@ -177,7 +177,7 @@ void remollGenBeam::SamplePhysics(remollVertex * /*vert*/, remollEvent *evt)
         fParticleName,
         evt->fBeamPolarization);
 
-    evt->SetEffCrossSection(0.0);
+    evt->SetEffCrossSection(1.0);
     evt->SetAsymmetry(0.0);
 
     evt->SetQ2(0.0);

--- a/src/remollGenBeam.cc
+++ b/src/remollGenBeam.cc
@@ -33,7 +33,7 @@ remollGenBeam::remollGenBeam()
   fRasterRefZ(-4.5*m),
   fParticleName("e-")
 {
-    fSampType = kNoTargetVolume;
+    fSamplingType = kNoTargetVolume;
     fApplyMultScatt = true;
 
     fThisGenMessenger->DeclarePropertyWithUnit("origin","mm",fOriginMean,"origin position mean: x y z unit");

--- a/src/remollGenExternal.cc
+++ b/src/remollGenExternal.cc
@@ -26,7 +26,8 @@ remollGenExternal::remollGenExternal()
   fEvent(0), fHit(0),
   fzOffset(0), fDetectorID(28), fLoopID(1)
 {
-  fSampType = kNoTargetVolume;
+  fSamplingType = kNoTargetVolume;
+
   // Add to generic messenger
   fThisGenMessenger->DeclareMethod("file",&remollGenExternal::SetGenExternalFile,"External generator event filename");
   fThisGenMessenger->DeclareMethod("zOffset",&remollGenExternal::SetGenExternalZOffset,"External generator zOffset");

--- a/src/remollPrimaryGeneratorAction.cc
+++ b/src/remollPrimaryGeneratorAction.cc
@@ -204,11 +204,12 @@ void remollPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
     G4double nthrown = remollRun::GetRunData()->GetNthrown();
 
     // Calculate rate
+    SamplingType_t sampling_type = fEventGen->GetSamplingType();
     if (fEvent->fRate == 0) { // If the rate is set to 0 then calculate it using the cross section
-        fEvent->fRate  = fEvent->fEffXs * fBeamTarg->GetEffLumin() / nthrown;
+        fEvent->fRate  = fEvent->fEffXs * fBeamTarg->GetEffLumin(sampling_type) / nthrown;
 
     } else { // For LUND - calculate rate and cross section
-        fEvent->fEffXs = fEvent->fRate * nthrown / fBeamTarg->GetEffLumin();
+        fEvent->fEffXs = fEvent->fRate * nthrown / fBeamTarg->GetEffLumin(sampling_type);
         fEvent->fRate  = fEvent->fRate / nthrown;
     }
 

--- a/src/remollVEventGen.cc
+++ b/src/remollVEventGen.cc
@@ -49,7 +49,7 @@ remollVEventGen::remollVEventGen(const G4String name)
     // Create specific event generator messenger
     fThisGenMessenger = new G4GenericMessenger(this,"/remoll/evgen/" + name + "/","Remoll " + name + " generator properties");
 
-    fSampType       = kActiveTargetVolume;
+    fSamplingType       = kActiveTargetVolume;
     fApplyMultScatt = false;
 }
 
@@ -85,7 +85,7 @@ void remollVEventGen::SetNumberOfParticles(G4int n)
 remollEvent* remollVEventGen::GenerateEvent()
 {
     // Set up beam/target vertex
-    remollVertex vert   = fBeamTarg->SampleVertex(fSampType);
+    remollVertex vert   = fBeamTarg->SampleVertex(fSamplingType);
 
     /////////////////////////////////////////////////////////////////////
     // Create and initialize values for event


### PR DESCRIPTION
For the beam generator, the `rate` variable was filled with zero. This PR fills the `rate` variable so it works identical to the other generators.

The effective luminosity for physics process generators requires the effective target length *L &rho; N<sub>A</sub> / A* (target length L, density &rho;, Avogadro N<sub>A</sub>, atomic mass A) multiplied with the beam frequency I/e (beam current I, electron charge e) in the effective luminosity to multiply with the differential cross section &sigma; of the event times the phase space d&Omega;, all normalized over the total number of simulated events N.

When an event generator (such as the beam generator) has no target (kNoTargetVolume), we instead pass the beam frequency, I/e, with `GetEffLumin`, and pass a cross section of 1 in `fEffXs`. The product results in a weight of I/e/N per event.