### PR TITLE
Modify collimator6 b

### DIFF
--- a/geometry/hybrid/hybridDaughter_unified.gdml
+++ b/geometry/hybrid/hybridDaughter_unified.gdml
@@ -611,7 +611,7 @@
             <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
-        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6B_Cylinder_solid1" rmax1="59.911" rmax2="65.411" rmin1="50" rmin2="55" startphi="330" z="71"/>
+        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6B_Cylinder_solid1" rmax1="59.911" rmax2="65.411" rmin1="50" rmin2="52" startphi="330" z="71"/>
         <subtraction name="Coll6B_solid_1">
             <first ref="Coll6B_solid1"/>
             <second ref="Coll6B_Cylinder_solid1"/>
@@ -634,7 +634,7 @@
             <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
-        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6B_Cylinder_solid2" rmax1="66.411" rmax2="71.912" rmin1="59" rmin2="64" startphi="-5" z="71"/>
+        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6B_Cylinder_solid2" rmax1="66.411" rmax2="71.912" rmin1="55" rmin2="58" startphi="-5" z="71"/>
         <subtraction name="Coll6B_solid_2">
             <first ref="Coll6B_solid2"/>
             <second ref="Coll6B_Cylinder_solid2"/>

--- a/geometry/hybrid/hybridDaughter_unified.gdml
+++ b/geometry/hybrid/hybridDaughter_unified.gdml
@@ -596,19 +596,22 @@
         
         <!--    Solid for Collimator 6B -->
         <xtru name="Coll6B_solid1" lunit="mm">
-            <twoDimVertex x="61.92" y="2.54"/>
-            <twoDimVertex x="133.35" y="2.54"/>
-            <twoDimVertex x="133.35" y="-26.98"/>
-            <twoDimVertex x="129.92" y="-26.98"/>
-            <twoDimVertex x="129.92" y="-35.11"/>
-            <twoDimVertex x="133.35" y="-35.11"/>
-            <twoDimVertex x="133.35" y="-39.22"/>
-            <twoDimVertex x="122.47" y="-61.80"/>
-            <twoDimVertex x="54.69" y="-29.16"/>
-            <section zOrder="1" zPosition="-34.925" xOffset="0" yOffset="0" scalingFactor="1"/>
-            <section zOrder="2" zPosition="34.925" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="53.978" y="-25.995"/>
+            <twoDimVertex x="108.116" y="-52.066"/>
+            <twoDimVertex x="115.027" y="-37.716"/>
+            <twoDimVertex x="113.030" y="-37.716"/>
+            <twoDimVertex x="113.030" y="-35.113"/>
+            <twoDimVertex x="109.601" y="-35.113"/>
+            <twoDimVertex x="109.601" y="-26.985"/>
+            <twoDimVertex x="113.030" y="-26.985"/>
+            <twoDimVertex x="113.030" y="-24.381"/>
+            <twoDimVertex x="120.000" y="-24.381"/>
+            <twoDimVertex x="120.000" y="0.000"/>
+            <twoDimVertex x="53.978" y="0.000"/>               
+            <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
-        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6B_Cylinder_solid1" rmax1="61.98" rmax2="67.47" rmin1="50" rmin2="55" startphi="330" z="71"/>
+        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6B_Cylinder_solid1" rmax1="59.911" rmax2="65.411" rmin1="50" rmin2="55" startphi="330" z="71"/>
         <subtraction name="Coll6B_solid_1">
             <first ref="Coll6B_solid1"/>
             <second ref="Coll6B_Cylinder_solid1"/>
@@ -616,19 +619,22 @@
         </subtraction>
         
         <xtru name="Coll6B_solid2" lunit="mm">
