### PR TITLE
Feature: require cxx 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,10 @@ include(CMakeEnv)
 # Use GNU install dirs
 include(GNUInstallDirs)
 
-# Request C++11 standard
-set(CMAKE_CXX_STANDARD 11)
+# Request C++17 standard
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_EXTENSIONS False)
+set(CMAKE_CXX_EXTENSIONS True)
 
 # MAC specific variable
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")


### PR DESCRIPTION
Several instances in the code already use c++17 syntax. It is aso required by recent geant4 versions. This pull request is also intended to get feedback:
- @rahmans1: Compute Canada?
- @chandabindu: Ifarm support?
- @cameronc137, @cipriangal: SBU cluster?
Just a test compilation and runexample.mac verification would be sufficient :-)