### PR TITLE
Bugfix: add current dir to macro search path

### DIFF
--- a/remoll.cc
+++ b/remoll.cc
@@ -193,7 +193,8 @@ int main(int argc, char** argv) {
 
 
     // Define UI session for interactive mode
-    G4String searchpath = std::string(CMAKE_INSTALL_FULL_DATADIR) + "/remoll";
+    G4String searchpath = ".";
+    searchpath += ":" + std::string(CMAKE_INSTALL_FULL_DATADIR) + "/remoll";
     searchpath += ":" + std::string(CMAKE_INSTALL_FULL_DATADIR) + "/remoll/macros";
     if (macro.size())
     {


### PR DESCRIPTION
If you (ever) ran `make install` and ended up with copied macros like `/usr/local/share/remoll/macros/load_magnetic_fieldmaps.mac`, then even running `build/remoll macros/runexample.mac` inside the sources directory will pick up that (potentially outdated) version in `/usr/local`.