### PR TITLE
581 update upstream 2bounce shield

### DIFF
--- a/geometry/upstream/upstreamToroid.gdml
+++ b/geometry/upstream/upstreamToroid.gdml
@@ -620,19 +620,21 @@
 		<section zOrder="2" zPosition="375" xOffset="0" yOffset="0" scalingFactor="1"/>
 	</xtru>
 	<polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_twobounce_long">
-                 <zplane rmin="25" rmax="30.875" z="-1076.325"/>
-                 <zplane rmin="25" rmax="30.875" z="-1063.625"/>
-                 <zplane rmin="25" rmax="32" z="-1063.625"/>
-                 <zplane rmin="25" rmax="32" z="1063.625"/>
-        </polycone>
-        <polycone aunit="deg" startphi="0" deltaphi="28.0" lunit="mm" name="solid_twobounce_groove">
-                 <zplane rmin="32" rmax="36" z="-1050.8000000000002"/>
-                 <zplane rmin="32" rmax="36" z="1076.4499999999998"/>
-        </polycone>
+		 <zplane rmin="25" rmax="30.875" z="-1076.3249999999998"/>
+		 <zplane rmin="25" rmax="30.875" z="-1063.625"/>
+		 <zplane rmin="25" rmax="32" z="-1063.625"/>
+		 <zplane rmin="25" rmax="32" z="1063.625"/>
+		 <zplane rmin="25" rmax="30.875" z="1063.625"/>
+		 <zplane rmin="25" rmax="30.875" z="1076.3249999999998"/>
+	</polycone>
+	<polycone aunit="deg" startphi="0" deltaphi="28.0" lunit="mm" name="solid_twobounce_groove">
+		 <zplane rmin="32" rmax="36" z="-1050.8000000000002"/>
+		 <zplane rmin="32" rmax="36" z="1076.4499999999998"/>
+	</polycone>
 	<polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_US_toroidMother">
-                 <zplane rmin="0" rmax="262.555" z="-1100"/>
-                 <zplane rmin="0" rmax="262.555" z="1089.1499999999996"/>
-        </polycone>
+		 <zplane rmin="0" rmax="262.555" z="-1100"/>
+		 <zplane rmin="0" rmax="262.555" z="1089.1499999999996"/>
+	</polycone>
 </solids>
 
 
@@ -1391,10 +1393,10 @@
 		</physvol>
 
 		<physvol name="twobounce_groove_1">
-                        <volumeref ref="logic_twobounce_groove"/>
-                        <position name="pos_twobounce_groove_1" x="0" y="0" z="12.824999999999818"/>
-                        <rotation name="rot_twobounce_groove_1" x="0" y="0" z="-0.20445285523362144"/>
-                </physvol>
+			<volumeref ref="logic_twobounce_groove"/>
+			<position name="pos_twobounce_groove_1" x="0" y="0" z="0"/>
+			<rotation name="rot_twobounce_groove_1" x="0" y="0" z="-0.20445285523362144"/>
+		</physvol>
 
 		<physvol name="ucoil_2">
 			<volumeref ref="logic_outer_E_2"/>
@@ -1451,10 +1453,10 @@
 		</physvol>
 
 		<physvol name="twobounce_groove_2">
-                        <volumeref ref="logic_twobounce_groove"/>
-                        <position name="pos_twobounce_groove_2" x="0" y="0" z="12.824999999999818"/>
-                        <rotation name="rot_twobounce_groove_2" x="0" y="0" z="0.6931450457920337"/>
-                </physvol>
+			<volumeref ref="logic_twobounce_groove"/>
+			<position name="pos_twobounce_groove_2" x="0" y="0" z="0"/>
+			<rotation name="rot_twobounce_groove_2" x="0" y="0" z="0.6931450457920337"/>
+		</physvol>
 
 		<physvol name="ucoil_3">
 			<volumeref ref="logic_outer_E_3"/>
@@ -1511,10 +1513,10 @@
 		</physvol>
 
 		<physvol name="twobounce_groove_3">
