### PR TITLE
TM2 and TM3 radial move-new default maps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,9 +373,12 @@ endif()
 # for i in *.txt ; do echo `md5sum $i|awk '{print$1}'`:`md5sum $i.gz|awk '{print$1}'`:$i ; done
 set(REMOLL_MAPS
 b8b30b803bae42f69135323ff40fe7db:99bf3fae83677c6c2f3e09a871682b2e:V2U.1a.50cm.parallel.txt
-d5f568675ca29e295c1013617a2dc092:b3e031ce9d97fa5331ec39e8903817e6:V2DSg.9.75cm.parallel.txt
+e4a96c2f3136d0eb020d90e74a532a6d:246d48001dd71174b62e16ecf07adc4d:V2U.1a.50cm.parallel.real_asymmetric.txt
+3ca8b6da4186d5de2a25bd89ef067a54:6a5fad69edd8cba457d85948bc42596b:subcoil_2_3_3mm_full.txt
+e6ab87da79a1dab8e759fcae6356e6f8:81b24e52bffbca83b3b7ca37b056f404:subcoil_2_3_3mm_real_asymmetric.txt
 )
 set(REMOLL_MAPS_EXTRA
+d5f568675ca29e295c1013617a2dc092:b3e031ce9d97fa5331ec39e8903817e6:V2DSg.9.75cm.parallel.txt
 1c79bc83e4da5e9d5e44338e28ce6ebe:c7591d167ca56e871e8e5eeecab2872c:V2DSg.9.75cm.txt
 f768447f761b9bf01af7c57e249d1d8a:94ec0017b21fc56d9d8084d68e479fd5:V2U.1a.50cm.txt
 b1b8f2845dc5cd420c6ff49ae7760a60:6002f6f5f092346cb2bdedac046d1905:V1U.2a.txt


### PR DESCRIPTION
The subcoils in TM2 and TM3 torus magnets in the downstream spectrometer is now shifted outward by radius 3mm to allow more room for belly plate shielding and better clearance with central beam.  The new default field  map is subcoil_2_3_3mm_full.txt and the realistic asymmetric map for this case is subcoil_2_3_3mm_real_asymmetric.txt. Also adding the realistic asymmetric map for the TM0 torus magnet in upstream region.

Didn't notice any significant deterioration in deconvolution with new default maps.
https://moller.jlab.org/DocDB/0009/000981/001/OffsetCoil2and3.pdf