### PR TITLE
Bugfix: [pion] fix light leakage at corners near PMT

### DIFF
--- a/geometry/pion/Lucite/pionDetectorLucite.gdml
+++ b/geometry/pion/Lucite/pionDetectorLucite.gdml
@@ -120,22 +120,31 @@
   <!-- y in downstream beam direction -->
   <!-- z in radial outward direction -->
   
-  <tube name="pionDetectorLucitePMTWindow_solid"
+  <box name="pionDetectorLucitePMTWindowSquare_solid"
+    x="pionDetectorLucitePMTDiameter"
+    y="pionDetectorLucitePMTDiameter"
+    z="pionDetectorLucitePMTThickness"/>
+  <tube name="pionDetectorLucitePMTWindowDisk_solid"
     rmin="0.0"
-    rmax="pionDetectorLucitePMTDiameter/2.0"
+    rmax="pionDetectorLucitePMTDiameter/2.0-pionDetectorLucitePMTHousingThickness"
     z="pionDetectorLucitePMTThickness"
     deltaphi="360.0" aunit="deg"/>
-  <tube name="pionDetectorLucitePMTInsideHousing_solid"
+
+  <tube name="pionDetectorLucitePMTHousingTubeInside_solid"
     rmin="0.0"
     rmax="pionDetectorLucitePMTDiameter/2.0-pionDetectorLucitePMTHousingThickness"
     z="(pionDetectorLucitePMTHousingHeight-pionDetectorLucitePMTHousingThickness-pionDetectorLucitePMTThickness)"
     deltaphi="360.0" aunit="deg"/>
-  <tube name="pionDetectorLucitePMTOutsideHousing_solid"
+  <tube name="pionDetectorLucitePMTHousingTubeOutside_solid"
     rmin="0.0"
     rmax="pionDetectorLucitePMTDiameter/2.0"
-    z="pionDetectorLucitePMTHousingHeight"
+    z="(pionDetectorLucitePMTHousingHeight-pionDetectorLucitePMTThickness)"
     deltaphi="360.0" aunit="deg"/>
-  <box name="pionDetectorLucitePMTOutsideHousingScaled_solid"
+  <box name="pionDetectorLucitePMTHousing_solid"
+    x="pionDetectorLucitePMTDiameter"
+    y="pionDetectorLucitePMTDiameter"
+    z="pionDetectorLucitePMTHousingHeight"/>
+  <box name="pionDetectorLucitePMTHousingAll_solid"
     x="SCALE_UP*numberOfPMTsInX*pionDetectorLucitePMTDiameter"
     y="SCALE_UP*numberOfPMTsInZ*pionDetectorLucitePMTDiameter"
     z="SCALE_UP*pionDetectorLucitePMTHousingHeight"/>
@@ -440,7 +449,7 @@
   </union>
   <union name="pionDetectorLucite_solid">
     <first ref="pionDetectorLucitePlanesReflectorLightGuideScaled_solid"/>
-    <second ref="pionDetectorLucitePMTOutsideHousingScaled_solid"/>
+    <second ref="pionDetectorLucitePMTHousingAll_solid"/>
     <position name="pionDetectorLucite_union_position"
       y="(pionDetectorLuciteAirThickness+pionDetectorLuciteMylarThickness+pionDetectorLuciteHeight+pionDetectorLuciteWedgeHeight)/2.0*tan(pionDetectorLuciteTheta)
               +(pionDetectorLuciteReflectorHeight)*tan(pionDetectorLuciteReflectorTheta)
@@ -632,10 +641,11 @@
       <volumeref ref="pionDetectorLuciteLightGuideInsideExitDetector_logical"/>
     </physvol>
   </volume>
+
   
-  <volume name="pionDetectorLucitePMTWindow_logical">
+  <volume name="pionDetectorLucitePMTWindowDisk_logical">
     <materialref ref="CsPhotocathode"/>
-    <solidref ref="pionDetectorLucitePMTWindow_solid"/>
+    <solidref ref="pionDetectorLucitePMTWindowDisk_solid"/>
     <auxiliary auxtype="SensDet" auxvalue="pionLucitePMTWindow"/>
     <auxiliary auxtype="DetNo" auxvalue="8000"/>
     <auxiliary auxtype="DetType" auxvalue="opticalphoton"/>
@@ -644,30 +654,47 @@
   </volume>
   <skinsurface name="pionDetectorLucitePMTWindow_skin"
     surfaceproperty="CsPhotocathode_surface">
-    <volumeref ref="pionDetectorLucitePMTWindow_logical"/>
+    <volumeref ref="pionDetectorLucitePMTWindowDisk_logical"/>
   </skinsurface>
