### PR TITLE
Hotfix: set parallel world overlap check to true to avoid segfault

### DIFF
--- a/src/remollDetectorConstruction.cc
+++ b/src/remollDetectorConstruction.cc
@@ -547,7 +547,8 @@ G4VPhysicalVolume* remollDetectorConstruction::ParseGDMLFile()
 
     // Parse GDML file
     fGDMLParser->SetOverlapCheck(fGDMLOverlapCheck);
-    // hide output if not validating or checking ovelaps
+    // hide output if not validating or checking overlaps
+    // https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2358
     if (! fGDMLOverlapCheck && ! fGDMLValidate)
       G4cout.setstate(std::ios_base::failbit);
     fGDMLParser->Read(fGDMLFile,fGDMLValidate);

--- a/src/remollParallelConstruction.cc
+++ b/src/remollParallelConstruction.cc
@@ -20,7 +20,7 @@ remollParallelConstruction::remollParallelConstruction(const G4String& name, con
   fGDMLPath(""),fGDMLFile(""),
   fGDMLParser(0),
   fGDMLValidate(false),
-  fGDMLOverlapCheck(false),
+  fGDMLOverlapCheck(true),
   fVerboseLevel(0),
   fParallelMessenger(0),
   fWorldVolume(0),
@@ -152,7 +152,8 @@ G4VPhysicalVolume* remollParallelConstruction::ParseGDMLFile()
 
   // Parse GDML file
   fGDMLParser->SetOverlapCheck(fGDMLOverlapCheck);
-  // hide output if not validating or checking ovelaps
+  // hide output if not validating or checking overlaps
+  // https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2358
   if (! fGDMLOverlapCheck && ! fGDMLValidate)
     G4cout.setstate(std::ios_base::failbit);
   fGDMLParser->Read(fGDMLFile,fGDMLValidate);


### PR DESCRIPTION
`G4cout.setstate(std::ios_base::failbit)` causes empty strings to be sent to G4UIQt, which triggers an unsigned int wrap around and segfault. We just set the default to overlap check, so we temporarily avoid the issue.

Ref: https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2358