### PR TITLE
[cmake] do not force cxx standard (even though we use 17 constructs)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,6 @@ include(CMakeEnv)
 # Use GNU install dirs
 include(GNUInstallDirs)
 
-# Request C++11 standard
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_EXTENSIONS False)
-
 # MAC specific variable
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_MACOSX_RPATH ON)


### PR DESCRIPTION
We have to let ROOT define the cxx standard, due to the way ROOT operates (https://root.cern/install/build_from_source/#caveats).