-                        <volumeref ref="logic_twobounce_groove"/>
-                        <position name="pos_twobounce_groove_3" x="0" y="0" z="12.824999999999818"/>
-                        <rotation name="rot_twobounce_groove_3" x="0" y="0" z="1.5907429468176888"/>
-                </physvol>
+			<volumeref ref="logic_twobounce_groove"/>
+			<position name="pos_twobounce_groove_3" x="0" y="0" z="0"/>
+			<rotation name="rot_twobounce_groove_3" x="0" y="0" z="1.5907429468176888"/>
+		</physvol>
 
 		<physvol name="ucoil_4">
 			<volumeref ref="logic_outer_E_4"/>
@@ -1571,10 +1573,10 @@
 		</physvol>
 
 		<physvol name="twobounce_groove_4">
-                        <volumeref ref="logic_twobounce_groove"/>
-                        <position name="pos_twobounce_groove_4" x="0" y="0" z="12.824999999999818"/>
-                        <rotation name="rot_twobounce_groove_4" x="0" y="0" z="2.488340847843344"/>
-                </physvol>
+			<volumeref ref="logic_twobounce_groove"/>
+			<position name="pos_twobounce_groove_4" x="0" y="0" z="0"/>
+			<rotation name="rot_twobounce_groove_4" x="0" y="0" z="2.488340847843344"/>
+		</physvol>
 
 		<physvol name="ucoil_5">
 			<volumeref ref="logic_outer_E_5"/>
@@ -1631,10 +1633,10 @@
 		</physvol>
 
 		<physvol name="twobounce_groove_5">
-                        <volumeref ref="logic_twobounce_groove"/>
-                        <position name="pos_twobounce_groove_5" x="0" y="0" z="12.824999999999818"/>
-                        <rotation name="rot_twobounce_groove_5" x="0" y="0" z="3.385938748868999"/>
-                </physvol>
+			<volumeref ref="logic_twobounce_groove"/>
+			<position name="pos_twobounce_groove_5" x="0" y="0" z="0"/>
+			<rotation name="rot_twobounce_groove_5" x="0" y="0" z="3.385938748868999"/>
+		</physvol>
 
 		<physvol name="ucoil_6">
 			<volumeref ref="logic_outer_E_6"/>
@@ -1690,11 +1692,11 @@
 			<rotation name="rot_shield4_bot_6" x="0" y="0" z="0"/>
 		</physvol>
 
-		 <physvol name="twobounce_groove_6">
-                        <volumeref ref="logic_twobounce_groove"/>
-                        <position name="pos_twobounce_groove_6" x="0" y="0" z="12.824999999999818"/>
-                        <rotation name="rot_twobounce_groove_6" x="0" y="0" z="4.283536649894654"/>
-                </physvol>
+		<physvol name="twobounce_groove_6">
+			<volumeref ref="logic_twobounce_groove"/>
+			<position name="pos_twobounce_groove_6" x="0" y="0" z="0"/>
+			<rotation name="rot_twobounce_groove_6" x="0" y="0" z="4.283536649894654"/>
+		</physvol>
 
 		<physvol name="ucoil_7">
 			<volumeref ref="logic_outer_E_7"/>
@@ -1751,16 +1753,16 @@
 		</physvol>
 
                 <physvol name="twobounce_groove_7">
-                        <volumeref ref="logic_twobounce_groove"/>
-                        <position name="pos_twobounce_groove_7" x="0" y="0" z="12.824999999999818"/>
-                        <rotation name="rot_twobounce_groove_7" x="0" y="0" z="5.1811345509203095"/>
-                </physvol>
+			<volumeref ref="logic_twobounce_groove"/>
+			<position name="pos_twobounce_groove_7" x="0" y="0" z="0"/>
+			<rotation name="rot_twobounce_groove_7" x="0" y="0" z="5.1811345509203095"/>
+		</physvol>
 
 		<physvol name="twobounce_long">
