### PR TITLE
[fields] GetFieldValue needs to initialize field when not debug

### DIFF
--- a/src/remollGlobalField.cc
+++ b/src/remollGlobalField.cc
@@ -253,9 +253,12 @@ void remollGlobalField::PrintFieldValue(const G4ThreeVector& r)
 
 void remollGlobalField::GetFieldValue(const G4double p[], G4double *field) const
 {
-    // Field is initialized to zero before passing to this function
+    // Field is not initialized to zero by geant4
+    field[0] = 0.0;
+    field[1] = 0.0;
+    field[2] = 0.0;
     for (auto it = fFields.begin(); it != fFields.end(); it++)
-        (*it)->GetFieldValue(p, field);
+        (*it)->AddFieldValue(p, field);
 }
 
 void remollGlobalField::SetZOffset(const G4String& name, G4double offset)

--- a/src/remollMagneticField.cc
+++ b/src/remollMagneticField.cc
@@ -528,16 +528,15 @@ void remollMagneticField::AddFieldValue(const G4double point[4], G4double *field
     }
 
     // Interpolate
-    G4double Bint[__NDIM] = {0};
-    G4ThreeVector Bcart(Bint[0], Bint[1], Bint[2]);
+    G4ThreeVector Bcart(0.0,0.0,0.0);
     for(int cidx = 0; cidx < __NDIM; cidx++ ){
         switch (type) {
             case kLinear: {
-                Bcart[cidx] = Bint[cidx] = _trilinearInterpolate(values[cidx], x);
+                Bcart[cidx] = _trilinearInterpolate(values[cidx], x);
                 break;
             }
             case kCubic: {
-                Bcart[cidx] = Bint[cidx] = _tricubicInterpolate(values[cidx], x);
+                Bcart[cidx] = _tricubicInterpolate(values[cidx], x);
                 break;
             }
         }


### PR DESCRIPTION
When geant4 calls our GetFieldValue function, it doesn't explicitly initialize the field variable. In debug mode, the compiler applies initialization, but in optimized compilation, that's not done. This makes sure the field values are explicitly initialized to zero before we start adding the actual field maps.