### PR TITLE
Lead donut turned on in moller mother

### DIFF
--- a/geometry/mollerMother.gdml
+++ b/geometry/mollerMother.gdml
@@ -384,10 +384,10 @@
       </physvol>
       
       <!-- Lead Donut -->
-     <!-- <physvol>
+      <physvol>
 	<file name="donut/donutConcreteLead.gdml"/>
 	<positionref ref="donutConcreteLeadFaceUS"/>
-      </physvol>-->
+      </physvol>
 
       <!-- Pion Detectors -->
       <!-- Note: disabled here and now inside the pion donut -->


### PR DESCRIPTION
Seems like lead donut was turned off in moller mother in one of the shielding related PRs. Guessing this should be turned on. 