### PR TITLE
Bugfix: [beam] if partname unknown, warn and exit instead of null pointer

### DIFF
--- a/src/remollGenBeam.cc
+++ b/src/remollGenBeam.cc
@@ -108,7 +108,14 @@ void remollGenBeam::SetPolarizationX(double sx){ fPolarization.setX(sx); }
 void remollGenBeam::SetPolarizationY(double sy){ fPolarization.setY(sy); }
 void remollGenBeam::SetPolarizationZ(double sz){ fPolarization.setZ(sz); }
 
-void remollGenBeam::SetPartName(G4String& name){ fParticleName = name; }
+void remollGenBeam::SetPartName(G4String& name){
+  G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
+  G4ParticleDefinition* particle = particleTable->FindParticle(name);
+  if (particle) fParticleName = name;
+  else {
+    G4cerr << "remollGenBeam: particle " << name << " not recognized." << G4endl;
+    exit(-1);
+  }
 
 G4double remollGenBeam::GetSpread(G4double spread, EOriginModel model)
 {

--- a/src/remollGenBeam.cc
+++ b/src/remollGenBeam.cc
@@ -116,6 +116,7 @@ void remollGenBeam::SetPartName(G4String& name){
     G4cerr << "remollGenBeam: particle " << name << " not recognized." << G4endl;
     exit(-1);
   }
+}
 
 G4double remollGenBeam::GetSpread(G4double spread, EOriginModel model)
 {


### PR DESCRIPTION
Too many times have I tried `/remoll/evgen/beam/partName pion` and wondered why it crashes during event generation. This puts the crash plainly where the incorrect partName is set.