-                        <volumeref ref="logic_twobounce_long"/>
-                        <position name="pos_twobounce_long" x="0" y="0" z="12.824999999999818"/>
-                        <rotation name="rot_twobounce_long" x="0" y="0" z="0"/>
-                </physvol>
+			<volumeref ref="logic_twobounce_long"/>
+			<position name="pos_twobounce_long" x="0" y="0" z="12.824999999999818"/>
+			<rotation name="rot_twobounce_long" x="0" y="0" z="0"/>
+		</physvol>
 
 		<auxiliary auxtype="Alpha" auxvalue="0.0"/>
 	</volume>

--- a/geometry/upstream/upstreamToroid.gdml
+++ b/geometry/upstream/upstreamToroid.gdml
@@ -636,9 +636,9 @@
                  <zplane rmin="32" rmax="36" z="1076.4499999999998"/>
         </polycone>
 	<polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_US_toroidMother">
-		 <zplane rmin="0" rmax="262.555" z="-1100"/>
-		 <zplane rmin="0" rmax="262.555" z="1024.32825"/>
-	</polycone>
+                 <zplane rmin="0" rmax="262.555" z="-1100"/>
+                 <zplane rmin="0" rmax="262.555" z="1089.1499999999996"/>
+        </polycone>
 </solids>
 
 

--- a/geometry/upstream/upstreamToroid.gdml
+++ b/geometry/upstream/upstreamToroid.gdml
@@ -635,6 +635,10 @@
                  <zplane rmin="32" rmax="36" z="-1050.8000000000002"/>
                  <zplane rmin="32" rmax="36" z="1076.4499999999998"/>
         </polycone>
+	<polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_US_toroidMother">
+		 <zplane rmin="0" rmax="262.555" z="-1100"/>
+		 <zplane rmin="0" rmax="262.555" z="1024.32825"/>
+	</polycone>
 </solids>
 
 

--- a/geometry/upstream/upstreamToroid.gdml
+++ b/geometry/upstream/upstreamToroid.gdml
@@ -619,30 +619,22 @@
 		<section zOrder="1" zPosition="-375" xOffset="0" yOffset="0" scalingFactor="1"/>
 		<section zOrder="2" zPosition="375" xOffset="0" yOffset="0" scalingFactor="1"/>
 	</xtru>
-	<polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_twobounce_connector_1">
-		 <zplane rmin="19" rmax="22" z="-16.075"/>
-		 <zplane rmin="19" rmax="22" z="16.075"/>
-	</polycone>
-	<polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_twobounce_connector_2">
-		 <zplane rmin="19" rmax="33" z="-25.0"/>
-		 <zplane rmin="19" rmax="33" z="25.0"/>
-	</polycone>
-	<polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_twobounce_connector_3">
-		 <zplane rmin="19" rmax="27" z="-4.0"/>
-		 <zplane rmin="19" rmax="27" z="4.0"/>
-	</polycone>
 	<polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_twobounce_long">
-		 <zplane rmin="27" rmax="32" z="-1017.85"/>
-		 <zplane rmin="27" rmax="32" z="1024.15"/>
-	</polycone>
-	<polycone aunit="deg" startphi="0" deltaphi="28.0" lunit="mm" name="solid_twobounce_groove">
-		 <zplane rmin="32" rmax="36" z="-1017.85"/>
-		 <zplane rmin="32" rmax="36" z="1024.15"/>
-	</polycone>
-	<polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_US_toroidMother">
-		 <zplane rmin="0" rmax="262.555" z="-1100"/>
-		 <zplane rmin="0" rmax="262.555" z="1024.32825"/>
-	</polycone>
+                 <zplane rmin="25" rmax="30.875" z="-1076.325"/>
+                 <zplane rmin="25" rmax="30.875" z="-1063.625"/>
+                 <zplane rmin="25" rmax="32" z="-1063.625"/>
+                 <zplane rmin="25" rmax="32" z="1063.625"/>
+        </polycone>
+        <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_twobounce_long">
+                 <zplane rmin="25" rmax="30.875" z="-1076.3249999999998"/>
+                 <zplane rmin="25" rmax="30.875" z="-1063.625"/>
+                 <zplane rmin="25" rmax="32" z="-1063.625"/>
+                 <zplane rmin="25" rmax="32" z="1063.625"/>
+        </polycone>
+        <polycone aunit="deg" startphi="0" deltaphi="28.0" lunit="mm" name="solid_twobounce_groove">
+                 <zplane rmin="32" rmax="36" z="-1050.8000000000002"/>
+                 <zplane rmin="32" rmax="36" z="1076.4499999999998"/>
+        </polycone>
 </solids>
 
 
