### PR TITLE
Changing the length of the upstream outer nose shield from 100 mm to …

### DIFF
--- a/geometry/upstream/upstreamDaughter_merged.gdml
+++ b/geometry/upstream/upstreamDaughter_merged.gdml
@@ -82,7 +82,7 @@
     <!--need to subtract 50/2 to accomdate for the beampipe moving downstream due to collimator thickness increasing. An additional 75 mm subtracted to move the beampipe upstream.-->
     <position name="shield_US_beampipe_center" unit="mm" x="0" y="0" z="shield_US_beampipe_center_z"/>
 
-    <constant name="nose_shield_US_beampipe_length" value="100"/>
+    <constant name="nose_shield_US_beampipe_length" value="75.569"/>
     <constant name="nose_shield_US_beampipe_center_z" value="nose_shield_US_beampipe_length/2 + posCOLL2z + COLL2_THICK/2+0.001-50/2-75"/>
     <position name="nose_shield_US_beampipe_center" unit="mm" x="0" y="0" z="nose_shield_US_beampipe_center_z"/>
  

--- a/geometry/upstream/upstream_nose_shield_beampipe.gdml
+++ b/geometry/upstream/upstream_nose_shield_beampipe.gdml
@@ -17,15 +17,15 @@
 <!--Naz : change it to different parts inner and outer shield , This is the outer one-->
 
      <polycone name="solid_nose_shield_US_beampipe_l" aunit="deg" startphi="0" deltaphi="360" lunit="mm">
-      <zplane rmin="23.5+1" rmax="35" z="-100/2"/>
-      <zplane rmin="23.6+1" rmax="35" z="-100/2+100"/>
+      <zplane rmin="23.5+1" rmax="35" z="-75.569/2"/>
+      <zplane rmin="23.6+1" rmax="35" z="-75.569/2+75.569"/>
       <!--<zplane rmin="23" rmax="28" z="-1945/2+1945"/>-->
      </polycone>
 
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_nose_shield_US_beampipe_mother">
-      <zplane rmin="23.5+1" rmax="35" z="-100/2"/>
-      <zplane rmin="23.6+1" rmax="35" z="-100/2+100"/>
+      <zplane rmin="23.5+1" rmax="35" z="-75.569/2"/>
+      <zplane rmin="23.6+1" rmax="35" z="-75.569/2+75.569"/>
       <!--<zplane rmin="0" rmax="28" z="-1945/2+1945"/>-->
     </polycone>
  


### PR DESCRIPTION
Originally the length of the outer nose shield was 100 mm. Reducing it to 75.569 mm to avoid overlap with the geometric mother volume of the coils. The shield geometry in the upstream coil region for plates and nose shields are currently under optimization. So, this may be changed again in the near future. 