### PR TITLE
Warn about disabled detectors with actual Det No

### DIFF
--- a/src/remollGenericDetector.cc
+++ b/src/remollGenericDetector.cc
@@ -134,13 +134,12 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
         G4cout << "remoll:   /remoll/SD/print_all" << G4endl;
         G4cout << "remoll:   /remoll/SD/enable_all" << G4endl;
         G4cout << "remoll:   /remoll/SD/disable_all" << G4endl;
-        G4cout << "remoll:   /remoll/SD/enable 4001" << G4endl;
-        G4cout << "remoll:   /remoll/SD/disable 4001" << G4endl;
+        G4cout << "remoll:   /remoll/SD/enable " << fDetNo << G4endl;
+        G4cout << "remoll:   /remoll/SD/disable " << fDetNo << G4endl;
         has_been_warned = true;
       }
       return false;
     }
-
 
     // Get the step point and track
     G4Track*     track = step->GetTrack();
@@ -188,7 +187,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
         G4cout << "remoll: To save optical photon hits, use the following in gdml:" << G4endl;
         G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"opticalphoton\"/>" << G4endl;
         G4cout << "remoll: or use the following in your macro:" << G4endl;
-        G4cout << "remoll:   /remoll/SD/detect opticalphoton 4001" << G4endl;
+        G4cout << "remoll:   /remoll/SD/detect opticalphoton " << fDetNo << G4endl;
         has_been_warned = true;
       }
       return false;
@@ -206,7 +205,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
         G4cout << "remoll: To save low energy neutral hits, use the following in gdml:" << G4endl;
         G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"lowenergyneutral\"/>" << G4endl;
         G4cout << "remoll: or use the following in your macro:" << G4endl;
-        G4cout << "remoll:   /remoll/SD/detect lowenergyneutral 4001" << G4endl;
+        G4cout << "remoll:   /remoll/SD/detect lowenergyneutral " << fDetNo << G4endl;
         has_been_warned = true;
       }
       return false;
@@ -240,7 +239,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
         G4cout << "remoll: To save entry boundary hits alone, use the following in gdml:" << G4endl;
         G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"boundaryhits\"/>" << G4endl;
         G4cout << "remoll: or use the following in your macro:" << G4endl;
-        G4cout << "remoll:   /remoll/SD/detect boundaryhits 4001" << G4endl;
+        G4cout << "remoll:   /remoll/SD/detect boundaryhits " << fDetNo << G4endl;
         has_been_warned = true;
       }
       return false;
@@ -257,7 +256,7 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
         G4cout << "remoll: To save secondary track hits too, use the following in gdml:" << G4endl;
         G4cout << "remoll:   <auxiliary auxtype=\"DetType\" auxvalue=\"secondaries\"/>" << G4endl;
         G4cout << "remoll: or use the following in your macro:" << G4endl;
-        G4cout << "remoll:   /remoll/SD/detect secondaries 4001" << G4endl;
+        G4cout << "remoll:   /remoll/SD/detect secondaries " << fDetNo << G4endl;
         has_been_warned = true;
       }
       return false;


### PR DESCRIPTION
Instead of using a 'fake' detector 4001, it now prints the actual detector number that generated the warning.