### PR TITLE
Feature: update detector and SAM pipe region

### DIFF
--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -140,12 +140,16 @@
     <volume name="logic_Neckdown">
       <materialref ref="G4_Al"/>
       <solidref ref="Neckdown"/>
+      <auxiliary auxtype="SensDet" auxvalue="coilDet"/>
+      <auxiliary auxtype="DetNo" auxvalue="800"/>
       <auxiliary auxtype="Color" auxvalue="Blue"/>
     </volume>
 
     <volume name="logic_Neckdown_DSpipe">
       <materialref ref="G4_Al"/>
       <solidref ref="Neckdown_DSpipe"/>
+      <auxiliary auxtype="SensDet" auxvalue="coilDet"/>
+      <auxiliary auxtype="DetNo" auxvalue="801"/>
       <auxiliary auxtype="Color" auxvalue="Blue"/>
     </volume>
 
@@ -153,30 +157,40 @@
     <volume name="logic_Neckdown_bellows_flange_1">
       <materialref ref="Inconel625"/>
       <solidref ref="Neckdown_bellows_flange_1"/>
+      <auxiliary auxtype="SensDet" auxvalue="coilDet"/>
+      <auxiliary auxtype="DetNo" auxvalue="802"/>
       <auxiliary auxtype="Color" auxvalue="Yellow"/>
     </volume> 
 
     <volume name="logic_Neckdown_bellows">
       <materialref ref="Inconel625_Air"/>
       <solidref ref="Neckdown_bellows"/>
+      <auxiliary auxtype="SensDet" auxvalue="coilDet"/>
+      <auxiliary auxtype="DetNo" auxvalue="803"/>
       <auxiliary auxtype="Color" auxvalue="Brown"/>
     </volume>
 
     <volume name="logic_Neckdown_bellows_flange_2">
       <materialref ref="Inconel625"/>
       <solidref ref="Neckdown_bellows_flange_2"/>
+      <auxiliary auxtype="SensDet" auxvalue="coilDet"/>
+      <auxiliary auxtype="DetNo" auxvalue="804"/>
       <auxiliary auxtype="Color" auxvalue="Yellow"/>
     </volume>
 
     <volume name="logic_SAM_support_placeholder">
       <materialref ref="G4_Al"/>
       <solidref ref="SAM_support_placeholder"/>
+      <auxiliary auxtype="SensDet" auxvalue="coilDet"/>
+      <auxiliary auxtype="DetNo" auxvalue="805"/>
       <auxiliary auxtype="Color" auxvalue="Blue"/>
     </volume>
 
     <volume name="logic_SAMpipeWithFlange">
       <materialref ref="G4_Al"/>
       <solidref ref="SAMpipeWithFlange"/>
+      <auxiliary auxtype="SensDet" auxvalue="coilDet"/>
+      <auxiliary auxtype="DetNo" auxvalue="806"/>
       <auxiliary auxtype="Color" auxvalue="Blue"/>
     </volume>
 

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -38,8 +38,8 @@
     </polycone>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_DSpipe">
-      <zplane rmin="196.85" rmax="203.2" z="24919.974"/>
-      <zplane rmin="196.85" rmax="203.2" z="25085.074"/>
+      <zplane rmin="200.025" rmax="203.2" z="25188.010"/>
+      <zplane rmin="200.025" rmax="203.2" z="25315.010"/>
     </polycone>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows_1">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -23,7 +23,7 @@
       <zplane rmin="0" rmax="600" z="19000.0"/>-->
       <zplane rmin="0" rmax="1019" z="19332.69+0.02"/>
       <zplane rmin="0" rmax="600" z="19332.69+0.02"/>
-      <zplane rmin="0" rmax="775" z="26720.141"/>
+      <zplane rmin="0" rmax="750" z="26720.141"/>
     </polycone>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_DSpipe3">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -42,7 +42,7 @@
       <zplane rmin="200.025" rmax="203.2" z="25315.010"/>
     </polycone>
 	
-    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows_flange1">
+    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows_flange_1">
       <zplane rmin="200.025" rmax="203.2" z="25315.010"/>
       <zplane rmin="200.025" rmax="203.2" z="25346.682"/>
       <zplane rmin="200.025" rmax="234.95" z="25346.682"/>

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -27,37 +27,6 @@
       <zplane rmin="0" rmax="770" z="26500.0"/>
     </polycone>
 
-    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_DSpipe2_2">
-      <zplane rmin="506.1201" rmax="510.8826" z="19000.0"/>
-      <zplane rmin="528.33" rmax="533.0925" z="19589+4.99"/>
-    </polycone>
-
-    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_DSpipe2_DSplate">
-      <zplane rmin="523.5" rmax="528.0" z="19589.0"/>
-      <zplane rmin="523.67" rmax="528." z="19589.0+5"/>
-      <zplane rmin="523.67" rmax="533.05" z="19589.0+5"/>
-      <zplane rmin="523.942" rmax="533.05" z="19589.0+5+8"/>
-      <zplane rmin="523.942" rmax="553.325" z="19589.0+5+8"/>
-      <zplane rmin="524.35" rmax="553.325" z="19589.0+5+8+12"/>
-    </polycone>
-
-    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_DSpipe2_bellow">
-      <zplane rmin="524.335" rmax="553.335" z="19614.0"/>
-      <zplane rmin="524.4556" rmax="553.335" z="19614.0+6.35"/>
-      <zplane rmin="524.4556" rmax="524.4556+6.35" z="19614.0+6.35"/>
-      <zplane rmin="524.9744" rmax="524.4556+6.35" z="19614.0+6.35+27.3"/>
-      <zplane rmin="524.9744" rmax="553.335" z="19614.0+6.35+27.3"/>
-      <zplane rmin="525.095" rmax="553.335" z="19614.0+6.35+27.3+6.35"/>
-      <zplane rmin="525.0" rmax="553.6" z="19614.0+6.35+27.3+6.35"/>
-      <zplane rmin="525.0" rmax="553.6" z="19614.0+6.35+27.3+6.35+100"/>
-      <zplane rmin="525.0" rmax="553.6" z="19614.0+6.35+27.3+6.35+100"/>
-      <zplane rmin="525.0" rmax="553.6" z="19614.0+6.35+27.3+6.35+100+4.8"/>
-      <zplane rmin="525.0" rmax="525.0+4.8" z="19614.0+6.35+27.3+6.35+100+4.8"/>
-      <zplane rmin="525.0" rmax="525.0+4.8" z="19614.0+6.35+27.3+6.35+100+4.8+30.4"/>
-      <zplane rmin="525.0" rmax="553.6" z="19614.0+6.35+27.3+6.35+100+4.8+30.4"/>
-      <zplane rmin="525.0" rmax="553.6" z="19614.0+6.35+27.3+6.35+100+4.8+30.4+4.8"/>
-    </polycone>
-
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_DSpipe3">
       <zplane rmin="525.0" rmax="544.05" z="19794.0"/>
       <zplane rmin="713.74" rmax="732.79" z="25219.694"/>
@@ -115,11 +84,6 @@
   </solids>
 
   <structure>
