### PR TITLE
feat: add copy depth propagation to ROOT file

### DIFF
--- a/geometry/pion/Lucite/pionDetectorLucite.gdml
+++ b/geometry/pion/Lucite/pionDetectorLucite.gdml
@@ -342,6 +342,7 @@
     <solidref ref="pionDetectorLucitePMTWindowDisk_solid"/>
     <auxiliary auxtype="SensDet" auxvalue="pionLucitePMTWindow"/>
     <auxiliary auxtype="DetNo" auxvalue="8000"/>
+    <auxiliary auxtype="CopyDepth" auxvalue="4"/>
     <auxiliary auxtype="DetType" auxvalue="opticalphoton"/>
     <auxiliary auxtype="Color" auxvalue="White"/>
     <auxiliary auxtype="Alpha" auxvalue="0.5"/>

--- a/include/remollGenericDetector.hh
+++ b/include/remollGenericDetector.hh
@@ -161,6 +161,10 @@ class remollGenericDetector : public G4VSensitiveDetector {
 
       void BuildStaticMessenger();
 
+      virtual void SetCopyDepth(G4int copy_depth) {
+        fCopyDepth = copy_depth;
+      }
+
       virtual void SetDetectorType(G4String det_type) {
         auto icompare = [](const G4String& lhs, const G4String& rhs) {
           #if G4VERSION_NUMBER < 1100
@@ -253,6 +257,7 @@ class remollGenericDetector : public G4VSensitiveDetector {
       G4bool fDetectBoundaryHits;
 
       G4int fDetNo;
+      G4int fCopyDepth;
 
       G4bool fEnabled;
 

--- a/src/remollDetectorConstruction.cc
+++ b/src/remollDetectorConstruction.cc
@@ -938,6 +938,17 @@ void remollDetectorConstruction::ParseAuxiliarySensDetInfo()
 
       }
 
+      // Find aux list entries with type CopyDepth
+      for (auto it_copydepth  = NextAuxWithType(list.begin(), list.end(), "CopyDepth");
+                it_copydepth != list.end();
+                it_copydepth  = NextAuxWithType(++it_copydepth, list.end(), "CopyDepth")) {
+
+        // Set copy depth
+        int copydepth = atoi(it_copydepth->value.data());
+        if (remollsd != nullptr) remollsd->SetCopyDepth(copydepth);
+
+      }
+
   } // end of loop over volumes
 
   if (fVerboseLevel > 0)

--- a/src/remollGenericDetector.cc
+++ b/src/remollGenericDetector.cc
@@ -24,6 +24,7 @@ remollGenericDetector::remollGenericDetector( G4String name, G4int detnum )
 {
   assert(detnum > 0);
   SetDetNo(detnum);
+  SetCopyDepth(0);
 
   fDetectSecondaries = false;
   fDetectOpticalPhotons = false;
@@ -150,9 +151,8 @@ G4bool remollGenericDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
     // Get copy ID from touchable history
     G4TouchableHistory* hist
       = (G4TouchableHistory*) (prepoint->GetTouchable());
-    G4VPhysicalVolume* volume = hist->GetVolume();
-    G4int copyID = volume->GetCopyNo();
-
+    G4VPhysicalVolume* volume = hist->GetVolume(fCopyDepth);
+    G4int copyID = (volume != nullptr? volume->GetCopyNo(): 0);
 
     // Add energy deposit to detector sum
     G4int pid = particle->GetPDGEncoding();


### PR DESCRIPTION
We've long had a feature in remoll that separates the detector number from the copy of that detector (e.g. `hit.det` 8000 but `hit.id` from 1 to 28). This enables it. Untested.