### PR TITLE
Implement hit.beta with track velocity

### DIFF
--- a/include/remollGenericDetectorHit.hh
+++ b/include/remollGenericDetectorHit.hh
@@ -48,7 +48,7 @@ class remollGenericDetectorHit : public G4VHit {
         G4double fThRec;
 
 	// Total momentum, energy, mass, kinetic energy
-	G4double fP, fE, fM, fK;
+	G4double fP, fE, fM, fK, fBeta;
 	// Origin
 	G4ThreeVector f3V;
 	// Geant4 track ID, particle type, and mother ID
@@ -92,6 +92,7 @@ class remollGenericDetectorHit : public G4VHit {
         hit.e  = fE;
         hit.m  = fM;
         hit.k  = fK;
+	hit.beta = fBeta;.cc
         hit.edep = fEdep;
         return hit;
       };

--- a/include/remollGenericDetectorHit.hh
+++ b/include/remollGenericDetectorHit.hh
@@ -92,7 +92,7 @@ class remollGenericDetectorHit : public G4VHit {
         hit.e  = fE;
         hit.m  = fM;
         hit.k  = fK;
-	hit.beta = fBeta;.cc
+        hit.beta = fBeta;
         hit.edep = fEdep;
         return hit;
       };

--- a/include/remolltypes.hh
+++ b/include/remolltypes.hh
@@ -12,7 +12,7 @@
 //#include <G4Types.hh>
 //#endif
 
-#define __RUNSTR_LEN 255
+#define __RUNSTR_LEN 255 fBeta for hit
 #define __MAXFILE_LEN 1048576 // MB file size limit
 
 #include "TTimeStamp.h"
@@ -77,7 +77,7 @@ struct remollGenericDetectorHit_t {
   double px, py, pz;
   double pxl, pyl, pzl;
   double sx, sy, sz;
-  double p, e, m, k;
+  double p, e, m, k, beta;
   double vx, vy, vz;
   double edep;
 };

--- a/src/remollGenericDetector.cc
+++ b/src/remollGenericDetector.cc
@@ -3,6 +3,7 @@
 #include "G4OpticalPhoton.hh"
 #include "G4SDManager.hh"
 #include "G4GenericMessenger.hh"
+#include "G4PhysicalConstants.hh"
 
 #include "remollGenericDetectorHit.hh"
 #include "remollGenericDetectorSum.hh"
@@ -303,6 +304,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
     hit->fE = track->GetTotalEnergy();
     hit->fM = particle->GetPDGMass();
     hit->fK = track->GetKineticEnergy();
+    hit->fBeta = track->GetVelocity() / c_light;
 
     hit->fTrID  = track->GetTrackID();
     hit->fmTrID = track->GetParentID();

--- a/src/remollGenericDetectorHit.cc
+++ b/src/remollGenericDetectorHit.cc
@@ -20,6 +20,7 @@ remollGenericDetectorHit::remollGenericDetectorHit(G4int det, G4int copy)
   fE  = -1.0;
   fM  = -1.0;
   fK  = -1.0;
+  fBeta = -1.0;
 
   f3XRec = G4ThreeVector(-1e9, -1e9, -1e9);
   f3dPRec = G4ThreeVector(-1e9, -1e9, -1e9);
@@ -56,6 +57,7 @@ remollGenericDetectorHit::remollGenericDetectorHit(const remollGenericDetectorHi
   fE      = right.fE;
   fM      = right.fM;
   fK      = right.fK;
+  fBeta   = right.fBeta;
 
   f3XRec  = right.f3XRec;
   f3dPRec = right.f3dPRec;


### PR DESCRIPTION
For faster Cherenkov studies without need to run optical photons.