-    <volume name="logic_DSpipe2_2">
-      <materialref ref="G4_Al"/>
-      <solidref ref="solid_DSpipe2_2"/>
-      <auxiliary auxtype="Color" auxvalue="Blue"/>
-    </volume>
 
     <volume name="logic_vacuum_insert">
       <materialref ref="G4_Galactic"/>
@@ -143,19 +107,6 @@
       <materialref ref="G4_Al"/>
       <solidref ref="sam_can_spherical_cap"/>
       <auxiliary auxtype="Color" auxvalue="Red"/>
-    </volume>
-
-
-    <volume name="logic_DSpipe2_DSplate">
-      <materialref ref="G4_Al"/>
-      <solidref ref="solid_DSpipe2_DSplate"/>
-      <auxiliary auxtype="Color" auxvalue="Blue"/>
-    </volume>
-
-    <volume name="logic_DSpipe2_bellow">
-      <materialref ref="G4_STAINLESS-STEEL"/>
-      <solidref ref="solid_DSpipe2_bellow"/>
-      <auxiliary auxtype="Color" auxvalue="Brown"/>
     </volume>
 
     <volume name="logic_DSpipe3">
@@ -280,18 +231,6 @@
     <volume name="DSbeampipeMother">
       <materialref ref="G4_Galactic"/>
       <solidref ref="solid_DSbeampipe_vacuum"/>
-
- <!--      <physvol name="DSpipe2_DSpipe2_2">
-	<volumeref ref="logic_DSpipe2_2"/>
-      </physvol>
-
-     <physvol name="DSpipe2_DSplate">
-	<volumeref ref="logic_DSpipe2_DSplate"/>
-      </physvol>
-
-      <physvol name="DSpipe2_bellow">
-	<volumeref ref="logic_DSpipe2_bellow"/>
-      </physvol>-->
 
       <physvol name="DSpipe3_DSpipe">
 	<volumeref ref="logic_DSpipe3"/>

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -31,10 +31,21 @@
       <zplane rmin="713.74" rmax="732.79" z="25219.694"/>
     </polycone>
     
-    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown">
-      <zplane rmin="203.2+0.254" rmax="216.154" z="24932.42"/>
-      <zplane rmin="720.09" rmax="732.79" z="25230.87"/>
+    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_mother">
+      <zplane rmin="0" rmax="206.375" z="25200.710"/>
+      <zplane rmin="0" rmax="701.127" z="25486.355"/>
     </polycone>
+	  
+    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_sub">
+      <zplane rmin="0" rmax="206.375" z="0"/>
+      <zplane rmin="0" rmax="203.2" z="25206.210-25200.710"/>
+      <zplane rmin="0" rmax="688.4255" z="25486.355-25200.710"/>
+    </polycone>
+  
+    <subtraction name= =“Neckdown” >
+      <first  ref=“Neckdown_mother” />
+      <second ref=“Neckdown_sub”/>
+    </subtraction>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_DSpipe">
       <zplane rmin="200.025" rmax="203.2" z="25188.010"/>

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -58,12 +58,14 @@
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_DSpipe">
       <zplane rmin="200.025" rmax="203.2" z="25188.010"/>
       <zplane rmin="200.025" rmax="203.2" z="25315.010"/>
-    </polycone>
-	
-    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows_flange_1">
       <zplane rmin="200.025" rmax="203.2" z="25315.010"/>
       <zplane rmin="200.025" rmax="203.2" z="25346.682"/>
       <zplane rmin="200.025" rmax="234.95" z="25346.682"/>
+      <zplane rmin="200.025" rmax="234.95" z="25375.130"/>	    
+    </polycone>
+	
+    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows_flange_1">
+      <zplane rmin="200.025" rmax="234.95" z="25375.130"/>      
       <zplane rmin="200.025" rmax="234.95" z="25390.878"/>
       <zplane rmin="203.581" rmax="234.95" z="25390.878"/>
       <zplane rmin="203.581" rmax="234.95" z="25403.578"/>	    
@@ -86,9 +88,7 @@
       <zplane rmin="203.581" rmax="234.95" z="25905.482"/>
       <zplane rmin="203.581" rmax="234.95" z="25918.182"/>
       <zplane rmin="200.025" rmax="234.95" z="25918.182"/>
-      <zplane rmin="200.025" rmax="234.95" z="25962.378"/>
-      <zplane rmin="200.025" rmax="203.2" z="25962.378"/>
-      <zplane rmin="200.025" rmax="203.2" z="25991.766"/>
+      <zplane rmin="200.025" rmax="234.95" z="25933.930"/>
     </polycone>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="SAM_support_placeholder">
@@ -97,6 +97,10 @@
     </polycone>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="SAMpipeWithFlange">
+      <zplane rmin="200.025" rmax="234.95" z="25933.930"/>
+      <zplane rmin="200.025" rmax="234.95" z="25962.378"/>
+      <zplane rmin="200.025" rmax="203.2" z="25962.378"/>
+      <zplane rmin="200.025" rmax="203.2" z="25991.766"/>
       <zplane rmin="196.85" rmax="203.2" z="25991.766"/>
       <zplane rmin="196.85" rmax="203.2" z="26694.741"/>
       <zplane rmin="196.85" rmax="584.2" z="26694.741"/>
@@ -155,7 +159,7 @@
     <volume name="logic_Neckdown_bellows">
       <materialref ref="G4_STAINLESS-STEEL"/>
       <solidref ref="Neckdown_bellows"/>
-      <auxiliary auxtype="Color" auxvalue="Blue"/>
+      <auxiliary auxtype="Color" auxvalue="Brown"/>
     </volume>
 
     <volume name="logic_Neckdown_bellows_flange_2">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -27,8 +27,16 @@
     </polycone>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_DSpipe3">
-      <zplane rmin="525.0" rmax="544.05" z="19794.0"/>
-      <zplane rmin="713.74" rmax="732.79" z="25219.694"/>
+      <zplane rmin="521.7" rmax="528.052" z="19415.451 "/>
+      <zplane rmin="542.341" rmax="548.693" z="20238.112"/>
+      <zplane rmin="542.341" rmax="574.093" z="20238.112 "/>
+      <zplane rmin="542.341" rmax="574.093" z="20263.512"/>
+      <zplane rmin="542.341" rmax="548.693" z="20263.512"/>
+      <zplane rmin="562.7" rmax="569.0525" z="21099.991"/>
+      <zplane rmin="562.7" rmax="608.5" z="21099.991"/>
+      <zplane rmin="562.7" rmax="608.5" z="21125.391"/>
+      <zplane rmin="576.745" rmax="595.8" z="21125.391"/>
+      <zplane rmin="676.445" rmax="695.5" z="25472.105"/>
     </polycone>
     
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_mother">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -41,15 +41,15 @@
       <zplane rmin="200.025" rmax="203.2" z="25188.010"/>
       <zplane rmin="200.025" rmax="203.2" z="25315.010"/>
     </polycone>
