### PR TITLE
Increasing the azimuthal extent of the subtracted annulus for Collima…

### DIFF
--- a/geometry/hybrid/hybridDaughter_unified.gdml
+++ b/geometry/hybrid/hybridDaughter_unified.gdml
@@ -601,7 +601,7 @@
             <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
-        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6B_Cylinder_solid2" rmax1="66.411" rmax2="71.912" rmin1="55" rmin2="56" startphi="-5" z="71"/>
+        <cone aunit="deg" deltaphi="50" lunit="mm" name="Coll6B_Cylinder_solid2" rmax1="66.411" rmax2="71.912" rmin1="55" rmin2="56" startphi="-15" z="71"/>
         <subtraction name="Coll6B_solid_2">
             <first ref="Coll6B_solid2"/>
             <second ref="Coll6B_Cylinder_solid2"/>


### PR DESCRIPTION
The inner radius of collimator 6B downstream piece wasn't properly sculpted because of incorrect azimuthal extent in subtracted annulus. This change should fix that.