@@ -1327,45 +1319,21 @@
 		<auxiliary auxtype="DetNo" auxvalue="4042"/>
 	</volume>
 
-	<volume name="logic_twobounce_connector_1">
-		<materialref ref="G4_W"/>
-		<solidref ref="solid_twobounce_connector_1"/>
-		<auxiliary auxtype="Color" auxvalue="blue"/>
-		<auxiliary auxtype="SensDet" auxvalue="coilDet"/>
-		<auxiliary auxtype="DetNo" auxvalue="90"/>
-	</volume>
+        <volume name="logic_twobounce_long">
+                <materialref ref="G4_W"/>
+                <solidref ref="solid_twobounce_long"/>
+                <auxiliary auxtype="Color" auxvalue="red"/>
+                <auxiliary auxtype="SensDet" auxvalue="coilDet"/>
+                <auxiliary auxtype="DetNo" auxvalue="95"/>
+        </volume>
 
-	<volume name="logic_twobounce_connector_2">
-		<materialref ref="G4_W"/>
-		<solidref ref="solid_twobounce_connector_2"/>
-		<auxiliary auxtype="Color" auxvalue="blue"/>
-		<auxiliary auxtype="SensDet" auxvalue="coilDet"/>
-		<auxiliary auxtype="DetNo" auxvalue="91"/>
-	</volume>
-
-	<volume name="logic_twobounce_connector_3">
-		<materialref ref="G4_W"/>
-		<solidref ref="solid_twobounce_connector_3"/>
-		<auxiliary auxtype="Color" auxvalue="blue"/>
-		<auxiliary auxtype="SensDet" auxvalue="coilDet"/>
-		<auxiliary auxtype="DetNo" auxvalue="92"/>
-	</volume>
-
-	<volume name="logic_twobounce_long">
-		<materialref ref="G4_W"/>
-		<solidref ref="solid_twobounce_long"/>
-		<auxiliary auxtype="Color" auxvalue="blue"/>
-		<auxiliary auxtype="SensDet" auxvalue="coilDet"/>
-		<auxiliary auxtype="DetNo" auxvalue="95"/>
-	</volume>
-
-	<volume name="logic_twobounce_groove">
-		<materialref ref="G4_W"/>
-		<solidref ref="solid_twobounce_groove"/>
-		<auxiliary auxtype="Color" auxvalue="blue"/>
-		<auxiliary auxtype="SensDet" auxvalue="coilDet"/>
-		<auxiliary auxtype="DetNo" auxvalue="96"/>
-	</volume>
+        <volume name="logic_twobounce_groove">
+                <materialref ref="G4_W"/>
+                <solidref ref="solid_twobounce_groove"/>
+                <auxiliary auxtype="Color" auxvalue="red"/>
+                <auxiliary auxtype="SensDet" auxvalue="coilDet"/>
+                <auxiliary auxtype="DetNo" auxvalue="96"/>
+        </volume>
 
 	<volume name="US_toroidMother">
 		<materialref ref="G4_Galactic"/>
@@ -1425,10 +1393,10 @@
 		</physvol>
 
 		<physvol name="twobounce_groove_1">
-			<volumeref ref="logic_twobounce_groove"/>
-			<position name="pos_twobounce_groove_1" x="0" y="0" z="0"/>
-			<rotation name="rot_twobounce_groove_1" x="0" y="0" z="-0.204452855234"/>
-		</physvol>
+                        <volumeref ref="logic_twobounce_groove"/>
+                        <position name="pos_twobounce_groove_1" x="0" y="0" z="12.824999999999818"/>
+                        <rotation name="rot_twobounce_groove_1" x="0" y="0" z="-0.20445285523362144"/>
+                </physvol>
 
 		<physvol name="ucoil_2">
 			<volumeref ref="logic_outer_E_2"/>