-
-    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows_1">
-      <zplane rmin="203.454" rmax="246.888" z="25072.374"/>
-      <zplane rmin="203.454" rmax="246.888" z="25085.074"/>
-      <zplane rmin="200.152" rmax="246.888" z="25085.074"/>
-      <zplane rmin="200.152" rmax="246.888" z="25119.872"/>
-      <zplane rmin="203.454+6.35" rmax="246.888" z="25119.872"/>
-      <zplane rmin="203.454+6.35" rmax="246.888" z="25119.872+12.7"/>
-    </polycone>
+	
+    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows_flange1">
+      <zplane rmin="200.025" rmax="203.2" z="25315.010"/>
+      <zplane rmin="200.025" rmax="203.2" z="25346.682"/>
+      <zplane rmin="200.025" rmax="234.95" z="25346.682"/>
+      <zplane rmin="200.025" rmax="234.95" z="25390.878"/>
+      <zplane rmin="203.581" rmax="234.95" z="25390.878"/>
+      <zplane rmin="203.581" rmax="234.95" z="25403.578"/>	    
+    </polycone>	  
     
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows_2">
       <zplane rmin="196.85" rmax="203.2+6.35" z="25119.872"/>
@@ -128,9 +128,9 @@
     </volume>
 
     
-    <volume name="logic_Neckdown_bellows_1">
+    <volume name="logic_Neckdown_bellows_flange_1">
       <materialref ref="G4_STAINLESS-STEEL"/>
-      <solidref ref="Neckdown_bellows_1"/>
+      <solidref ref="Neckdown_bellows_flange_1"/>
       <auxiliary auxtype="Color" auxvalue="Blue"/>
     </volume> 
 
@@ -244,8 +244,8 @@
 	<volumeref ref="logic_Neckdown_DSpipe"/>
       </physvol>
 
-      <physvol name="Neckdown_bellows_1">
-	<volumeref ref="logic_Neckdown_bellows_1"/>
+      <physvol name="Neckdown_bellows_flange_1">
+	<volumeref ref="logic_Neckdown_bellows_flange_1"/>
       </physvol>
 
       <physvol name="Neckdown_bellows_2">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -215,143 +215,143 @@
       <physvol name="Sam_can_1">
 	<volumeref ref="SAM_cans_logic"/>
 	<rotation name="can_rotation1" x="90" y="45" unit="deg"/>
-	<position name="can_position1" x="77.425+10.035" y="-77.425-10.035" z="25637.524+12.7+34.798+12.7+50+150"/>
+	<position name="can_position1" x="77.425+10.035" y="-77.425-10.035" z="26235.085"/>
       </physvol>
 
       <physvol name="SAM_Detectors_1">
         <volumeref ref="logic_SAM_Detectors"/>
         <rotation name="quartz_rotation1"  z="-45" unit="deg"/>
-        <position name="quartz_position1" x="16.425+25.55" y="-16.425-25.55" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="quartz_position1" x="16.425+25.55" y="-16.425-25.55" z="26235.085"/>
       </physvol>
 
       <physvol name="Sam_sphere_1">
         <volumeref ref="SAM_can_spherical_logic"/>
         <rotation name="sphere_rotation1" x="90" y="45" unit="deg"/>
-        <position name="sphere_position1" x="44-12+5.15" y="-44+12-5.15" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="sphere_position1" x="44-12+5.15" y="-44+12-5.15" z="26235.085"/>
       </physvol>
      
       <physvol name="SAM_Detectors_2">
         <volumeref ref="logic_SAM_Detectors"/>
-        <position name="quartz_position2" x="0" y="-51.425-6.75" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="quartz_position2" x="0" y="-51.425-6.75" z="26171.585"/>
       </physvol>
 
       <physvol name="Sam_can_2">
         <volumeref ref="SAM_cans_logic"/>
         <rotation name="can_rotation2" unit="deg" x="90"/>
-        <position name="can_position2" x="0" y="-77.425-45" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="can_position2" x="0" y="-77.425-45" z="26171.585"/>
       </physvol>
 
       <physvol name="Sam_sphere_2">
         <volumeref ref="SAM_can_spherical_logic"/>
         <rotation name="sphere_rotation2" unit="deg" x="90"/>
-        <position name="sphere_position2" x="0" y="-45.25-6" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="sphere_position2" x="0" y="-45.25-6" z="26171.585"/>
       </physvol>
 
       <physvol name="Sam_can_3">
         <volumeref ref="SAM_cans_logic"/>
         <rotation name="can_rotation3" unit="deg" x="90" y="-45"/>
-        <position name="can_position3" x="77.425+10.035" y="77.425+10.035" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="can_position3" x="77.425+10.035" y="77.425+10.035" z="26235.085"/>
       </physvol>
 
       <physvol name="SAM_Detectors_3">
         <volumeref ref="logic_SAM_Detectors"/>
         <rotation name="quartz_rotation3"  z="45" unit="deg"/>
-        <position name="quartz_position3" x="16.425+25.55" y="16.425+25.55" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="quartz_position3" x="16.425+25.55" y="16.425+25.55" z="26235.085"/>
       </physvol>
 
       <physvol name="Sam_sphere_3">
         <volumeref ref="SAM_can_spherical_logic"/>
         <rotation name="sphere_rotation3" unit="deg" x="-90" y="45"/>
-        <position name="sphere_position3" x="44-12+5.15" y="44-12+5.15" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="sphere_position3" x="44-12+5.15" y="44-12+5.15" z="26235.085"/>
       </physvol>
 
       <physvol name="Sam_can_4">
         <volumeref ref="SAM_cans_logic"/>
         <rotation name="can_rotation4" unit="deg" y="90"/>
-        <position name="can_position4" x="-77.425-45" y="0" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="can_position4" x="-77.425-45" y="0" z="26171.585"/>
       </physvol>
 
       <physvol name="SAM_Detectors_4">
         <volumeref ref="logic_SAM_Detectors"/>
         <rotation name="can_rotation4" unit="deg" z="90"/> 
-        <position name="quartz_position4" x="-51.425-6.75" y="0" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="quartz_position4" x="-51.425-6.75" y="0" z="26171.585"/>
       </physvol>
 
       <physvol name="Sam_sphere_4">
         <volumeref ref="SAM_can_spherical_logic"/>
         <rotation name="sphere_rotation4" unit="deg" y="-90"/>
-        <position name="sphere_position4" x="-45.25-6" y="0" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="sphere_position4" x="-45.25-6" y="0" z="26171.585"/>
       </physvol>
 
       <physvol name="sam_can_5">
         <volumeref ref="SAM_cans_logic"/>
         <rotation name="can_rotation5" unit="deg" x="90" y="45"/>
-        <position name="can_position5" x="-77.425-10.035" y="77.425+10.035" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="can_position5" x="-77.425-10.035" y="77.425+10.035" z="26235.085"/>
       </physvol>
 
       <physvol name="SAM_Detectors_5">
         <volumeref ref="logic_SAM_Detectors"/>
         <rotation name="quartz_rotation5"  z="-45" unit="deg"/>
-        <position name="quartz_position5" x="-16.425-25.55" y="16.425+25.55" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="quartz_position5" x="-16.425-25.55" y="16.425+25.55" z="26235.085"/>
       </physvol>
 
       <physvol name="sam_sphere_5">
         <volumeref ref="SAM_can_spherical_logic"/>
         <rotation name="sphere_rotation5" unit="deg" x="-90" y="-45"/>
