### PR TITLE
Bugfix: beam target as object in primary generator

### DIFF
--- a/include/remollBeamTarget.hh
+++ b/include/remollBeamTarget.hh
@@ -4,6 +4,7 @@
 #include "remolltypes.hh"
 #include "remollglobs.hh"
 #include "remollVertex.hh"
+#include "remollMultScatt.hh"
 
 #include "G4ThreeVector.hh"
 #include <vector>
@@ -28,7 +29,6 @@
 class G4GenericMessenger;
 class G4VPhysicalVolume;
 class G4Material;
-class remollMultScatt;
 
 class remollBeamTarget {
 
@@ -90,8 +90,12 @@ class remollBeamTarget {
 	G4double fBeamCurrent;
 	G4double fBeamPolarization;
 
-	remollMultScatt *fMS;
+    private:
+	remollMultScatt fMS;
+    public:
+        const remollMultScatt& GetMultScatt() const { return fMS; }
 
+    private:
 	bool fAlreadyWarned;
         bool fAlreadyWarned_LH2;
 

--- a/include/remollMultScatt.hh
+++ b/include/remollMultScatt.hh
@@ -90,7 +90,7 @@ class remollMultScatt {
 	double GenerateMSPlane(double p, const std::tuple<double,double,double>& m);
 	double GenerateMSPlane(double p, const std::vector<std::tuple<double,double,double>>& m);
 
-	double GetPDGTh(){ return fthpdg; }
+	double GetPDGTh() const { return fthpdg; }
 
     private:
 

--- a/include/remollPrimaryGeneratorAction.hh
+++ b/include/remollPrimaryGeneratorAction.hh
@@ -1,6 +1,8 @@
 #ifndef remollPrimaryGeneratorAction_h
 #define remollPrimaryGeneratorAction_h 1
 
+#include "remollBeamTarget.hh"
+
 #include "G4VUserPrimaryGeneratorAction.hh"
 #include "G4VPrimaryGenerator.hh"
 #include "G4String.hh"
@@ -10,7 +12,6 @@
 class G4GenericMessenger;
 class G4ParticleGun;
 class G4Event;
-class remollBeamTarget;
 class remollVEventGen;
 class remollEvent;
 
@@ -38,7 +39,7 @@ class remollPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 
     G4ParticleGun* fParticleGun;
 
-    remollBeamTarget *fBeamTarg;
+    remollBeamTarget fBeamTarg;
 
 
     remollEvent *fEvent;

--- a/src/remollBeamTarget.cc
+++ b/src/remollBeamTarget.cc
@@ -20,7 +20,6 @@
 #include "Randomize.hh"
 
 #include "remollBeamTarget.hh"
-#include "remollMultScatt.hh"
 
 #include <math.h>
 
@@ -47,9 +46,6 @@ remollBeamTarget::remollBeamTarget()
   fX0(0.0),fY0(0.0),fTh0(0.0),fPh0(0.0),
   fdTh(0.0),fdPh(0.0),fCorrTh(0.0),fCorrPh(0.0)
 {
-    // Create new multiple scattering
-    fMS = new remollMultScatt();
-
     // Infrared energy cutoff
     fEnergyCut = 1e-6 * MeV;
 
@@ -85,7 +81,6 @@ remollBeamTarget::~remollBeamTarget()
 {
     delete fMessengerTarget;
     delete fMessenger;
-    delete fMS;
 }
 
 G4double remollBeamTarget::GetEffLumin(SamplingType_t sampling_type)
@@ -425,9 +420,9 @@ remollVertex remollBeamTarget::SampleVertex(SamplingType_t sampling_type)
     // Sample multiple scattering angles
     G4double msth = 0, msph = 0;
     if (ms.size() > 0) {
-	fMS->Init(fBeamEnergy, ms);
-	msth = fMS->GenerateMSPlane();
-	msph = fMS->GenerateMSPlane();
+	fMS.Init(fBeamEnergy, ms);
+	msth = fMS.GenerateMSPlane();
+	msph = fMS.GenerateMSPlane();
     }
     assert( !std::isnan(msth) && !std::isnan(msph) );
     assert( !std::isinf(msth) && !std::isinf(msph) );

--- a/src/remollGenpElastic.cc
+++ b/src/remollGenpElastic.cc
@@ -9,7 +9,6 @@
 #include "remollEvent.hh"
 #include "remollVertex.hh"
 #include "remollBeamTarget.hh"
-#include "remollMultScatt.hh"
 #include "remolltypes.hh"
 
 #include <math.h>
@@ -229,7 +228,7 @@ void remollGenpElastic::SamplePhysics(remollVertex *vert, remollEvent *evt){
     // as anything less than three sigma of the characteristic
     // width
     
-    if( th < 3.0*fBeamTarg->fMS->GetPDGTh() ){
+    if( th < 3.0*fBeamTarg->GetMultScatt().GetPDGTh() ){
 	sigma = 0.0;
     }
 

--- a/src/remollPrimaryGeneratorAction.cc
+++ b/src/remollPrimaryGeneratorAction.cc
@@ -35,7 +35,7 @@
 #include "remollGenHyperon.hh"
 
 remollPrimaryGeneratorAction::remollPrimaryGeneratorAction()
-: fEventGen(0),fPriGen(0),fParticleGun(0),fBeamTarg(0),fEvent(0),fMessenger(0),fEffCrossSection(0)
+: fEventGen(0),fPriGen(0),fParticleGun(0),fEvent(0),fMessenger(0),fEffCrossSection(0)
 {
     static bool has_been_warned = false;
     if (! has_been_warned) {
@@ -72,9 +72,6 @@ remollPrimaryGeneratorAction::remollPrimaryGeneratorAction()
     #endif
     #endif
 
-    // Create beam target
-    fBeamTarg = new remollBeamTarget();
-
     // Default generator
     G4String default_generator = "moller";
     SetGenerator(default_generator);
@@ -91,7 +88,6 @@ remollPrimaryGeneratorAction::~remollPrimaryGeneratorAction()
     fPriGenMap.clear();
     if (fEvGenMessenger) delete fEvGenMessenger;
     if (fMessenger) delete fMessenger;
-    if (fBeamTarg)  delete fBeamTarg;
     if (fEventGen)  delete fEventGen;
 }
 
@@ -131,7 +127,7 @@ void remollPrimaryGeneratorAction::SetGenerator(G4String& genname)
 
     // Set the beam target
     if (fEventGen) {
-      fEventGen->SetBeamTarget(fBeamTarg);
+      fEventGen->SetBeamTarget(&fBeamTarg);
     }
 }
 
@@ -206,10 +202,10 @@ void remollPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
     // Calculate rate
     SamplingType_t sampling_type = fEventGen->GetSamplingType();
     if (fEvent->fRate == 0) { // If the rate is set to 0 then calculate it using the cross section
-        fEvent->fRate  = fEvent->fEffXs * fBeamTarg->GetEffLumin(sampling_type) / nthrown;
+        fEvent->fRate  = fEvent->fEffXs * fBeamTarg.GetEffLumin(sampling_type) / nthrown;
 
     } else { // For LUND - calculate rate and cross section
-        fEvent->fEffXs = fEvent->fRate * nthrown / fBeamTarg->GetEffLumin(sampling_type);
+        fEvent->fEffXs = fEvent->fRate * nthrown / fBeamTarg.GetEffLumin(sampling_type);
         fEvent->fRate  = fEvent->fRate / nthrown;
     }
 


### PR DESCRIPTION
Requires #530.

Fewer pointers makes everyone happier.