@@ -1485,10 +1453,10 @@
 		</physvol>
 
 		<physvol name="twobounce_groove_2">
-			<volumeref ref="logic_twobounce_groove"/>
-			<position name="pos_twobounce_groove_2" x="0" y="0" z="0"/>
-			<rotation name="rot_twobounce_groove_2" x="0" y="0" z="0.693145045792"/>
-		</physvol>
+                        <volumeref ref="logic_twobounce_groove"/>
+                        <position name="pos_twobounce_groove_2" x="0" y="0" z="12.824999999999818"/>
+                        <rotation name="rot_twobounce_groove_2" x="0" y="0" z="0.6931450457920337"/>
+                </physvol>
 
 		<physvol name="ucoil_3">
 			<volumeref ref="logic_outer_E_3"/>
@@ -1545,10 +1513,10 @@
 		</physvol>
 
 		<physvol name="twobounce_groove_3">
-			<volumeref ref="logic_twobounce_groove"/>
-			<position name="pos_twobounce_groove_3" x="0" y="0" z="0"/>
-			<rotation name="rot_twobounce_groove_3" x="0" y="0" z="1.59074294682"/>
-		</physvol>
+                        <volumeref ref="logic_twobounce_groove"/>
+                        <position name="pos_twobounce_groove_3" x="0" y="0" z="12.824999999999818"/>
+                        <rotation name="rot_twobounce_groove_3" x="0" y="0" z="1.5907429468176888"/>
+                </physvol>
 
 		<physvol name="ucoil_4">
 			<volumeref ref="logic_outer_E_4"/>
@@ -1605,10 +1573,10 @@
 		</physvol>
 
 		<physvol name="twobounce_groove_4">
-			<volumeref ref="logic_twobounce_groove"/>
-			<position name="pos_twobounce_groove_4" x="0" y="0" z="0"/>
-			<rotation name="rot_twobounce_groove_4" x="0" y="0" z="2.48834084784"/>
-		</physvol>
+                        <volumeref ref="logic_twobounce_groove"/>
+                        <position name="pos_twobounce_groove_4" x="0" y="0" z="12.824999999999818"/>
+                        <rotation name="rot_twobounce_groove_4" x="0" y="0" z="2.488340847843344"/>
+                </physvol>
 
 		<physvol name="ucoil_5">
 			<volumeref ref="logic_outer_E_5"/>
@@ -1665,10 +1633,10 @@
 		</physvol>
 
 		<physvol name="twobounce_groove_5">
-			<volumeref ref="logic_twobounce_groove"/>
-			<position name="pos_twobounce_groove_5" x="0" y="0" z="0"/>
-			<rotation name="rot_twobounce_groove_5" x="0" y="0" z="3.38593874887"/>
-		</physvol>
+                        <volumeref ref="logic_twobounce_groove"/>
+                        <position name="pos_twobounce_groove_5" x="0" y="0" z="12.824999999999818"/>
+                        <rotation name="rot_twobounce_groove_5" x="0" y="0" z="3.385938748868999"/>
+                </physvol>
 
 		<physvol name="ucoil_6">
 			<volumeref ref="logic_outer_E_6"/>
@@ -1724,11 +1692,11 @@
 			<rotation name="rot_shield4_bot_6" x="0" y="0" z="0"/>
 		</physvol>
 
-		<physvol name="twobounce_groove_6">
-			<volumeref ref="logic_twobounce_groove"/>
-			<position name="pos_twobounce_groove_6" x="0" y="0" z="0"/>
-			<rotation name="rot_twobounce_groove_6" x="0" y="0" z="4.28353664989"/>
-		</physvol>
+		 <physvol name="twobounce_groove_6">
+                        <volumeref ref="logic_twobounce_groove"/>
+                        <position name="pos_twobounce_groove_6" x="0" y="0" z="12.824999999999818"/>
+                        <rotation name="rot_twobounce_groove_6" x="0" y="0" z="4.283536649894654"/>
+                </physvol>
 
 		<physvol name="ucoil_7">
 			<volumeref ref="logic_outer_E_7"/>
