### PR TITLE
[CMakeLists] find boost QUIET also OPTIONAL_COMPONENTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ list(APPEND sources ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Dict.cxx)
 #----------------------------------------------------------------------------
 # Boost
 #
-find_package(Boost QUIET COMPONENTS iostreams filesystem)
+find_package(Boost QUIET OPTIONAL_COMPONENTS iostreams filesystem)
 if(Boost_FOUND)
   message(STATUS "Boost found --> building with boost enabled.")
   include_directories(${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
This removes some warnings when boost is not available. Remoll works fine without boost, so no warnings should be emitted.