-            <twoDimVertex x="68.43" y="-2.54"/>
-            <twoDimVertex x="133.35" y="-2.54"/>
-            <twoDimVertex x="133.35" y="26.98"/>
-            <twoDimVertex x="129.92" y="26.98"/>
-            <twoDimVertex x="129.92" y="35.11"/>
-            <twoDimVertex x="133.35" y="35.11"/>
-            <twoDimVertex x="133.35" y="39.22"/>
-            <twoDimVertex x="122.47" y="61.80"/>
-            <twoDimVertex x="60.55" y="31.98"/>
-            <section zOrder="1" zPosition="-34.925" xOffset="0" yOffset="0" scalingFactor="1"/>
-            <section zOrder="2" zPosition="34.925" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <twoDimVertex x="57.455" y="-5.080"/>
+            <twoDimVertex x="120.000" y="-5.080"/>
+            <twoDimVertex x="120.000" y="24.381"/>
+            <twoDimVertex x="113.030" y="24.381"/>
+            <twoDimVertex x="113.030" y="26.985"/>
+            <twoDimVertex x="109.601" y="26.985"/>
+            <twoDimVertex x="109.601" y="35.113"/>
+            <twoDimVertex x="113.030" y="35.113"/>
+            <twoDimVertex x="113.030" y="37.716"/>
+            <twoDimVertex x="115.027" y="37.716"/>
+            <twoDimVertex x="105.912" y="56.643"/>
+            <twoDimVertex x="57.455" y="33.307"/>
+            <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
+            <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
-        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6B_Cylinder_solid2" rmax1="68.47" rmax2="73.97" rmin1="59" rmin2="64" startphi="-5" z="71"/>
+        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6B_Cylinder_solid2" rmax1="66.411" rmax2="71.912" rmin1="59" rmin2="64" startphi="-5" z="71"/>
         <subtraction name="Coll6B_solid_2">
             <first ref="Coll6B_solid2"/>
             <second ref="Coll6B_Cylinder_solid2"/>

--- a/geometry/hybrid/hybridDaughter_unified.gdml
+++ b/geometry/hybrid/hybridDaughter_unified.gdml
@@ -634,7 +634,7 @@
             <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
-        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6B_Cylinder_solid2" rmax1="66.411" rmax2="71.912" rmin1="55" rmin2="58" startphi="-5" z="71"/>
+        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6B_Cylinder_solid2" rmax1="66.411" rmax2="71.912" rmin1="55" rmin2="56" startphi="-5" z="71"/>
         <subtraction name="Coll6B_solid_2">
             <first ref="Coll6B_solid2"/>
             <second ref="Coll6B_Cylinder_solid2"/>

--- a/geometry/hybrid/hybridDaughter_unified.gdml
+++ b/geometry/hybrid/hybridDaughter_unified.gdml
@@ -615,7 +615,7 @@
         <subtraction name="Coll6B_solid_1">
             <first ref="Coll6B_solid1"/>
             <second ref="Coll6B_Cylinder_solid1"/>
-            <position name="Coll6B_Sub_pos1" unit="mm" x="0" y="0" z="0" />
+            <position name="Coll6B_Sub_pos1" unit="mm" x="0" y="0" z="69.850/2" />
         </subtraction>
         
         <xtru name="Coll6B_solid2" lunit="mm">
@@ -638,7 +638,7 @@
         <subtraction name="Coll6B_solid_2">
             <first ref="Coll6B_solid2"/>
             <second ref="Coll6B_Cylinder_solid2"/>
-            <position name="Coll6B_Sub_pos2" unit="mm" x="0" y="0" z="0" />
+            <position name="Coll6B_Sub_pos2" unit="mm" x="0" y="0" z="69.850/2" />
         </subtraction>
         
         
@@ -3660,13 +3660,13 @@
             <loop for="iloop" from="0" to="6" step="1">
                 <physvol>
                     <volumeref ref="Coll6B_logic1"/>
-                    <position x="0" y="0" z="2617.541+(13335.194-13332.736)-2864.764-90"/>
+                    <position x="0" y="0" z="2594.768-2864.764-90"/>
                     <rotation unit="deg" x="0" y="0" z="iloop*360./7."/>
                 </physvol>
                 
                 <physvol>
                     <volumeref ref="Coll6B_logic2"/>
-                    <position x="0" y="0" z="2617.541+82.55+(13335.194-13332.736)-2864.764-90"/>
+                    <position x="0" y="0" z="2677.318-2864.764-90"/>
                     <rotation unit="deg" x="0" y="0" z="iloop*360./7."/>
                 </physvol>
             </loop>


### PR DESCRIPTION
**Work in progress. Do not merge yet**
Suffers from similar issue to collimator 6A (https://github.com/JeffersonLab/remoll/pull/563) based on JLAB CAD:

1) Vertices don't match exactly between JLAB CAD and what we had in simulation develop. Will make an overlay of 2D profile to check how different it is actually.
2) Again the inner radial face in CAD is not conical. 
![COllimator6BFront](https://user-images.githubusercontent.com/7409132/182552070-9a4936b9-3612-421c-907a-57fbe4e94a0d.PNG)
![COllimator6BSide](https://user-images.githubusercontent.com/7409132/182552090-fc888f24-5ce7-4166-8ae2-fb8cba360777.PNG)

Once the https://github.com/JeffersonLab/remoll/pull/562 is merged and the above issues resolved, this PR needs to be merged to avoid collimator 6B overlap with new support structure.