-        <position name="sphere_position5" x="-44+12-5.15" y="44-12+5.15" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="sphere_position5" x="-44+12-5.15" y="44-12+5.15" z="26235.085"/>
       </physvol>
 
       <physvol name="Sam_can_6">
         <volumeref ref="SAM_cans_logic"/>
         <rotation name="can_rotation6" unit="deg" x="-90"/>
-        <position name="can_position6" x="0" y="77.425+45" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="can_position6" x="0" y="77.425+45" z="26171.585"/>
       </physvol>
 
       <physvol name="SAM_Detectors_6">
         <volumeref ref="logic_SAM_Detectors"/>
-        <position name="quartz_position6" x="0" y="51.425+6.75" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="quartz_position6" x="0" y="51.425+6.75" z="26171.585"/>
       </physvol>
 
       <physvol name="Sam_sphere_6">
         <volumeref ref="SAM_can_spherical_logic"/>
         <rotation name="sphere_rotation6" unit="deg" x="-90"/>
-        <position name="sphere_position6" x="0" y="45.25+6" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="sphere_position6" x="0" y="45.25+6" z="26171.585"/>
       </physvol>
 
       <physvol name="Sam_can_7">
         <volumeref ref="SAM_cans_logic"/>
         <rotation name="can_rotation7" unit="deg" x="90" y="-45"/>
-        <position name="can_position7" x="-77.425-10.035" y="-77.425-10.035" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="can_position7" x="-77.425-10.035" y="-77.425-10.035" z="26235.085"/>
       </physvol>
 
       <physvol name="SAM_Detectors_7">
         <volumeref ref="logic_SAM_Detectors"/>
         <rotation name="quartz_rotation7"  z="45" unit="deg"/>
-        <position name="quartz_position7" x="-16.425-25.55" y="-16.425-25.55" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="quartz_position7" x="-16.425-25.55" y="-16.425-25.55" z="26235.085"/>
       </physvol>
 
       <physvol name="Sam_sphere_7">
         <volumeref ref="SAM_can_spherical_logic"/>
         <rotation name="sphere_rotation7" unit="deg" x="90" y="-45"/>
-        <position name="sphere_position7" x="-44+12-5.15" y="-44+12-5.15" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="sphere_position7" x="-44+12-5.15" y="-44+12-5.15" z="26235.085"/>
       </physvol>
 
       <physvol name="Sam_can_8">
         <volumeref ref="SAM_cans_logic"/>
         <rotation name="can_rotation8" unit="deg" y="-90"/>
-        <position name="can_position8" x="77.425+45" y="0" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="can_position8" x="77.425+45" y="0" z="26171.585"/>
       </physvol>
 
       <physvol name="SAM_Detectors_8">
         <volumeref ref="logic_SAM_Detectors"/>
         <rotation name="can_rotation8" unit="deg" z="90"/> 
-        <position name="quartz_position8" x="51.425+6.75" y="0" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="quartz_position8" x="51.425+6.75" y="0" z="26171.585"/>
       </physvol>
 
       <physvol name="Sam_sphere_8">
         <volumeref ref="SAM_can_spherical_logic"/>
         <rotation name="sphere_rotation8" unit="deg" y="90"/>
-        <position name="sphere_position8" x="45.25+6" y="0" z="25637.524+12.7+34.798+12.7+50+150"/>
+        <position name="sphere_position8" x="45.25+6" y="0" z="26171.585"/>
       </physvol>
     
       <physvol name="SAMpipeWithFlange">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -42,9 +42,9 @@
       <zplane rmin="0" rmax="688.4255" z="25486.355-25200.710"/>
     </polycone>
   
-    <subtraction name=“Neckdown” >
-      <first  ref=“Neckdown_mother” />
-      <second ref=“Neckdown_sub”/>
+    <subtraction name="Neckdown" >
+      <first  ref="Neckdown_mother" />
+      <second ref="Neckdown_sub"/>
     </subtraction>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_DSpipe">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -45,9 +45,9 @@
     </polycone>
 	  
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_sub">
-      <zplane rmin="0" rmax="206.375" z="25200.710"/>
+      <zplane rmin="0" rmax="206.952" z="25200.710-1"/>
       <zplane rmin="0" rmax="203.2" z="25206.210"/>
-      <zplane rmin="0" rmax="688.4255" z="25486.355"/>
+      <zplane rmin="0" rmax="690.1576" z="25486.355+1"/>
     </polycone>
   
     <subtraction name="Neckdown">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -64,13 +64,13 @@
       <zplane rmin="200.025" rmax="203.073" z="25916.149"/>
     </polycone>
 
-    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows_3">
-      <zplane rmin="203.454+6.35" rmax="246.888" z="25637.524"/>
-      <zplane rmin="203.454+6.35" rmax="246.888" z="25637.524+12.7"/>
-      <zplane rmin="200.152" rmax="246.888" z="25637.524+12.7"/>
-      <zplane rmin="200.152" rmax="246.888" z="25637.524+12.7+34.798"/>
-      <zplane rmin="203.454" rmax="246.888" z="25637.524+12.7+34.798"/>
-      <zplane rmin="203.454" rmax="246.888" z="25637.524+12.7+34.798+12.7"/>
+    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows_flange_2">
+      <zplane rmin="203.581" rmax="234.95" z="25905.482"/>
+      <zplane rmin="203.581" rmax="234.95" z="25918.182"/>
+      <zplane rmin="200.025" rmax="234.95" z="25918.182"/>
+      <zplane rmin="200.025" rmax="234.95" z="25962.378"/>
+      <zplane rmin="200.025" rmax="203.2" z="25962.378"/>
+      <zplane rmin="200.025" rmax="203.2" z="25991.766"/>
     </polycone>
 
     <tube name = "Shield" rmin="203.454" rmax="403.454" z="300" deltaphi="360" startphi="0" aunit="deg" lunit= "mm"/>
@@ -148,9 +148,9 @@
       <auxiliary auxtype="Color" auxvalue="Blue"/>
     </volume>
 
-    <volume name="logic_Neckdown_bellows_3">
+    <volume name="logic_Neckdown_bellows_flange_2">
       <materialref ref="G4_STAINLESS-STEEL"/>
-      <solidref ref="Neckdown_bellows_3"/>
+      <solidref ref="Neckdown_bellows_flange_2"/>
       <auxiliary auxtype="Color" auxvalue="Blue"/>
     </volume>
 
@@ -260,8 +260,8 @@
 	<volumeref ref="logic_Neckdown_bellows"/>
       </physvol>
 
-      <physvol name="Neckdown_bellows_3">
-	<volumeref ref="logic_Neckdown_bellows_3"/>
+      <physvol name="Neckdown_bellows_flange_2">
+	<volumeref ref="logic_Neckdown_bellows_flange_2"/>
       </physvol>
 
       <physvol name="Shield">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -37,15 +37,14 @@
     </polycone>
 	  
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_sub">
-      <zplane rmin="0" rmax="206.375" z="0"/>
-      <zplane rmin="0" rmax="203.2" z="25206.210-25200.710"/>
-      <zplane rmin="0" rmax="688.4255" z="25486.355-25200.710"/>
+      <zplane rmin="0" rmax="206.375" z="25200.710"/>
+      <zplane rmin="0" rmax="203.2" z="25206.210"/>
+      <zplane rmin="0" rmax="688.4255" z="25486.355"/>
     </polycone>
   
     <subtraction name="Neckdown">
       <first  ref="Neckdown_mother"/>
       <second ref="Neckdown_sub"/>
