### PR TITLE
Feature: cubic magnetic field interpolation

### DIFF
--- a/include/remollGlobalField.hh
+++ b/include/remollGlobalField.hh
@@ -27,6 +27,7 @@ class remollGlobalField : public G4MagneticField {
 
         void AddNewField(G4String& name);
 
+        void SetInterpolationType(const G4String& name, const G4String& type);
         void SetZOffset(const G4String& name, G4double offset);
         void SetFieldScale(const G4String& name, G4double scale);
         void SetMagnetCurrent(const G4String& name, G4double current);

--- a/include/remollMagneticField.hh
+++ b/include/remollMagneticField.hh
@@ -45,7 +45,8 @@ class remollMagneticField : public G4MagneticField {
 	remollMagneticField(const G4String&);
 	virtual ~remollMagneticField() { };
 
-	void GetFieldValue(const G4double Point[4], G4double *Bfield) const;
+	void AddFieldValue(const G4double point[4], G4double *field) const;
+	void GetFieldValue(const G4double point[4], G4double *field) const;
 
 	void SetFieldScale(G4double scale) { fFieldScale = scale; }
 	void SetRefCurrent(G4double current) { fRefCurrent = current; }

--- a/include/remollMagneticField.hh
+++ b/include/remollMagneticField.hh
@@ -42,24 +42,20 @@ class remollMagneticField : public G4MagneticField {
 
     public:
 
-	remollMagneticField( G4String );
-	virtual ~remollMagneticField();
+	remollMagneticField(const G4String&);
+	virtual ~remollMagneticField() { };
 
 	void GetFieldValue(const G4double Point[4], G4double *Bfield) const;
 
-	void InitializeGrid();
-	void ReadFieldMap();
+	void SetFieldScale(G4double scale) { fFieldScale = scale; }
+	void SetRefCurrent(G4double current) { fRefCurrent = current; }
+	void SetCurrent(G4double current) { SetFieldScale(current/fRefCurrent); }
 
-	void SetFieldScale(G4double s);
-	void SetMagnetCurrent(G4double s);
+	void SetZoffset(G4double z) { fZoffset = z; }
 
-	void SetZoffset(G4double z){ fZoffset= z; }
-
-	G4String GetName();
+	const G4String& GetName() const { return fName; }
 
 	enum Coord_t { kR, kPhi, kZ };
-
-	G4bool IsInit(){ return fInit; }
 
         G4bool IsInBoundingBox(const G4double* p) const {
           if (p[2] - fZoffset < fMin[kZ] || p[2] - fZoffset > fMax[kZ]) return false;
@@ -72,8 +68,8 @@ class remollMagneticField : public G4MagneticField {
 	G4String fName;
 	G4String fFilename;
 
-	G4int fN[__NDIM];
-	G4double fMin[__NDIM], fMax[__NDIM];
+	size_t fN[__NDIM];
+	G4double fUnit[__NDIM], fMin[__NDIM], fMax[__NDIM], fStep[__NDIM];
 	G4double fFileMin[__NDIM], fFileMax[__NDIM];
 
 	G4int fNxtant; // Number of *tants (septants, or whatever)
@@ -86,9 +82,7 @@ class remollMagneticField : public G4MagneticField {
 	G4double fZMapOffset, fPhiMapOffset;
 
 	G4double fFieldScale; // Scale overall field by this amount
-	G4double fMagCurrent0; // Scale overall field by this amount
-
-	G4bool fInit;
+	G4double fRefCurrent; // Reference current for magnetic field
 
     private:
 

--- a/include/remollMagneticField.hh
+++ b/include/remollMagneticField.hh
@@ -14,7 +14,7 @@
   */
 
 class remollMagneticField : public G4MagneticField {
-    /*! 
+    /*!
      * Moller spectrometer magnetic field class
      *
      * Use trilinear interpolation in cylindrical coordinates
@@ -36,7 +36,12 @@ class remollMagneticField : public G4MagneticField {
      *
      */
 
+    private:
+
+        enum EInterpolationType {kLinear, kCubic};
+
     public:
+
 	remollMagneticField( G4String );
 	virtual ~remollMagneticField();
 
@@ -84,6 +89,67 @@ class remollMagneticField : public G4MagneticField {
 	G4double fMagCurrent0; // Scale overall field by this amount
 
 	G4bool fInit;
+
+    private:
+
+        EInterpolationType fInterpolationType;
+
+    public:
+
+        void SetInterpolationType(EInterpolationType type) {
+            fInterpolationType = type;
+        }
+        void SetInterpolationType(const G4String& type) {
+            if (type == "linear") SetInterpolationType(kLinear);
+            if (type == "cubic") SetInterpolationType(kCubic);
+        }
+        EInterpolationType GetInterpolationType() const {
+            return fInterpolationType;
+        }
+
+    private:
+
+        static const char kLinearMap[8][3];
+        static const char kCubicMap[64][3];
+
+        double _linearInterpolate(const double p[2 << 0], double x) const {
+            return p[0] + x * (p[1] - p[0]);
+        }
+        double _bilinearInterpolate(const double p[2 << 1], const double x[2]) const {
+            double c[2];
+            c[0] = _linearInterpolate(&(p[0]), x[0]);
+            c[1] = _linearInterpolate(&(p[2]), x[0]);
+            return _linearInterpolate(c, x[1]);
+        }
+        double _trilinearInterpolate(const double p[2 << 2], const double x[3]) const {
+            double c[2];
+            c[0] = _bilinearInterpolate(&(p[0]), &(x[0]));
+            c[1] = _bilinearInterpolate(&(p[4]), &(x[0]));
+            return _linearInterpolate(c, x[2]);
+        }
+
+        double _cubicInterpolate(const double p[4 << 0], double x) const {
+            return p[1] +
+                   0.5 * x * (p[2] - p[0] +
+                              x * (2. * p[0] - 5. * p[1] + 4. * p[2] - p[3] +
+                                   x * (3. * (p[1] - p[2]) + p[3] - p[0])));
+        }
+        double _bicubicInterpolate(const double p[4 << 1], const double x[2]) const {
+            double c[4];
+            c[0] = _cubicInterpolate(&(p[0]),  x[1]);
+            c[1] = _cubicInterpolate(&(p[4]),  x[1]);
+            c[2] = _cubicInterpolate(&(p[8]),  x[1]);
+            c[3] = _cubicInterpolate(&(p[12]), x[1]);
+            return _cubicInterpolate(c, x[0]);
+        }
+        double _tricubicInterpolate(const double p[4 << 2], const double x[3]) const {
+            double c[4];
+            c[0] = _bicubicInterpolate(&(p[0]),  &(x[1]));
+            c[1] = _bicubicInterpolate(&(p[16]), &(x[1]));
+            c[2] = _bicubicInterpolate(&(p[32]), &(x[1]));
+            c[3] = _bicubicInterpolate(&(p[48]), &(x[1]));
+            return _cubicInterpolate(c, x[0]);
+        }
 };
 
 

--- a/macros/tests/unit/test_fields_cubic.mac
+++ b/macros/tests/unit/test_fields_cubic.mac
@@ -1,0 +1,54 @@
+/run/numberOfThreads 1
+/run/initialize
+
+/control/execute macros/load_magnetic_fieldmaps.mac
+
+/remoll/field/interpolation map_directory/V2DSg.9.75cm.txt linear
+#0.35    -180    8.5     0.00357702902439        0.000508489642332       0.00792856854346
+/remoll/field/value 0.3500 0.0 8.50
+/remoll/field/value 0.3502 0.0 8.51
+/remoll/field/value 0.3504 0.0 8.52
+/remoll/field/value 0.3506 0.0 8.53
+/remoll/field/value 0.3508 0.0 8.54
+/remoll/field/value 0.3510 0.0 8.55
+/remoll/field/value 0.3512 0.0 8.56
+/remoll/field/value 0.3514 0.0 8.57
+/remoll/field/value 0.3516 0.0 8.58
+/remoll/field/value 0.3518 0.0 8.59
+/remoll/field/value 0.3520 0.0 8.60
+#0.352   -180    8.6     8.3868756498e-05        0.0241781282489 0.00052352054301
+/remoll/field/value 0.3522 0.0 8.61
+/remoll/field/value 0.3524 0.0 8.62
+/remoll/field/value 0.3526 0.0 8.63
+/remoll/field/value 0.3528 0.0 8.64
+/remoll/field/value 0.3530 0.0 8.65
+/remoll/field/value 0.3532 0.0 8.66
+/remoll/field/value 0.3534 0.0 8.67
+/remoll/field/value 0.3536 0.0 8.68
+/remoll/field/value 0.3538 0.0 8.69
+/remoll/field/value 0.3540 0.0 8.70
+
+/remoll/field/interpolation map_directory/V2DSg.9.75cm.txt cubic
+#0.35    -180    8.5     0.00357702902439        0.000508489642332       0.00792856854346
+/remoll/field/value 0.3500 0.0 8.50
+/remoll/field/value 0.3502 0.0 8.51
+/remoll/field/value 0.3504 0.0 8.52
+/remoll/field/value 0.3506 0.0 8.53
+/remoll/field/value 0.3508 0.0 8.54
+/remoll/field/value 0.3510 0.0 8.55
+/remoll/field/value 0.3512 0.0 8.56
+/remoll/field/value 0.3514 0.0 8.57
+/remoll/field/value 0.3516 0.0 8.58
+/remoll/field/value 0.3518 0.0 8.59
+/remoll/field/value 0.3520 0.0 8.60
+#0.352   -180    8.6     8.3868756498e-05        0.0241781282489 0.00052352054301
+/remoll/field/value 0.3522 0.0 8.61
+/remoll/field/value 0.3524 0.0 8.62
+/remoll/field/value 0.3526 0.0 8.63
+/remoll/field/value 0.3528 0.0 8.64
+/remoll/field/value 0.3530 0.0 8.65
+/remoll/field/value 0.3532 0.0 8.66
+/remoll/field/value 0.3534 0.0 8.67
+/remoll/field/value 0.3536 0.0 8.68
+/remoll/field/value 0.3538 0.0 8.69
+/remoll/field/value 0.3540 0.0 8.70

--- a/src/remollGlobalField.cc
+++ b/src/remollGlobalField.cc
@@ -79,6 +79,7 @@ remollGlobalField::remollGlobalField()
     fGlobalFieldMessenger->DeclareProperty("deltachord",fDeltaChord,"Set delta chord for the chord finder");
     fGlobalFieldMessenger->DeclareProperty("deltaonestep",fDeltaOneStep,"Set delta one step for the field manager");
     fGlobalFieldMessenger->DeclareProperty("deltaintersection",fMinStep,"Set delta intersection for the field manager");
+    fGlobalFieldMessenger->DeclareMethod("interpolation",&remollGlobalField::SetInterpolationType,"Set magnetic field interpolation type");
     fGlobalFieldMessenger->DeclareMethod("zoffset",&remollGlobalField::SetZOffset,"Set magnetic field z offset");
     fGlobalFieldMessenger->DeclareMethod("scale",&remollGlobalField::SetFieldScale,"Scale magnetic field by factor");
     fGlobalFieldMessenger->DeclareMethod("current",&remollGlobalField::SetMagnetCurrent,"Scale magnetic field by current");
@@ -285,6 +286,18 @@ void remollGlobalField::SetZOffset(const G4String& name, G4double offset)
   } else {
     G4cerr << "WARNING " << __FILE__ << " line " << __LINE__
            << ": field " << name << " offset failed" << G4endl;
+  }
+}
+
+void remollGlobalField::SetInterpolationType(const G4String& name, const G4String& type)
+{
+  remollMagneticField *field = GetFieldByName(name);
+  if (field) {
+    G4AutoLock lock(&remollGlobalFieldMutex);
+    field->SetInterpolationType(type);
+  } else {
+    G4cerr << "WARNING " << __FILE__ << " line " << __LINE__
+           << ": field " << name << " interpolation type failed" << G4endl;
   }
 }
 

--- a/src/remollGlobalField.cc
+++ b/src/remollGlobalField.cc
@@ -195,46 +195,39 @@ void remollGlobalField::AddNewField(G4String& name)
 
   // If this field has already been loaded
   if (GetFieldByName(name) != 0) return;
-  
+
   // Load new field
   remollMagneticField *thisfield = new remollMagneticField(name);
-  if (thisfield->IsInit()) {
-    fFields.push_back(thisfield);
+  fFields.push_back(thisfield);
 
-    if (fVerboseLevel > 0)
-      G4cout << __FUNCTION__ << ": field " << name << " was added." << G4endl;
+  if (fVerboseLevel > 0)
+    G4cout << __FUNCTION__ << ": field " << name << " was added." << G4endl;
 
-    // Add file data to output data stream
+  // Add file data to output data stream
+  remollRunData *rd = remollRun::GetRunData();
 
-    remollRunData *rd = remollRun::GetRunData();
+  // FIXME disabled TMD5 functionality as long as CentOS 7.2 is common
+  // due to kernel bug when running singularity containers
 
-    // FIXME disabled TMD5 functionality as long as CentOS 7.2 is common
-    // due to kernel bug when running singularity containers
+  //TMD5 *md5 = TMD5::FileChecksum(name.data());
 
-    //TMD5 *md5 = TMD5::FileChecksum(name.data());
+  filedata_t fdata;
 
-    filedata_t fdata;
+  strcpy(fdata.filename, name.data());
+  strcpy(fdata.hashsum, "no hash" ); // md5->AsString() );
 
-    strcpy(fdata.filename, name.data());
-    strcpy(fdata.hashsum, "no hash" ); // md5->AsString() );
+  //G4cout << "MD5 checksum " << md5->AsString() << G4endl;
 
-    //G4cout << "MD5 checksum " << md5->AsString() << G4endl;
+  //delete md5;
 
-    //delete md5;
+  struct stat fs;
+  stat(name.data(), &fs);
+  fdata.timestamp = TTimeStamp( fs.st_mtime );
 
-    struct stat fs;
-    stat(name.data(), &fs);
-    fdata.timestamp = TTimeStamp( fs.st_mtime );
+  if (fVerboseLevel > 0)
+    G4cout << __FUNCTION__ << ": field timestamp = " << fdata.timestamp << G4endl;
 
-    if (fVerboseLevel > 0)
-      G4cout << __FUNCTION__ << ": field timestamp = " << fdata.timestamp << G4endl;
-
-    rd->AddMagData(fdata);
-
-  } else {
-    G4cerr << "WARNING " << __FILE__ << " line " << __LINE__
-           << ": field " << name << " was not initialized." << G4endl;
-  }
+  rd->AddMagData(fdata);
 }
 
 remollMagneticField* remollGlobalField::GetFieldByName(const G4String& name) const
@@ -318,7 +311,7 @@ void remollGlobalField::SetMagnetCurrent(const G4String& name, G4double current)
   remollMagneticField *field = GetFieldByName(name);
   if (field) {
     G4AutoLock lock(&remollGlobalFieldMutex);
-    field->SetMagnetCurrent(current);
+    field->SetRefCurrent(current);
   } else {
     G4cerr << "WARNING " << __FILE__ << " line " << __LINE__
            << ": field " << name << " scaling failed" << G4endl;

--- a/src/remollGlobalField.cc
+++ b/src/remollGlobalField.cc
@@ -251,23 +251,11 @@ void remollGlobalField::PrintFieldValue(const G4ThreeVector& r)
     G4cout << "T" << G4endl;
 }
 
-void remollGlobalField::GetFieldValue(const G4double p[], G4double *resB) const
+void remollGlobalField::GetFieldValue(const G4double p[], G4double *field) const
 {
-    G4double Bsum [__GLOBAL_NDIM] = {0};
-
-    std::vector<remollMagneticField*>::const_iterator it = fFields.begin();
-    for (it = fFields.begin(); it != fFields.end(); it++) {
-        G4double thisB[__GLOBAL_NDIM] = {0};
-        (*it)->GetFieldValue(p, thisB);
-
-        for (int i = 0; i < __GLOBAL_NDIM; i++) {
-          Bsum[i] += thisB[i];
-        }
-    }
-
-    for (int i = 0; i < __GLOBAL_NDIM; i++) {
-        resB[i] = Bsum[i];
-    }
+    // Field is initialized to zero before passing to this function
+    for (auto it = fFields.begin(); it != fFields.end(); it++)
+        (*it)->GetFieldValue(p, field);
 }
 
 void remollGlobalField::SetZOffset(const G4String& name, G4double offset)

--- a/src/remollMagneticField.cc
+++ b/src/remollMagneticField.cc
@@ -107,7 +107,7 @@ const char remollMagneticField::kCubicMap[64][3] = {
 };
 
 remollMagneticField::remollMagneticField( G4String filename )
-: fInterpolationType(kCubic)
+: fInterpolationType(kLinear)
 {
     fName = filename;
     fFilename = filename;

--- a/src/remollMagneticField.cc
+++ b/src/remollMagneticField.cc
@@ -633,7 +633,7 @@ void remollMagneticField::GetFieldValue(const G4double Point[4], G4double *Bfiel
             values[cidx][i] =
                     fBFieldData[cidx]
                            [idx[kR] + map[i][kR]]
-                           [(idx[kPhi] + map[i][kPhi]) % (fN[kPhi]-1)] // wrap around
+                           [(idx[kPhi] + map[i][kPhi] + fN[kPhi] - 1) % (fN[kPhi]-1)] // wrap around
                            [idx[kZ] + map[i][kZ]];
         }
     }
@@ -642,30 +642,12 @@ void remollMagneticField::GetFieldValue(const G4double Point[4], G4double *Bfiel
     G4double Bint[__NDIM] = {0};
     for(int cidx = 0; cidx < __NDIM; cidx++ ){
 
-                G4double c00, c10, c01, c11;
-                c00 = fBFieldData[cidx][idx[kR]][idx[kPhi]][idx[kZ]]*(1.0-x[kR])
-                    + fBFieldData[cidx][idx[kR]+1][idx[kPhi]][idx[kZ]]*x[kR];
-                c10 = fBFieldData[cidx][idx[kR]][idx[kPhi]+1][idx[kZ]]*(1.0-x[kR])
-                    + fBFieldData[cidx][idx[kR]+1][idx[kPhi]+1][idx[kZ]]*x[kR];
-                c01 = fBFieldData[cidx][idx[kR]][idx[kPhi]][idx[kZ]+1]*(1.0-x[kR])
-                    + fBFieldData[cidx][idx[kR]+1][idx[kPhi]][idx[kZ]+1]*x[kR];
-                c11 = fBFieldData[cidx][idx[kR]][idx[kPhi]+1][idx[kZ]+1]*(1.0-x[kR])
-                    + fBFieldData[cidx][idx[kR]+1][idx[kPhi]+1][idx[kZ]+1]*x[kR];
-
-                G4double c0 = c00*(1.0-x[kPhi]) + c10*x[kPhi];
-                G4double c1 = c01*(1.0-x[kPhi]) + c11*x[kPhi];
-
-                Bint[cidx] = c0*(1.0-x[kZ])+c1*x[kZ];
-                G4cout << Bint[cidx] << ": ";
-
-        switch (fInterpolationType) {
+        switch (type) {
             case kLinear: {
-                G4cout << _trilinearInterpolate(values[cidx], x) / Bint[cidx] << "L" << G4endl;
                 Bint[cidx] = _trilinearInterpolate(values[cidx], x);
                 break;
             }
             case kCubic: {
-                G4cout << _tricubicInterpolate(values[cidx], x) / Bint[cidx] << G4endl;
                 Bint[cidx] = _tricubicInterpolate(values[cidx], x);
                 break;
             }


### PR DESCRIPTION
This introduces cubic interpolation of the magnetic fields. This should be able to reproduce fast changes in the field map more accurately. The linear interpolation was also rewritten using a convolution kernel, so that it makes more sense how the cubic interpolation works.

- At the edge of the field map (boundary layer of 1 cell size), cubic interpolation is impossible in its canonical form since it would require a point at index -1 or index `size` (where `size-1` is the largest allowable). In these cells, the cubic interpolation falls back to the linear interpolation.
- In the case of phi we can do better (this is implemented): we wrap can around from the edge at -180 to +180 (in fact, we have to, otherwise the sector at -180 will look different because it will use linear interpolation when all other sectors use cubic). This is only correct for the field maps that we are currently using: from -180 to +180. At this moment, the code will fail to produce correct results for other field maps. Either, we toss that functionality entirely, or we need to add support for sector fieldmaps to the cubic interpolation.
- In the case of r at the lower edge (r = 0, index 0) we can do better as well (this is not implemented): we can assume that the value at index -1 is the value of the field at index 1, but for 180 degrees around the azimuth. At this point, we just assume linear when close to r = 0.

For runexample.mac (100 events), we get 323720 field lookup of which 5008 are 'downgraded' from cubic to linear. When comparing directly with the linear case, there are large differences (in the ratio), but those are on very small values. It would be useful to check whether there are large differences in areas where the field is sizeable and well-behaved.

Someone can probably also run a largish simulation and compare the peak position/shape.