+  <volume name="pionDetectorLucitePMTWindow_logical">
+    <materialref ref="G4_Al"/>
+    <solidref ref="pionDetectorLucitePMTWindowSquare_solid"/>
+    <physvol name="pionDetectorLucitePMTWindowDisk_physical">
+      <volumeref ref="pionDetectorLucitePMTWindowDisk_logical"/>
+    </physvol>
+  </volume>
 
-  <volume name="pionDetectorLucitePMTInsideHousing_logical">
-    <materialref ref="G4_AIR"/>
-    <solidref ref="pionDetectorLucitePMTInsideHousing_solid"/>
+  <volume name="pionDetectorLucitePMTHousingTubeInside_logical">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="pionDetectorLucitePMTHousingTubeInside_solid"/>
     <auxiliary auxtype="SensDet" auxvalue="pionLucitePMTHousing"/>
     <auxiliary auxtype="DetNo" auxvalue="8020"/>
     <auxiliary auxtype="DetType" auxvalue="opticalphoton"/>
     <auxiliary auxtype="Color" auxvalue="Blue"/>
     <auxiliary auxtype="Alpha" auxvalue="0.2"/>
   </volume>
-  <volume name="pionDetectorLucitePMTOutsideHousing_logical">
+  <volume name="pionDetectorLucitePMTHousingTube_logical">
     <materialref ref="G4_Al"/>
-    <solidref ref="pionDetectorLucitePMTOutsideHousing_solid"/>
+    <solidref ref="pionDetectorLucitePMTHousingTubeOutside_solid"/>
+    <physvol name="pionDetectorLucitePMTHousingTubeInside_physical">
+      <volumeref ref="pionDetectorLucitePMTHousingTubeInside_logical"/>
+      <position name="pionDetectorLucitePMTHousingTubeInside_position"
+        z="-pionDetectorLucitePMTHousingThickness/2.0"/>
+    </physvol>
+    <auxiliary auxtype="Alpha" auxvalue="0.9"/>
+  </volume>
+  <volume name="pionDetectorLucitePMTHousing_logical">
+    <materialref ref="G4_Al"/>
+    <solidref ref="pionDetectorLucitePMTHousing_solid"/>
+    <physvol name="pionDetectorLucitePMTHousingTube_physical">
+      <volumeref ref="pionDetectorLucitePMTHousingTube_logical"/>
+      <position name="pionDetectorLucitePMTHousingTube_position"
+        z="(+pionDetectorLucitePMTThickness)/2.0"/>
+    </physvol>
     <physvol name="pionDetectorLucitePMTWindow_physical">
       <volumeref ref="pionDetectorLucitePMTWindow_logical"/>
       <position name="pionDetectorLucitePMTWindow_position"
-        z="(-pionDetectorLucitePMTHousingHeight+pionDetectorLucitePMTHousingThickness)/2.0"/>
-    </physvol>
-    <physvol name="pionDetectorLucitePMTInsideHousing_physical">
-      <volumeref ref="pionDetectorLucitePMTInsideHousing_logical"/>
-      <position name="pionDetectorLucitePMTInsideHousing_position"
-        z="(+pionDetectorLucitePMTHousingThickness-pionDetectorLucitePMTThickness)/2.0"/>
+        z="(-pionDetectorLucitePMTHousingHeight+pionDetectorLucitePMTThickness)/2.0"/>
     </physvol>
     <auxiliary auxtype="Alpha" auxvalue="0.9"/>
   </volume>
@@ -713,9 +740,9 @@
          So we set to = from + 1 and use steps of 2 to get the same outcome. -->
     <loop for="iPMTX" from="1" to="2*numberOfPMTsInX" step="2">
       <loop for="iPMTZ" from="1" to="2*numberOfPMTsInZ" step="2">
-        <physvol name="pionDetectorLucitePMTOutsideHousing_physical">
-          <volumeref ref="pionDetectorLucitePMTOutsideHousing_logical"/>
-          <position name="pionDetectorLucitePMTOutsideHousing_position"
+        <physvol name="pionDetectorLucitePMTHousing_physical">
+          <volumeref ref="pionDetectorLucitePMTHousing_logical"/>
+          <position name="pionDetectorLucitePMTHousing_position"
             x="((iPMTX-1)/2-(numberOfPMTsInX-1)/2)*pionDetectorLucitePMTDiameter"
             y="(pionDetectorLuciteHeight+pionDetectorLuciteWedgeHeight)/2.0*tan(pionDetectorLuciteTheta)
               +pionDetectorLuciteReflectorHeight*tan(pionDetectorLuciteReflectorTheta)


### PR DESCRIPTION
Previously the round PMT surface was just put in the square lightguide end without closing up the holes on the side. This fixes that (but doesn't actually make those corners reflective; presumably a minor issue).