-      <position name="Neckdown_sub_pos" x="0" y="0" z="0" unit="mm"/>
     </subtraction>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_DSpipe">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -42,7 +42,7 @@
       <zplane rmin="0" rmax="688.4255" z="25486.355-25200.710"/>
     </polycone>
   
-    <subtraction name= =“Neckdown” >
+    <subtraction name=“Neckdown” >
       <first  ref=“Neckdown_mother” />
       <second ref=“Neckdown_sub”/>
     </subtraction>

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -23,7 +23,7 @@
       <zplane rmin="0" rmax="600" z="19000.0"/>-->
       <zplane rmin="0" rmax="1019" z="19332.69+0.02"/>
       <zplane rmin="0" rmax="600" z="19332.69+0.02"/>
-      <zplane rmin="0" rmax="770" z="26500.0"/>
+      <zplane rmin="0" rmax="775" z="26720.141"/>
     </polycone>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_DSpipe3">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -42,9 +42,10 @@
       <zplane rmin="0" rmax="688.4255" z="25486.355-25200.710"/>
     </polycone>
   
-    <subtraction name="Neckdown" >
-      <first  ref="Neckdown_mother" />
+    <subtraction name="Neckdown">
+      <first  ref="Neckdown_mother"/>
       <second ref="Neckdown_sub"/>
+      <position name="Neckdown_sub_pos" x="0" y="0" z="0" unit="mm"/>
     </subtraction>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_DSpipe">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -51,9 +51,17 @@
       <zplane rmin="203.581" rmax="234.95" z="25403.578"/>	    
     </polycone>	  
     
-    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows_2">
-      <zplane rmin="196.85" rmax="203.2+6.35" z="25119.872"/>
-      <zplane rmin="196.85" rmax="203.2+6.35" z="25119.872+530.352"/>
+    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows">
+      <zplane rmin="200.025" rmax="203.073" z="25392.912"/>
+      <zplane rmin="200.025" rmax="203.073" z="25467.509"/>
+      <zplane rmin="200.025" rmax="226.4155" z="25467.509"/>
+      <zplane rmin="200.025" rmax="226.4155" z="25470.557"/>
+      <zplane rmin="203.2" rmax="226.4155" z="25470.557"/>
+      <zplane rmin="203.2" rmax="226.4155" z="25838.504"/>
+      <zplane rmin="200.025" rmax="226.4155" z="25838.504"/>
+      <zplane rmin="200.025" rmax="226.4155" z="25841.552"/>
+      <zplane rmin="200.025" rmax="203.073" z="25841.552"/>
+      <zplane rmin="200.025" rmax="203.073" z="25916.149"/>
     </polycone>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="Neckdown_bellows_3">
@@ -134,9 +142,9 @@
       <auxiliary auxtype="Color" auxvalue="Blue"/>
     </volume> 
 
-    <volume name="logic_Neckdown_bellows_2">
+    <volume name="logic_Neckdown_bellows">
       <materialref ref="G4_STAINLESS-STEEL"/>
-      <solidref ref="Neckdown_bellows_2"/>
+      <solidref ref="Neckdown_bellows"/>
       <auxiliary auxtype="Color" auxvalue="Blue"/>
     </volume>
 
@@ -248,8 +256,8 @@
 	<volumeref ref="logic_Neckdown_bellows_flange_1"/>
       </physvol>
 
-      <physvol name="Neckdown_bellows_2">
-	<volumeref ref="logic_Neckdown_bellows_2"/>
+      <physvol name="Neckdown_bellows">
+	<volumeref ref="logic_Neckdown_bellows"/>
       </physvol>
 
       <physvol name="Neckdown_bellows_3">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -75,19 +75,14 @@
 
     <tube name = "Shield" rmin="203.454" rmax="403.454" z="300" deltaphi="360" startphi="0" aunit="deg" lunit= "mm"/>
 
-    
-
-    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="SAMpipe">
-      <zplane rmin="196.85" rmax="203.2" z="25637.524+12.7+34.798"/>
-      <zplane rmin="196.85" rmax="203.2" z="25637.524+12.7+34.798+735.838+53.74"/>
+    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="SAMpipeWithFlange">
+      <zplane rmin="196.85" rmax="203.2" z="25991.766"/>
+      <zplane rmin="196.85" rmax="203.2" z="26694.741"/>
+      <zplane rmin="196.85" rmax="584.2" z="26694.741"/>
+      <zplane rmin="196.85" rmax="584.2" z="26704.266"/>
+      <zplane rmin="190.5" rmax="584.2" z="26704.266"/>
+      <zplane rmin="190.5" rmax="584.2" z="26720.141"/>
     </polycone>
-
-
-    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="neckdown_flange">
-      <zplane rmin="190.5" rmax="584.2" z="26420.86+53.74"/>
-      <zplane rmin="190.5" rmax="584.2" z="26446.26+53.74"/>
-    </polycone>
-
 
   </solids>
 
@@ -223,18 +218,11 @@
       
     </volume>
 
-    <volume name="logic_SAMpipe">
+    <volume name="logic_SAMpipeWithFlange">
       <materialref ref="G4_Al"/>
-      <solidref ref="SAMpipe"/>
+      <solidref ref="SAMpipeWithFlange"/>
       <auxiliary auxtype="Color" auxvalue="Blue"/>
     </volume>
-
-    <volume name="logic_neckdown_flange">
-      <materialref ref="G4_Al"/>
-      <solidref ref="neckdown_flange"/>
-      <auxiliary auxtype="Color" auxvalue="Blue"/>
-    </volume>
-    
 
     <volume name="DSbeampipeMother">
       <materialref ref="G4_Galactic"/>
@@ -410,17 +398,11 @@
         <rotation name="sphere_rotation8" unit="deg" y="90"/>
         <position name="sphere_position8" x="45.25+6" y="0" z="25637.524+12.7+34.798+12.7+50+150"/>
       </physvol>
-
-     
-      <physvol name="SAMpipe">
-	<volumeref ref="logic_SAMpipe"/>
+    
+      <physvol name="SAMpipeWithFlange">
+	<volumeref ref="logic_SAMpipeWithFlange"/>
       </physvol>
-
-      <physvol name="neckdown_flange">
-	<volumeref ref="logic_neckdown_flange"/>
-      </physvol>
-
-
+  
     </volume>
 
   </structure>

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -151,21 +151,21 @@
 
     
     <volume name="logic_Neckdown_bellows_flange_1">
-      <materialref ref="G4_STAINLESS-STEEL"/>
+      <materialref ref="Inconel625"/>
       <solidref ref="Neckdown_bellows_flange_1"/>
-      <auxiliary auxtype="Color" auxvalue="Blue"/>
+      <auxiliary auxtype="Color" auxvalue="Yellow"/>
     </volume> 
 
     <volume name="logic_Neckdown_bellows">
-      <materialref ref="G4_STAINLESS-STEEL"/>
+      <materialref ref="Inconel625_Air"/>
       <solidref ref="Neckdown_bellows"/>
       <auxiliary auxtype="Color" auxvalue="Brown"/>
     </volume>
 
     <volume name="logic_Neckdown_bellows_flange_2">