@@ -1784,35 +1752,17 @@
 			<rotation name="rot_shield4_bot_7" x="0" y="0" z="0"/>
 		</physvol>
 
-		<physvol name="twobounce_groove_7">
-			<volumeref ref="logic_twobounce_groove"/>
-			<position name="pos_twobounce_groove_7" x="0" y="0" z="0"/>
-			<rotation name="rot_twobounce_groove_7" x="0" y="0" z="5.18113455092"/>
-		</physvol>
-
-		<physvol name="twobounce_connector_1">
-			<volumeref ref="logic_twobounce_connector_1"/>
-			<position name="pos_twobounce_connector_1" x="0" y="0" z="-1083.925"/>
-			<rotation name="rot_twobounce_connector_1" x="0" y="0" z="0"/>
-		</physvol>
-
-		<physvol name="twobounce_connector_2">
-			<volumeref ref="logic_twobounce_connector_2"/>
-			<position name="pos_twobounce_connector_2" x="0" y="0" z="-1042.85"/>
-			<rotation name="rot_twobounce_connector_2" x="0" y="0" z="0"/>
-		</physvol>
-
-		<physvol name="twobounce_connector_3">
-			<volumeref ref="logic_twobounce_connector_3"/>
-			<position name="pos_twobounce_connector_3" x="0" y="0" z="-1013.85"/>
-			<rotation name="rot_twobounce_connector_3" x="0" y="0" z="0"/>
-		</physvol>
+                <physvol name="twobounce_groove_7">
+                        <volumeref ref="logic_twobounce_groove"/>
+                        <position name="pos_twobounce_groove_7" x="0" y="0" z="12.824999999999818"/>
+                        <rotation name="rot_twobounce_groove_7" x="0" y="0" z="5.1811345509203095"/>
+                </physvol>
 
 		<physvol name="twobounce_long">
-			<volumeref ref="logic_twobounce_long"/>
-			<position name="pos_twobounce_long" x="0" y="0" z="0"/>
-			<rotation name="rot_twobounce_long" x="0" y="0" z="0"/>
-		</physvol>
+                        <volumeref ref="logic_twobounce_long"/>
+                        <position name="pos_twobounce_long" x="0" y="0" z="12.824999999999818"/>
+                        <rotation name="rot_twobounce_long" x="0" y="0" z="0"/>
+                </physvol>
 
 		<auxiliary auxtype="Alpha" auxvalue="0.0"/>
 	</volume>

--- a/geometry/upstream/upstreamToroid.gdml
+++ b/geometry/upstream/upstreamToroid.gdml
@@ -625,12 +625,6 @@
                  <zplane rmin="25" rmax="32" z="-1063.625"/>
                  <zplane rmin="25" rmax="32" z="1063.625"/>
         </polycone>
-        <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="solid_twobounce_long">
-                 <zplane rmin="25" rmax="30.875" z="-1076.3249999999998"/>
-                 <zplane rmin="25" rmax="30.875" z="-1063.625"/>
-                 <zplane rmin="25" rmax="32" z="-1063.625"/>
-                 <zplane rmin="25" rmax="32" z="1063.625"/>
-        </polycone>
         <polycone aunit="deg" startphi="0" deltaphi="28.0" lunit="mm" name="solid_twobounce_groove">
                  <zplane rmin="32" rmax="36" z="-1050.8000000000002"/>
                  <zplane rmin="32" rmax="36" z="1076.4499999999998"/>


### PR DESCRIPTION
Update 2 bounce shield modified to closely match MIT CAD specs.

Inner r is 25 mm, outer r is 36 mm. Slots are cut out from 32 mm to 36 mm in radius to fit coils. Length is 2152.65 mm. The upstream face is at 936.5 mm, not right against C2.

Additional context
[Studies showed no adverse effect from modified 2bounce design on spectrometer dose.] (https://moller.jlab.org/DocDB/0010/001029/001/UpstreamDose_status.pdf) 

Would be good to check the effect on detector background before merge. **High priority item.**