### PR TITLE
Bugfix: store git info string in root file

### DIFF
--- a/include/remollRunData.hh
+++ b/include/remollRunData.hh
@@ -51,9 +51,9 @@ class remollRunData : public TObject {
 	long int  fSeed;
 	double fBeamE;
 	char fGenName[__RUNSTR_LEN];
+	std::string fRunPath;
 
-	char fHostName[__RUNSTR_LEN];
-	char fRunPath[__RUNSTR_LEN];
+        std::string fHostName;
 
 	remollTextFile              fMacro;
 	std::vector<remollTextFile> fGDMLFiles;

--- a/include/remollRunData.hh
+++ b/include/remollRunData.hh
@@ -45,6 +45,7 @@ class remollRunData : public TObject {
 
 	void Print();
 
+        std::string fGitInfo;
 	TTimeStamp fRunTime;
 
 	long int  fNthrown;
@@ -60,7 +61,7 @@ class remollRunData : public TObject {
 
 	std::vector<filedata_t> fMagData;
 
-	ClassDef(remollRunData, 1);
+	ClassDef(remollRunData, 2);
 };
 
 #endif//__REMOLLRUNDATA_HH

--- a/include/remollRunData.hh
+++ b/include/remollRunData.hh
@@ -46,7 +46,6 @@ class remollRunData : public TObject {
 
 	long int  fNthrown;
 	long int  fSeed;
-	double fBeamE;
 	std::string fRunPath;
 
         std::string fHostName;

--- a/include/remollRunData.hh
+++ b/include/remollRunData.hh
@@ -28,8 +28,6 @@ class remollRunData : public TObject {
 
 	void Init();
 
-	void SetGenName(const char *n){ strcpy(fGenName, n); }
-	const char *GetGenName(){ return fGenName; }
 
 	void SetBeamE(double E){ fBeamE = E; }
 	void SetSeed(unsigned long int seed){ fSeed = seed; }
@@ -51,7 +49,6 @@ class remollRunData : public TObject {
 	long int  fNthrown;
 	long int  fSeed;
 	double fBeamE;
-	char fGenName[__RUNSTR_LEN];
 	std::string fRunPath;
 
         std::string fHostName;

--- a/include/remollRunData.hh
+++ b/include/remollRunData.hh
@@ -18,8 +18,8 @@
 class remollRunData : public TObject {
   using TObject::Print;
     public:
-	remollRunData();
-	virtual ~remollRunData();
+	remollRunData() { };
+	virtual ~remollRunData() { };
 
 	unsigned long long int GetNthrown(){ return fNthrown; }
 	void SetNthrown(unsigned long long int n){ fNthrown = n; }

--- a/include/remollRunData.hh
+++ b/include/remollRunData.hh
@@ -15,8 +15,6 @@
  * stream
 */
 
-class TGeoManager;
-
 class remollRunData : public TObject {
   using TObject::Print;
     public:

--- a/include/remollRunData.hh
+++ b/include/remollRunData.hh
@@ -21,39 +21,59 @@ class remollRunData : public TObject {
 	remollRunData() { };
 	virtual ~remollRunData() { };
 
-	unsigned long long int GetNthrown(){ return fNthrown; }
-	void SetNthrown(unsigned long long int n){ fNthrown = n; }
-
-	void Init();
-
-
-	void SetBeamE(double E){ fBeamE = E; }
-	void SetSeed(unsigned long int seed){ fSeed = seed; }
-
-	void AddMagData(filedata_t d){fMagData.push_back(d);}
-	void SetMacroFile(const char *fn){ fMacro = remollTextFile(fn); }
-	void AddGDMLFile(const char *fn);
-	void ClearGDMLFiles(){ fGDMLFiles.clear(); }
-
-	void RecreateGDML(const char *adir = NULL, bool clobber = false);
-
-	remollTextFile GetGDMLFile(int i){ return fGDMLFiles[i]; }
+        void Init();
 
 	void Print();
 
-        std::string fGitInfo;
-	TTimeStamp fRunTime;
+    private:
+        std::vector<filedata_t> fMagData;
+    public:
+	void AddMagData(filedata_t d) { fMagData.push_back(d); }
 
-	long int  fNthrown;
-	long int  fSeed;
-	std::string fRunPath;
+    private:
+	remollTextFile fMacro;
+    public:
+	void SetMacroFile(const char *fn) { fMacro = remollTextFile(fn); }
 
-        std::string fHostName;
-
-	remollTextFile              fMacro;
+    private:
 	std::vector<remollTextFile> fGDMLFiles;
+    public:
+	void AddGDMLFile(const char *fn);
+	remollTextFile GetGDMLFile(int i) const { return fGDMLFiles[i]; }
+	void ClearGDMLFiles(){ fGDMLFiles.clear(); }
+	void RecreateGDML(const char *adir = NULL, bool clobber = false);
 
-	std::vector<filedata_t> fMagData;
+    private:
+	long int fNthrown;
+    public:
+	void SetNthrown(unsigned long long int n) { fNthrown = n; }
+	unsigned long long int GetNthrown() const { return fNthrown; }
+
+    private:
+	long int fSeed;
+    public:
+	void SetSeed(unsigned long int seed) { fSeed = seed; }
+        unsigned long long int GetSeed() const { return fSeed; }
+
+    private:
+        std::string fGitInfo;
+    public:
+        std::string GetGitInfo() const { return fGitInfo; }
+
+    private:
+	TTimeStamp fRunTime;
+    public:
+        TTimeStamp GetRunTime() const { return fRunTime; }
+
+    private:
+	std::string fRunPath;
+    public:
+        std::string GetRunPath() const { return fRunPath; }
+
+    private:
+        std::string fHostName;
+    public:
+        std::string GetHostName() const { return fHostName; }
 
 	ClassDef(remollRunData, 2);
 };

--- a/src/remollPrimaryGeneratorAction.cc
+++ b/src/remollPrimaryGeneratorAction.cc
@@ -131,8 +131,6 @@ void remollPrimaryGeneratorAction::SetGenerator(G4String& genname)
     if (fEventGen) {
       fEventGen->SetBeamTarget(fBeamTarg);
     }
-
-    remollRun::GetRunData()->SetGenName(genname.data());
 }
 
 void remollPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)

--- a/src/remollRunData.cc
+++ b/src/remollRunData.cc
@@ -17,7 +17,6 @@ remollRunData::remollRunData()
     fSeed = 0;
     fNthrown = -1;
     fBeamE   = -1e9;
-    fGenName[0]  = '\0';
     fHostName[0] = '\0';
 }
 
@@ -28,7 +27,6 @@ void remollRunData::Init()
 {
     fNthrown = 0;
     fBeamE   = 0;
-    strcpy(fGenName, "default");
     fGitInfo = gGitInfo;
 
     const unsigned int length = 128;
@@ -60,7 +58,6 @@ void remollRunData::Print()
     G4cout << "Run Path " << fRunPath << G4endl;;
     G4cout << "N generated = " << fNthrown << G4endl;
     G4cout << "Beam Energy = " << fBeamE << "GeV" << G4endl;
-    G4cout << "Generator   = " << fGenName << G4endl;
 
     G4cout << "Field maps:" << G4endl;
     for (unsigned int i = 0; i < fMagData.size(); i++ ){

--- a/src/remollRunData.cc
+++ b/src/remollRunData.cc
@@ -17,7 +17,6 @@ remollRunData::remollRunData()
     fSeed = 0;
     fNthrown = -1;
     fBeamE   = -1e9;
-    fHostName[0] = '\0';
 }
 
 remollRunData::~remollRunData(){

--- a/src/remollRunData.cc
+++ b/src/remollRunData.cc
@@ -15,6 +15,8 @@ extern const char* const gGitInfo;
 void remollRunData::Init()
 {
     fNthrown = 0;
+    fSeed = 0;
+
     fGitInfo = gGitInfo;
 
     const unsigned int length = 128;
@@ -43,7 +45,7 @@ void remollRunData::Print()
     G4cout << fGitInfo << G4endl;
     G4cout << "-------------------------------------------------" << G4endl;
     G4cout << "Run at " << fRunTime.AsString("ls") << " on " << fHostName << G4endl;
-    G4cout << "Run Path " << fRunPath << G4endl;;
+    G4cout << "Run path " << fRunPath << G4endl;
     G4cout << "N generated = " << fNthrown << G4endl;
 
     G4cout << "Field maps:" << G4endl;

--- a/src/remollRunData.cc
+++ b/src/remollRunData.cc
@@ -29,6 +29,8 @@ void remollRunData::Init()
     fNthrown = 0;
     fBeamE   = 0;
     strcpy(fGenName, "default");
+    fGitInfo = gGitInfo;
+
     const unsigned int length = 128;
 
     char hostname[length];
@@ -52,7 +54,7 @@ void remollRunData::Print()
 {
     G4cout << "git repository info" << G4endl;
     G4cout << "-------------------------------------------------" << G4endl;
-    G4cout << gGitInfo << G4endl;
+    G4cout << fGitInfo << G4endl;
     G4cout << "-------------------------------------------------" << G4endl;
     G4cout << "Run at " << fRunTime.AsString("ls") << " on " << fHostName << G4endl;
     G4cout << "Run Path " << fRunPath << G4endl;;

--- a/src/remollRunData.cc
+++ b/src/remollRunData.cc
@@ -15,7 +15,6 @@ extern const char* const gGitInfo;
 void remollRunData::Init()
 {
     fNthrown = 0;
-    fBeamE   = 0;
     fGitInfo = gGitInfo;
 
     const unsigned int length = 128;
@@ -46,7 +45,6 @@ void remollRunData::Print()
     G4cout << "Run at " << fRunTime.AsString("ls") << " on " << fHostName << G4endl;
     G4cout << "Run Path " << fRunPath << G4endl;;
     G4cout << "N generated = " << fNthrown << G4endl;
-    G4cout << "Beam Energy = " << fBeamE << "GeV" << G4endl;
 
     G4cout << "Field maps:" << G4endl;
     for (unsigned int i = 0; i < fMagData.size(); i++ ){

--- a/src/remollRunData.cc
+++ b/src/remollRunData.cc
@@ -12,16 +12,6 @@
 // External objects
 extern const char* const gGitInfo;
 
-remollRunData::remollRunData()
-{
-    fSeed = 0;
-    fNthrown = -1;
-    fBeamE   = -1e9;
-}
-
-remollRunData::~remollRunData(){
-}
-
 void remollRunData::Init()
 {
     fNthrown = 0;

--- a/src/remollRunData.cc
+++ b/src/remollRunData.cc
@@ -29,13 +29,22 @@ void remollRunData::Init()
     fNthrown = 0;
     fBeamE   = 0;
     strcpy(fGenName, "default");
-    if(gethostname(fHostName,__RUNSTR_LEN) == -1){
-	fprintf(stderr, "%s line %d: ERROR could not get hostname\n", __PRETTY_FUNCTION__ ,  __LINE__ );
-	fprintf(stderr, "%s\n",strerror(errno));
+    const unsigned int length = 128;
+
+    char hostname[length];
+    if (gethostname(hostname, length) == -1) {
+	G4cerr << "Error:  " << __PRETTY_FUNCTION__ << " line " << __LINE__ << ": "
+               << "could not get hostname" << G4endl;
+    } else {
+        fHostName = hostname;
     }
-    if(getcwd(fRunPath,__RUNSTR_LEN) == NULL){
-	fprintf(stderr, "%s line %d: ERROR could not get current working directory\n", __PRETTY_FUNCTION__ ,  __LINE__ );
-	fprintf(stderr, "%s\n",strerror(errno));
+
+    char runpath[length];
+    if (getcwd(runpath, length) == NULL) {
+	G4cerr << "Error:  " << __PRETTY_FUNCTION__ << " line " << __LINE__ << ": "
+               << "could not get current working directory" << G4endl;
+    } else {
+        fRunPath = runpath;
     }
 }
 


### PR DESCRIPTION
This turns `fGitInfo` into a private variable that will be stored in output ROOT trees, so it can be used to compared between output ROOT files. Some general cleanup in remollRunData in the process.