### PR TITLE
Feature collar1update

### DIFF
--- a/geometry/hybrid/hybridDaughter_unified.gdml
+++ b/geometry/hybrid/hybridDaughter_unified.gdml
@@ -13,6 +13,7 @@
         
         <constant name="PI" value="1.*pi"/>
         <constant name="DOFFSET" value="13366.57+5300.59/2-8.73/2"/>
+        <constant name="hybridcenter" value="11287.5"/>
         <constant name="DEGRAD" value="PI/180."/>
         <constant name="SEPTANT" value ="360./7"/>
         <position name="CENTER" unit="mm" x="0" y="0" z="0"/>
@@ -193,7 +194,7 @@
         </polycone>
         
         <!--collar solids -->
-        <cone name="solidCollar1" lunit="mm" aunit="rad" startphi="0" deltaphi="2*pi" rmin1="612" rmax1="750" rmin2="621" rmax2="750" z="100+50"/>
+        <cone name="solidCollar1" lunit="mm" aunit="rad" startphi="0" deltaphi="2*pi" rmin1="620" rmax1="750" rmin2="630" rmax2="750" z="100+50"/>
         <!--<cone name="solidCollar2" lunit="mm" aunit="rad" startphi="0" deltaphi="2*pi" rmin1="1013" rmax1="1315" rmin2="1022" rmax2="1315" z="100+50"/>-->
         
         <!-- drift pipe -->
@@ -3018,7 +3019,7 @@
             
             <physvol name="collar1">
                 <volumeref ref="logicCollar1"/>
-                <position unit="mm" name="collar1pos" x="0" y="0" z="16950.09-DOFFSET-150./2.-400./2"/>
+                <position unit="mm" name="collar1pos" x="0" y="0" z="11767.12+150./2-hybridcenter"/>
                 <!--<position lunit="mm" name="collar1pos" x="0" y="0" z="17350-25-DOFFSET"/>-->
                 <rotation aunit="rad" name="collar1rot" x="0" y="0" z="0"/>
             </physvol>

--- a/geometry/mollerParallel.gdml
+++ b/geometry/mollerParallel.gdml
@@ -1377,12 +1377,12 @@
 
     <physvol name="Collar1Ent_phys">
       <volumeref ref="Collar1Ent_log"/>
-      <position name="Collar1Ent_pos" unit="mm" x="0" y="0" z="11875.09-0.5"/>
+      <position name="Collar1Ent_pos" unit="mm" x="0" y="0" z="11767.12-0.5"/>
     </physvol>
 
     <physvol name="collar1Exit_phys">
       <volumeref ref="collar1Exit_log"/>
-      <position name="Collar1Exit_pos" unit="mm" x="0" y="0" z="11875.09+150+0.5"/>
+      <position name="Collar1Exit_pos" unit="mm" x="0" y="0" z="11767.12+150+0.5"/>
     </physvol>
 
     <physvol name="Drift1_phys">
@@ -1397,13 +1397,13 @@
 
     <physvol name="collar2Ent_phys">
       <volumeref ref="collar2Ent_log"/>
-      <position name="Collar2Ent_pos" unit="mm" x="0" y="0" z="19182.69-0.5"/>
+      <position name="Collar2Ent_pos" unit="mm" x="0" y="0" z="19132.69-0.5"/>
     </physvol>
 
-    <!--<physvol name="Collar2Exit_phys">
+    <physvol name="Collar2Exit_phys">
       <volumeref ref="Collar2Exit_log"/>
-      <position name="Collar2Exit_pos" unit="mm" x="0" y="0" z="19182.69+150+0.6"/>
-    </physvol>-->
+      <position name="Collar2Exit_pos" unit="mm" x="0" y="0" z="19132.69+150+0.6"/>
+    </physvol>
 
     <!-- Tracking planes -->
     <physvol name="trackingDetectorVirtualPlaneFront1_phys">


### PR DESCRIPTION
Collar 1 needs updates for its inner radii as the JLab engineers have changed the location of collar 1.
Based on studies shown on docDB 963, the inner radii for collar 1 at the new locations are set at 620 mm (for the upstream face) and 630 mm (for the downstream face).
Please review and merge this pull request ASAP since other people (The ferrous material group and the VTech group) are waiting for the updated geometry for their studies.