-      <materialref ref="G4_STAINLESS-STEEL"/>
+      <materialref ref="Inconel625"/>
       <solidref ref="Neckdown_bellows_flange_2"/>
-      <auxiliary auxtype="Color" auxvalue="Blue"/>
+      <auxiliary auxtype="Color" auxvalue="Yellow"/>
     </volume>
 
     <volume name="logic_SAM_support_placeholder">

--- a/geometry/beampipe/downstream/beampipeDSMother.gdml
+++ b/geometry/beampipe/downstream/beampipeDSMother.gdml
@@ -11,7 +11,6 @@
 
   <solids>
     <box name = "SAM_Detectors" x="20" y="13" z="6" unit="mm"/>
-    <tube name = "Vacuum_Insert" rmin="0" rmax="80" z="180" deltaphi="360" startphi="0" aunit="deg" lunit= "mm"/>
     <tube name = "SAM_cans" rmin="17.4625" rmax="19.05" z="142" deltaphi="360" startphi="0" aunit="deg" lunit= "mm"/>
     <sphere aunit="deg" startphi="0" deltaphi="360" starttheta="0" deltatheta="90" lunit="mm" name="sam_can_spherical_cap"
             rmin="18.796"
@@ -73,7 +72,10 @@
       <zplane rmin="200.025" rmax="203.2" z="25991.766"/>
     </polycone>
 
-    <tube name = "Shield" rmin="203.454" rmax="403.454" z="300" deltaphi="360" startphi="0" aunit="deg" lunit= "mm"/>
+    <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="SAM_support_placeholder">
+      <zplane rmin="203.2" rmax="260.03" z="26114.816"/>
+      <zplane rmin="203.2" rmax="260.03" z="26291.854"/>
+    </polycone>
 
     <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="SAMpipeWithFlange">
       <zplane rmin="196.85" rmax="203.2" z="25991.766"/>
@@ -87,12 +89,6 @@
   </solids>
 
   <structure>
-
-    <volume name="logic_vacuum_insert">
-      <materialref ref="G4_Galactic"/>
-      <solidref ref="Vacuum_Insert"/>
-      <auxiliary auxtype="Color" auxvalue="Red"/>
-    </volume>
 
     <volume name="logic_SAM_Detectors">
       <materialref ref="G4_SILICON_DIOXIDE"/>
@@ -149,73 +145,10 @@
       <auxiliary auxtype="Color" auxvalue="Blue"/>
     </volume>
 
-    <volume name="logic_Shield">
-      <materialref ref="G4_Pb"/>
-      <solidref ref="Shield"/>
+    <volume name="logic_SAM_support_placeholder">
+      <materialref ref="G4_Al"/>
+      <solidref ref="SAM_support_placeholder"/>
       <auxiliary auxtype="Color" auxvalue="Blue"/>
-      <physvol name="hole1">
-        <volumeref ref="logic_vacuum_insert"/>
-        <rotation name="rotation1" x="90" y="45" unit="deg"/>
-        <position name="hole1_position" x="203.454+8" y="-203.454-8" z="0"/>
-      </physvol>
-
-
-      <physvol name="hole2">
-        <volumeref ref="logic_vacuum_insert"/>
-        <rotation name="rotation2" unit="deg" x="90"/>
-        <position name="hole2_position" x="0" y="-203.454-95" z="0"/>
-      </physvol>
-
-      
-
-      <physvol name="hole3">
-        <volumeref ref="logic_vacuum_insert"/>
-        <rotation name="rotation3" unit="deg" x="90" y="-45"/>
-        <position name="hole3_position" x="203.454+8" y="203.454+8" z="0"/>
-      </physvol>
-
-      
-
-      <physvol name="hole4">
-        <volumeref ref="logic_vacuum_insert"/>
-        <rotation name="rotation4" unit="deg" y="90"/>
-        <position name="hole4_position" x="-203.454-95" y="0" z="0"/>
-      </physvol>
-
-      
-
-      <physvol name="hole5">
-        <volumeref ref="logic_vacuum_insert"/>
-        <rotation name="rotation5" unit="deg" x="90" y="45"/>
-        <position name="hole5_position" x="-203.454-8" y="203.454+8" z="0"/>
-      </physvol>
-
-      
-
-      <physvol name="hole6">
-        <volumeref ref="logic_vacuum_insert"/>
-        <rotation name="rotation6" unit="deg" x="-90"/>
-        <position name="hole6_position" x="0" y="203.454+95" z="0"/>
-      </physvol>
-
-      
-
-
-      <physvol name="hole7">
-        <volumeref ref="logic_vacuum_insert"/>
-        <rotation name="rotation7" unit="deg" x="90" y="-45"/>
-        <position name="hole7_position" x="-203.454-8" y="-203.454-8" z="0"/>
-      </physvol>
-
-      
-
-      <physvol name="hole8">
-        <volumeref ref="logic_vacuum_insert"/>
-        <rotation name="rotation8" unit="deg" y="-90"/>
-        <position name="hole8_position" x="203.454+95" y="0" z="0"/>
-      </physvol>
-
-      
     </volume>
 
     <volume name="logic_SAMpipeWithFlange">
@@ -252,9 +185,8 @@
 	<volumeref ref="logic_Neckdown_bellows_flange_2"/>
       </physvol>
 
-      <physvol name="Shield">
-	<volumeref ref="logic_Shield"/>
-	<position name="Shield_position" unit="mm" x="0" y="0" z="25637.524+12.7+34.798+12.7+50+150"/>
+      <physvol name="SAM_support_placeholder">
+	<volumeref ref="logic_SAM_support_placeholder"/>
       </physvol>
 
       <physvol name="Sam_can_1">

--- a/geometry/hall/hallDaughter_dump.gdml
+++ b/geometry/hall/hallDaughter_dump.gdml
@@ -215,9 +215,16 @@
     <tube aunit="deg" deltaphi="360" lunit="mm" name="cylHallMother_1" rmax="radius_of_cylwall - 110." rmin="0" startphi="0" z="height_cylwall - thick_cylwall*2"/>
     <box lunit="mm" name="boxHallMother_out" x="width_mother" y="height_mother" z="length_mother"/>
     <box lunit="mm" name="boxHallMother_in" x="width_mother - 2500." y="height_mother - 2500." z="length_mother - 2000."/>
+    <box lunit="mm" name="subDumpholeMother"  x="10*dumpUSSub_width" y="2*780" z="(26720.141-radius_of_cylwall+110)"/>
+
+    <subtraction name="boxHallMother_2">
+      <first ref="boxHallMother_out"/>
+      <second ref="subDumpholeMother"/>
+      <position ref="pos_subDumpholeMother" x="0" y="0" z="radius_of_cylwall-110+(26720.141-radius_of_cylwall+110)/2.0" unit="mm"/>
+    </subtraction>
 
     <subtraction name ="boxHallMother_1">
-      <first ref="boxHallMother_out"/>
+      <first ref="boxHallMother_2"/>
       <second ref="cylHallMother_1"/>
       <positionref ref="cylwall_center" />
       <rotationref ref="scRot_1"/>

