### PR TITLE
[magneticfield] field at maximum extent value must fail

### DIFF
--- a/src/remollMagneticField.cc
+++ b/src/remollMagneticField.cc
@@ -455,14 +455,14 @@ void remollMagneticField::GetFieldValue(const G4double Point[4], G4double *Bfiel
     }
 
     // Check that the point is within the defined region
-    if( r > fMax[kR] || r < fMin[kR] ||
-	z > fMax[kZ] || z < fMin[kZ] ){
+    if( r >= fMax[kR] || r < fMin[kR] ||
+	z >= fMax[kZ] || z < fMin[kZ] ){
 	return;
     }
 
     // Ensure we're going to get our grid indices correct
-    assert( fMin[kR] <= r && r <= fMax[kR] );
-    assert( fMin[kZ] <= z && z <= fMax[kZ] );
+    assert( fMin[kR] <= r && r < fMax[kR] );
+    assert( fMin[kZ] <= z && z < fMax[kZ] );
 
     // 2. Next calculate phi (slower)
     G4double phi = atan2(Point[1],Point[0]);
@@ -501,12 +501,12 @@ void remollMagneticField::GetFieldValue(const G4double Point[4], G4double *Bfiel
 
     // Check that the point is within the defined region
     // before interpolation.  If it is outside, the field is zero
-    if( lphi > fFileMax[kPhi] || lphi < fFileMin[kPhi] ){
+    if( lphi >= fFileMax[kPhi] || lphi < fFileMin[kPhi] ){
 	return;
     }
 
     // Ensure we're going to get our grid indices correct
-    assert( fFileMin[kPhi] <= lphi && lphi <= fFileMax[kPhi] );
+    assert( fFileMin[kPhi] <= lphi && lphi < fFileMax[kPhi] );
 
 
     // 3. Get interoplation variables


### PR DESCRIPTION
The field map routines use linear extrapolation. This requires finding the cell around a point where the field must be calculated. For a radial field map from `min_r` to `max_r` with `n_r+1` values, the index of the point just below a point with coordinate r is calculated with `index = modf(r / delta_r, &remainder)` with `remainder` the normalized position in the cell. To get the cell point just above our point of interest, we use `index+1`. In particular when `r == max_r`, we find `index = n_r`, and `index+1` is out of range of the map. We must exclude this edge case (for all three dimensions of r, phi, and z).

The edge cases appear particularly often when they happen to coincide with a volume boundary, as is the case for a 75cm radius. Geant4 forces the step to end at those boundaries, and therefore the radius ends up on the exact field map boundary.

This fixes #453.