### PR TITLE
Hotfix: Revert collimator 6A location change

### DIFF
--- a/geometry/hybrid/hybridDaughter_unified.gdml
+++ b/geometry/hybrid/hybridDaughter_unified.gdml
@@ -3647,13 +3647,13 @@
             <loop for="iloop" from="0" to="6" step="1">
                 <physvol>
                     <volumeref ref="Coll6A_logic1"/>
-                    <position x="0" y="0" z="1223.168-2864.764-90+136.9"/>
+                    <position x="0" y="0" z="1223.168-2864.764-90"/>
                     <rotation unit="deg" x="0" y="0" z="iloop*360./7."/>
                 </physvol>
                 
                 <physvol>
                     <volumeref ref="Coll6A_logic2"/>
-                    <position x="0" y="0" z="1305.718-2864.764-90+136.9"/>
+                    <position x="0" y="0" z="1305.718-2864.764-90"/>
                     <rotation unit="deg" x="0" y="0" z="iloop*360./7."/>
                 </physvol>
             </loop>

--- a/geometry/mollerParallel.gdml
+++ b/geometry/mollerParallel.gdml
@@ -1194,7 +1194,7 @@
 
     <physvol name="Col6AEnt_phys">
       <volumeref ref="Col6AEnt_log"/>
-      <position name="Col6AEnt_pos" unit="mm" x="0" y="0" z="9692.594-0.5"/>
+      <position name="Col6AEnt_pos" unit="mm" x="0" y="0" z="9555.904-0.5"/>
     </physvol>
 
     <physvol name="LintelExit_phys">


### PR DESCRIPTION
Collimator 6A and one of the corresponding virtual planes were erroneously moved in [PR#580](https://github.com/JeffersonLab/remoll/pull/580/files). This hotfix puts it back to where it was and should match drawing number A09005-15-03-5421 and A09005-15-03-5420 from Dave Kashy. Picture after hotfix:
![Collimator6A](https://user-images.githubusercontent.com/7409132/227379217-91807bc3-7fc3-4a03-944c-64bc9ffbd3ed.JPG)