--- a/geometry/hall/hallDaughter_dump.gdml
+++ b/geometry/hall/hallDaughter_dump.gdml
@@ -220,7 +220,7 @@
     <subtraction name="boxHallMother_2">
       <first ref="boxHallMother_out"/>
       <second ref="subDumpholeMother"/>
-      <position ref="pos_subDumpholeMother" x="0" y="0" z="radius_of_cylwall-110+(26720.141-radius_of_cylwall+110)/2.0" unit="mm"/>
+      <position name="pos_subDumpholeMother" x="0" y="0" z="radius_of_cylwall-110+(26720.141-radius_of_cylwall+110)/2.0" unit="mm"/>
     </subtraction>
 
     <subtraction name ="boxHallMother_1">
@@ -237,8 +237,15 @@
       <position z="26000."/>
     </subtraction>
 
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="cylHallDet_2" rmax="radius_max_cylHallDet" rmin="radius_max_cylHallDet - 0.1" startphi="0" z="height_cylHallDet"/>
 
-    <tube aunit="deg" deltaphi="360" lunit="mm" name="cylHallDet_1" rmax="radius_max_cylHallDet" rmin="radius_max_cylHallDet - 0.1" startphi="0" z="height_cylHallDet"/>
+    <subtraction name="cylHallDet_1">
+      <first ref="cylHallDet_2"/>
+      <second ref="subDumpholeMother"/>
+      <position name="pos_subDumpholedet" x="0" z="-1.*center_cylwall - thick_cylwall/2" y="-1*(radius_of_cylwall-110+(26720.141-radius_of_cylwall+110)/2.0)" unit="mm"/>
+      <rotation name="rot_subDumpholedet" x="90" z="0" y="0" unit="deg"/>
+    </subtraction>
+
     <tube aunit="deg" deltaphi="360" lunit="mm" name="hallFlatLidDet_solid" 
 	  rmax="radius_max_cylHallDet - 0.2" rmin="0" startphi="0" z="0.1"/>
 

--- a/geometry/hall/hallDaughter_dump.gdml
+++ b/geometry/hall/hallDaughter_dump.gdml
@@ -237,18 +237,6 @@
       <position z="26000."/>
     </subtraction>
 
-    <tube aunit="deg" deltaphi="360" lunit="mm" name="cylHallDet_2" rmax="radius_max_cylHallDet" rmin="radius_max_cylHallDet - 0.1" startphi="0" z="height_cylHallDet"/>
-
-    <subtraction name="cylHallDet_1">
-      <first ref="cylHallDet_2"/>
-      <second ref="subDumpholeMother"/>
-      <position name="pos_subDumpholedet" x="0" z="-1.*center_cylwall - thick_cylwall/2" y="-1*(radius_of_cylwall-110+(26720.141-radius_of_cylwall+110)/2.0)" unit="mm"/>
-      <rotation name="rot_subDumpholedet" x="90" z="0" y="0" unit="deg"/>
-    </subtraction>
-
-    <tube aunit="deg" deltaphi="360" lunit="mm" name="hallFlatLidDet_solid" 
-	  rmax="radius_max_cylHallDet - 0.2" rmin="0" startphi="0" z="0.1"/>
-
     <!--Hall A top wall -->
   <sphere aunit="deg" startphi="0" deltaphi="360" starttheta="0" deltatheta="180" lunit="mm" name="hall_top_shell"  
 	  rmin="radius_topwall_in" rmax="radius_topwall_out"/>
@@ -276,16 +264,6 @@
       <second ref="hall_dumphole"/> 
       <positionref ref="hall_dumphole_sub_trans"/>
       <!-- <rotationref ref="scRot_1"/> -->
-  </subtraction>
-
-  <!--Hall A top wall detector -->
-  <sphere aunit="deg" startphi="0" deltaphi="360" starttheta="0" deltatheta="180" lunit="mm" name="halldet_top_shell"  rmin="radius_topwall_out+10" rmax="radius_topwall_out+10+1"/>
-  <tube aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="halldet_top_sub" rmin="0.0" rmax="radius_topwall_out+11" z="2*(radius_topwall_out+10+1)" />
- 
-  <subtraction name ="topwalldet_solid">
-      <first ref="halldet_top_shell"/>
-      <second ref="halldet_top_sub"/>
-      <positionref ref="topwallTrans_1"/>
   </subtraction>
 
   <!-- Dump Enclosure -->
@@ -455,31 +433,6 @@
   </solids>
 
 <structure>
-
-    <volume name="hallVerticalWallDet_logic">
-      <materialref ref="Vacuum"/>
-      <solidref ref="cylHallDet_1"/>
-      <auxiliary auxtype="Alpha" auxvalue="0.1"/>
-      <auxiliary auxtype="SensDet" auxvalue="planeDet"/>
-      <auxiliary auxtype="DetNo" auxvalue="99"/>
-    </volume>
-
-    <volume name="hallFlatLidDet_logic">
-      <materialref ref="Vacuum"/>
-      <solidref ref="hallFlatLidDet_solid"/>
-      <auxiliary auxtype="Alpha" auxvalue="0.1"/>
-      <auxiliary auxtype="SensDet" auxvalue="planeDet"/>
-      <auxiliary auxtype="DetNo" auxvalue="101"/>
-    </volume>
-
-    <volume name="topWallOuterDet_logic">
-      <materialref ref="Vacuum"/>
-      <solidref ref="topwalldet_solid"/>
-      <auxiliary auxtype="Alpha" auxvalue="0.1"/>
-      <auxiliary auxtype="SensDet" auxvalue="planeDet"/>
-      <auxiliary auxtype="DetNo" auxvalue="107"/>
-    </volume>
-
 
     <volume name="topwall_logic">
       <materialref ref="Concrete"/>
@@ -653,26 +606,8 @@
       <materialref ref="Vacuum"/>  <!-- air ??? -->
       <solidref ref="boxHallMother"/>
 
-      <physvol name="hallVerticalWallDet">
-        <volumeref ref="hallVerticalWallDet_logic"/>
-        <positionref ref="cylHallDet_1_center"/>
-	<rotationref ref="scRot_1"/>
-      </physvol>
-
-      <physvol name="hallFlatLidDet">
-        <volumeref ref="hallFlatLidDet_logic"/> <!-- this should be removed once we fix the hall lid CG -->
-        <position name="hallFlatLidDet_pos" unit="mm" y="center_cylwall + height_cylwall/2. - 1"/>
-	<rotationref ref="scRot_1"/>
-      </physvol>
-
       <physvol name="topWall">
         <volumeref ref="topwall_logic"/>
-        <positionref ref="topwall_center"/>
-        <rotationref ref="scRot_1"/>
-      </physvol>
-
-      <physvol name="topWallOuterDet">
-        <volumeref ref="topWallOuterDet_logic"/>
         <positionref ref="topwall_center"/>
         <rotationref ref="scRot_1"/>
       </physvol>

--- a/geometry/materials.xml
+++ b/geometry/materials.xml
@@ -467,13 +467,13 @@
     <fraction n="0.004" ref="G4_Al"/>
     <fraction n="0.004" ref="G4_Ti"/>
     <fraction n="0.01" ref="G4_Co"/>
