### PR TITLE
Modify collimator 6 A

### DIFF
--- a/geometry/hybrid/hybridDaughter_unified.gdml
+++ b/geometry/hybrid/hybridDaughter_unified.gdml
@@ -555,19 +555,20 @@
         
         <!--    Solid for Collimator 6A -->
         <xtru name="Coll6A_solid1" lunit="mm">
-            <twoDimVertex x="52.77" y="-7.79"/>
-            <twoDimVertex x="46.90" y="-25.41"/>
-            <twoDimVertex x="91.58" y="-46.92"/>
-            <twoDimVertex x="95.25" y="-46.92"/>
-            <twoDimVertex x="95.25" y="-27.87"/>
-            <twoDimVertex x="98.42" y="-27.87"/>
-            <twoDimVertex x="98.42" y="-24.70"/>
-            <twoDimVertex x="70.79" y="-24.70"/>
-            <twoDimVertex x="70.79" y="-7.79"/>
-            <section zOrder="1" zPosition="-34.925" xOffset="0" yOffset="0" scalingFactor="1"/>
-            <section zOrder="2" zPosition="34.925" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="49.836" y="-7.792"/>
+            <twoDimVertex x="49.836" y="-24.000"/>
+            <twoDimVertex x="95.250" y="-45.870"/>
+            <twoDimVertex x="95.250" y="-35.113"/>
+            <twoDimVertex x="91.821" y="-35.113"/>
+            <twoDimVertex x="91.821" y="-26.985"/>
+            <twoDimVertex x="95.250" y="-26.985"/>
+            <twoDimVertex x="95.250" y="-25.080"/>
+            <twoDimVertex x="70.787" y="-25.080"/>
+            <twoDimVertex x="70.787" y="-7.792"/>
+            <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
-        <cone aunit="deg" deltaphi="30" lunit="mm" name="Coll6A_Cylinder_solid1" rmax1="53.34" rmax2="56.02" rmin1="45" rmin2="50" startphi="-30" z="70"/>
+        <cone aunit="deg" deltaphi="30" lunit="mm" name="Coll6A_Cylinder_solid1" rmax1="55.314" rmax2="57.982" rmin1="45" rmin2="50" startphi="-30" z="70"/>
         <subtraction name="Coll6A_solid_1">
             <first ref="Coll6A_solid1"/>
             <second ref="Coll6A_Cylinder_solid1"/>
@@ -575,19 +576,21 @@
         </subtraction>
         
         <xtru name="Coll6A_solid2" lunit="mm">
-            <twoDimVertex x="46.76" y="26.78"/>
-            <twoDimVertex x="55.97" y="7.79"/>
-            <twoDimVertex x="70.79" y="7.79"/>
-            <twoDimVertex x="70.79" y="24.70"/>
-            <twoDimVertex x="98.42" y="24.70"/>
-            <twoDimVertex x="98.42" y="27.87"/>
-            <twoDimVertex x="95.25" y="27.87"/>
-            <twoDimVertex x="95.25" y="46.92"/>
-            <twoDimVertex x="91.58" y="46.92"/>
-            <section zOrder="1" zPosition="-34.925" xOffset="0" yOffset="0" scalingFactor="1"/>
-            <section zOrder="2" zPosition="34.925" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="50.277" y="29.851"/>
+            <twoDimVertex x="50.277" y="7.792"/>
+            <twoDimVertex x="70.787" y="7.792"/>
+            <twoDimVertex x="70.787" y="25.080"/>
+            <twoDimVertex x="95.250" y="25.080"/>
+            <twoDimVertex x="95.250" y="26.985"/>
+            <twoDimVertex x="91.821" y="26.985"/>
+            <twoDimVertex x="91.821" y="35.113"/>
+            <twoDimVertex x="95.250" y="35.113"/>
+            <twoDimVertex x="95.250" y="45.870"/>
+            <twoDimVertex x="93.046" y="50.447"/>
+            <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
-        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6A_Cylinder_solid2" rmax1="56.51" rmax2="59.19" rmin1="45" rmin2="50" startphi="5" z="70"/>
+        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6A_Cylinder_solid2" rmax1="58.471" rmax2="61.143" rmin1="45" rmin2="50" startphi="5" z="70"/>
         <subtraction name="Coll6A_solid_2">
             <first ref="Coll6A_solid2"/>
             <second ref="Coll6A_Cylinder_solid2"/>

--- a/geometry/hybrid/hybridDaughter_unified.gdml
+++ b/geometry/hybrid/hybridDaughter_unified.gdml
@@ -572,7 +572,7 @@
         <subtraction name="Coll6A_solid_1">
             <first ref="Coll6A_solid1"/>
             <second ref="Coll6A_Cylinder_solid1"/>
-            <position name="Coll6A_Sub_pos1" unit="mm" x="0" y="0" z="0" />
+            <position name="Coll6A_Sub_pos1" unit="mm" x="0" y="0" z="69.850/2" />
         </subtraction>
         
         <xtru name="Coll6A_solid2" lunit="mm">
@@ -594,7 +594,7 @@
         <subtraction name="Coll6A_solid_2">
             <first ref="Coll6A_solid2"/>
             <second ref="Coll6A_Cylinder_solid2"/>
-            <position name="Coll6A_Sub_pos2" unit="mm" x="0" y="0" z="0" />
+            <position name="Coll6A_Sub_pos2" unit="mm" x="0" y="0" z="69.850/2" />
         </subtraction>
         
         <!--    Solid for Collimator 6B -->
@@ -3643,13 +3643,13 @@
             <loop for="iloop" from="0" to="6" step="1">
                 <physvol>
                     <volumeref ref="Coll6A_logic1"/>
-                    <position x="0" y="0" z="1245.941+(13335.194-13332.736)-2864.764-90"/>
+                    <position x="0" y="0" z="1223.168-2864.764-90"/>
                     <rotation unit="deg" x="0" y="0" z="iloop*360./7."/>
                 </physvol>
                 
                 <physvol>
                     <volumeref ref="Coll6A_logic2"/>
-                    <position x="0" y="0" z="1245.941+82.55+(13335.194-13332.736)-2864.764-90"/>
+                    <position x="0" y="0" z="1305.718-2864.764-90"/>
                     <rotation unit="deg" x="0" y="0" z="iloop*360./7."/>
                 </physvol>
             </loop>


### PR DESCRIPTION
**Work in Progress. Do not Merge Yet** Extracted the collimator 6A dimensions and positions from CAD file provided by JLAB (email chain with Daniel on 28 April, 2022). The details look different from what had previously in develop. May be a byproduct of shifting clamps. 

Once the https://github.com/JeffersonLab/remoll/pull/562 is merged, this PR needs to be merged to avoid collimator 6A overlap with new support structure.

Two keys points:
1) Given it's at a new z position, we probably need a new physics sculpt and propagate that through to JLAB CAD to avoid discrepancy. 
2) In CAD, the inner radial face of collimator 6A is a flat plane while we model it as a conical curved surface in simulation implementation. Does this matter?

See pictures below for updated collimator view:
![Collimator6New](https://user-images.githubusercontent.com/7409132/182503310-84f6664e-3bb5-4898-bbca-86778ab4c7f0.PNG)

![New](https://user-images.githubusercontent.com/7409132/182503676-7b27d2ac-b706-4b08-bb53-e72e0f4b86a0.PNG)

