### PR TITLE
Bugfix: [vis] turn off smooth trajectory due to endless memory leak warnings

### DIFF
--- a/vis/vis.mac
+++ b/vis/vis.mac
@@ -31,7 +31,7 @@
 #
 # Declare that trajectories and hits should be added to the scene
 #
-/vis/scene/add/trajectories smooth rich
+/vis/scene/add/trajectories rich
 /vis/scene/add/hits
 
 #


### PR DESCRIPTION
With `/vis/scene/add/trajectories smooth` there are many trajectory points created that result in memory leaks. Geant4 'helpfully' warns about it, but that floods the output with our typical events. The memory leak itself is probably not relevant since most visualization jobs are likely to run with few events anyway. If you need smooth trajectories, you will have to turn this on by hand.