### PR TITLE
Bugfix: Use real momentum for physics generators instead of true momentum

### DIFF
--- a/src/remollPrimaryGeneratorAction.cc
+++ b/src/remollPrimaryGeneratorAction.cc
@@ -172,24 +172,24 @@ void remollPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       fEvent = fEventGen->GenerateEvent();
       for (unsigned int pidx = 0; pidx < fEvent->fPartType.size(); pidx++) {
 
-        double p = fEvent->fPartMom[pidx].mag();
+        double p = fEvent->fPartRealMom[pidx].mag();
         double m = fEvent->fPartType[pidx]->GetPDGMass();
         double kinE = sqrt(p*p + m*m) - m;
 
         fParticleGun->SetParticleDefinition(fEvent->fPartType[pidx]);
         fParticleGun->SetParticleEnergy(kinE);
         fParticleGun->SetParticlePosition(fEvent->fPartPos[pidx]);
-        fParticleGun->SetParticleMomentumDirection(fEvent->fPartMom[pidx].unit());
+        fParticleGun->SetParticleMomentumDirection(fEvent->fPartRealMom[pidx].unit());
 
         G4ThreeVector pol(0,0,0);
         if (pidx == 0) {
           if (cross.mag() !=0) {
             if (cross.mag() == 1) //transverse polarization
-              pol = G4ThreeVector( (fEvent->fPartMom[0].unit()).cross(cross));
+              pol = G4ThreeVector( (fEvent->fPartRealMom[0].unit()).cross(cross));
             else if (fBeamPol.contains("+") ) //positive helicity
-              pol = fEvent->fPartMom[0].unit();
+              pol = fEvent->fPartRealMom[0].unit();
             else //negative helicity
-              pol = - fEvent->fPartMom[0].unit();
+              pol = - fEvent->fPartRealMom[0].unit();
           }
         }
         fParticleGun->SetParticlePolarization(pol);

--- a/src/remollVEventGen.cc
+++ b/src/remollVEventGen.cc
@@ -125,7 +125,7 @@ void remollVEventGen::PolishEvent(remollEvent *ev) {
         exit(1);
     }
 
-    G4ThreeVector rotax      = (fBeamTarg->fDir.cross(G4ThreeVector(0.0, 0.0, 1.0))).unit();
+    G4ThreeVector rotax      = (-1)*(fBeamTarg->fDir.cross(G4ThreeVector(0.0, 0.0, 1.0))).unit();
     G4RotationMatrix msrot;
     msrot.rotate(fBeamTarg->fDir.theta(), rotax);
 


### PR DESCRIPTION
1) Flipped the sign of the axis to perform multiple scattering and other rotations. Effect negligible at shallow angles. But the problem shows up when using unidirectional large angle beams with physics generators. This commit should mitigate that.

2) Previously primary generator action used the true momentum instead of the real momentum for particle generation. Resulting in forward biased momentum all the time. Again negligible at shallow angles when beam is mostly parallel to the beamline but shows up for large angle beams.


Rate  in Ring 5 (900-1060 mm) before change:      122.32 GHz, 54.69 GHz, 45.94 GHz, 21.68 GHz
Rate in Ring 5 (900-1060 mm) after change:          121.97 GHz, 54.38 GHz, 45.93 GHz, 21.66 GHz