-  </materials>
+  </material>
   
   <material name="Inconel625_Air" state="solid">
     <D value="0.001338" unit="g/cm3"/>
     <fraction n="0.90" ref="G4_Air"/>
     <fraction n="0.10" ref="Inconel625"/>
-  </materials> 
+  </material> 
   
   <material name="Tyvek" state="solid">
     <MEE unit="eV" value="56.5182975271737"/> 

--- a/geometry/materials.xml
+++ b/geometry/materials.xml
@@ -471,7 +471,7 @@
   
   <material name="Inconel625_Air" state="solid">
     <D value="0.001338" unit="g/cm3"/>
-    <fraction n="0.90" ref="G4_Air"/>
+    <fraction n="0.90" ref="G4_AIR"/>
     <fraction n="0.10" ref="Inconel625"/>
   </material> 
   

--- a/geometry/materials.xml
+++ b/geometry/materials.xml
@@ -451,6 +451,30 @@
     <fraction n="0.31" ref="CW90"/>
   </material>
   
+  <material name="Inconel625" state="solid">
+    <D value="8.314" unit="g/cm3"/>
+    <fraction n="0.58" ref="G4_Ni"/>
+    <fraction n="0.20" ref="G4_Cr"/>
+    <fraction n="0.05" ref="G4_Fe"/>
+    <fraction n="0.10" ref="G4_Mo"/>
+    <fraction n="0.0307" ref="G4_Nb"/>
+    <fraction n="0.010" ref="G4_Ta"/>
+    <fraction n="0.001" ref="G4_C"/>
+    <fraction n="0.005" ref="G4_Mn"/>
+    <fraction n="0.005" ref="G4_Si"/>
+    <fraction n="0.00015" ref="G4_P"/>
+    <fraction n="0.00015" ref="G4_S"/>
+    <fraction n="0.004" ref="G4_Al"/>
+    <fraction n="0.004" ref="G4_Ti"/>
+    <fraction n="0.01" ref="G4_Co"/>
+  </materials>
+  
+  <material name="Inconel625_Air" state="solid">
+    <D value="0.001338" unit="g/cm3"/>
+    <fraction n="0.90" ref="G4_Air"/>
+    <fraction n="0.10" ref="Inconel625"/>
+  </materials> 
+  
   <material name="Tyvek" state="solid">
     <MEE unit="eV" value="56.5182975271737"/> 
     <D unit="g/cm3" value="0.96"/>

--- a/geometry/mollerParallel.gdml
+++ b/geometry/mollerParallel.gdml
@@ -1086,7 +1086,7 @@
 
     <physvol name="hallFlatLidDet">
       <volumeref ref="hallFlatLidDet_logic"/>
-      <position name="hallFlatLidDet_pos" unit="mm" x="0" y="17770.0/2-4470.0-1" z="0"/>
+      <position name="hallFlatLidDet_pos" unit="mm" x="0" y="17770.0-4470.0-1" z="0"/>
       <rotation name="hallFlatLidDet_rot" unit="deg" x="90" y="0" z="0"/>
     </physvol>
 

--- a/geometry/mollerParallel.gdml
+++ b/geometry/mollerParallel.gdml
@@ -16,6 +16,17 @@
 
 <solids>
   &world;
+  
+  <tube  
+    name="hallVerticalWallDet_solid" 
+    startphi="0" deltaphi="360" aunit="deg" 
+    rmax="26517.6-10" rmin="26517.6-10-0.1" z="17770.-1487." lunit="mm"/>
+
+  <tube 
+    name="hallFlatLidDet_solid"
+    startphi="0" deltaphi="360" aunit="deg"  
+    rmax="26517.6-10-0.2" rmin="0" z="0.1" lunit="mm"/>
+
   <tube
     name="VirtualPlane_solid"
     startphi="0" deltaphi="360" aunit="deg"
@@ -146,6 +157,26 @@
 </solids>
 
 <structure>
+	
+  <volume name="hallVerticalWallDet_logic">
+     <materialref ref="G4_Galactic"/>
+     <solidref ref="hallVerticalWallDet_solid"/>
+     <auxiliary auxtype="Visibility" auxvalue="true"/>
+     <auxiliary auxtype="Color" auxvalue="yellow"/>
+     <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+     <auxiliary auxtype="SensDet" auxvalue="planeDet"/>
+     <auxiliary auxtype="DetNo" auxvalue="99"/>
+   </volume>
+
+   <volume name="hallFlatLidDet_logic">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="hallFlatLidDet_solid"/>
+    <auxiliary auxtype="Visibility" auxvalue="true"/>
+    <auxiliary auxtype="Color" auxvalue="yellow"/>	   
+    <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+    <auxiliary auxtype="SensDet" auxvalue="planeDet"/>
+    <auxiliary auxtype="DetNo" auxvalue="101"/>
+  </volume>
 
   <volume name="tgtPbCollar_log">
     <materialref ref="G4_Galactic"/>
@@ -1046,6 +1077,18 @@
   <volume name="ParallelWorld_logical">
     <materialref ref="G4_Galactic"/>
     <solidref ref="parallel_solid"/>
+	  
+    <physvol name="hallVerticalWallDet">
+      <volumeref ref="hallVerticalWallDet_logic"/>
+      <position name="hallVerticalWallDet_pos" unit="mm" x="0" y="(17770.0/2-4470.0) + 1487.0/2" z="0"/>
+      <rotation name="hallVerticalWallDet_rot" unit="deg" x="90" y="0" z="0"/>
+    </physvol>
+
+    <physvol name="hallFlatLidDet">
+      <volumeref ref="hallFlatLidDet_logic"/>
+      <position name="hallFlatLidDet_pos" unit="mm" x="0" y="17770.0/2-4470.0-1" z="0"/>
+      <rotation name="hallFlatLidDet_rot" unit="deg" x="90" y="0" z="0"/>
+    </physvol>
 
     <physvol name="tgtPbCollar_phys">
       <volumeref ref="tgtPbCollar_log"/>


### PR DESCRIPTION
Updated the detector and SAM pipe region in accordance with the latest CAD file received from Randy Wilson (JLAB). 

Main changes:

1) Introduced material definitions for Inconel625 and Inconel625(10%)-Air(90%) mixture
2) Updated radial dimensions and z-extents of detector pipe, neckdown, SAM pipe, bellows and flanges. Set bellows flanges (yellow) to Inconel 625 material and the bellows to Inconel-Air mixture(brown). Set everything in blue to Aluminum including detector pipe, neckdown and SAM pipe with flange. 
![ExperimentalGeometry](https://user-images.githubusercontent.com/7409132/185771843-68060ca0-d5da-438b-a0ac-5ff1ee78ce7f.PNG)
![ZoomedExperimentalGeometry](https://user-images.githubusercontent.com/7409132/185771844-7c90d85a-4c98-48dd-822a-8c1c7a73b18b.PNG)
3) Subtracted out a hole in hall logical volume and hall wall detector logical volume to avoid overlaps. 
4) Added an annulus of Aluminum as placeholders for the tubes holding the SAMs in place.
5) Moved the SAM placeholders to new location as per the CAD
6) Added sensitive detector ids for elements in the region after the neckdown (800-806)
