### PR TITLE
Bugfix beam target mult scatt

### DIFF
--- a/include/remollBeamTarget.hh
+++ b/include/remollBeamTarget.hh
@@ -4,6 +4,7 @@
 #include "remolltypes.hh"
 #include "remollglobs.hh"
 #include "remollVertex.hh"
+#include "remollMultScatt.hh"
 
 #include "G4ThreeVector.hh"
 #include <vector>
@@ -28,7 +29,6 @@
 class G4GenericMessenger;
 class G4VPhysicalVolume;
 class G4Material;
-class remollMultScatt;
 
 class remollBeamTarget {
 
@@ -90,8 +90,12 @@ class remollBeamTarget {
 	G4double fBeamCurrent;
 	G4double fBeamPolarization;
 
-	remollMultScatt *fMS;
+    private:
+	remollMultScatt fMS;
+    public:
+        const remollMultScatt& GetMultScatt() const { return fMS; }
 
+    private:
 	bool fAlreadyWarned;
         bool fAlreadyWarned_LH2;
 

--- a/include/remollMultScatt.hh
+++ b/include/remollMultScatt.hh
@@ -90,7 +90,7 @@ class remollMultScatt {
 	double GenerateMSPlane(double p, const std::tuple<double,double,double>& m);
 	double GenerateMSPlane(double p, const std::vector<std::tuple<double,double,double>>& m);
 
-	double GetPDGTh(){ return fthpdg; }
+	double GetPDGTh() const { return fthpdg; }
 
     private:
 

--- a/src/remollBeamTarget.cc
+++ b/src/remollBeamTarget.cc
@@ -20,7 +20,6 @@
 #include "Randomize.hh"
 
 #include "remollBeamTarget.hh"
-#include "remollMultScatt.hh"
 
 #include <math.h>
 
@@ -47,9 +46,6 @@ remollBeamTarget::remollBeamTarget()
   fX0(0.0),fY0(0.0),fTh0(0.0),fPh0(0.0),
   fdTh(0.0),fdPh(0.0),fCorrTh(0.0),fCorrPh(0.0)
 {
-    // Create new multiple scattering
-    fMS = new remollMultScatt();
-
     // Infrared energy cutoff
     fEnergyCut = 1e-6 * MeV;
 
@@ -85,7 +81,6 @@ remollBeamTarget::~remollBeamTarget()
 {
     delete fMessengerTarget;
     delete fMessenger;
-    delete fMS;
 }
 
 G4double remollBeamTarget::GetEffLumin(SamplingType_t sampling_type)
@@ -425,9 +420,9 @@ remollVertex remollBeamTarget::SampleVertex(SamplingType_t sampling_type)
     // Sample multiple scattering angles
     G4double msth = 0, msph = 0;
     if (ms.size() > 0) {
-	fMS->Init(fBeamEnergy, ms);
-	msth = fMS->GenerateMSPlane();
-	msph = fMS->GenerateMSPlane();
+	fMS.Init(fBeamEnergy, ms);
+	msth = fMS.GenerateMSPlane();
+	msph = fMS.GenerateMSPlane();
     }
     assert( !std::isnan(msth) && !std::isnan(msph) );
     assert( !std::isinf(msth) && !std::isinf(msph) );

--- a/src/remollGenpElastic.cc
+++ b/src/remollGenpElastic.cc
@@ -9,7 +9,6 @@
 #include "remollEvent.hh"
 #include "remollVertex.hh"
 #include "remollBeamTarget.hh"
-#include "remollMultScatt.hh"
 #include "remolltypes.hh"
 
 #include <math.h>
@@ -229,7 +228,7 @@ void remollGenpElastic::SamplePhysics(remollVertex *vert, remollEvent *evt){
     // as anything less than three sigma of the characteristic
     // width
     
-    if( th < 3.0*fBeamTarg->fMS->GetPDGTh() ){
+    if( th < 3.0*fBeamTarg->GetMultScatt().GetPDGTh() ){
 	sigma = 0.0;
     }
 


### PR DESCRIPTION
Includes #528.

Change remollBeamTarget::fMS from pointer type to member. Avoid memory errors.  