### PR TITLE
Redesign collimator 6A and 6B

### DIFF
--- a/geometry/hybrid/hybridDaughter_unified.gdml
+++ b/geometry/hybrid/hybridDaughter_unified.gdml
@@ -519,16 +519,16 @@
         
         <!--    Solid for Collimator 6A -->
         <xtru name="Coll6A_solid1" lunit="mm">
-            <twoDimVertex x="49.836" y="-7.792"/>
-            <twoDimVertex x="49.836" y="-24.000"/>
-            <twoDimVertex x="95.250" y="-45.870"/>
-            <twoDimVertex x="95.250" y="-35.113"/>
-            <twoDimVertex x="91.821" y="-35.113"/>
-            <twoDimVertex x="91.821" y="-26.985"/>
-            <twoDimVertex x="95.250" y="-26.985"/>
-            <twoDimVertex x="95.250" y="-25.080"/>
+            <twoDimVertex x="30.000" y="2.000"/>
+            <twoDimVertex x="30.000" y="-14.447"/>
+            <twoDimVertex x="88.900" y="-42.812"/>
+            <twoDimVertex x="88.900" y="-35.113"/>
+            <twoDimVertex x="85.471" y="-35.113"/>
+            <twoDimVertex x="85.471" y="-26.985"/>
+            <twoDimVertex x="88.900" y="-26.985"/>
+            <twoDimVertex x="88.900" y="-25.080"/>
             <twoDimVertex x="70.787" y="-25.080"/>
-            <twoDimVertex x="70.787" y="-7.792"/>
+            <twoDimVertex x="70.787" y="2.000"/>
             <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
@@ -540,17 +540,17 @@
         </subtraction>
         
         <xtru name="Coll6A_solid2" lunit="mm">
-            <twoDimVertex x="50.277" y="29.851"/>
-            <twoDimVertex x="50.277" y="7.792"/>
-            <twoDimVertex x="70.787" y="7.792"/>
+            <twoDimVertex x="30.000" y="20.086"/>
+            <twoDimVertex x="30.000" y="-2.000"/>
+            <twoDimVertex x="70.787" y="-2.000"/>
             <twoDimVertex x="70.787" y="25.080"/>
-            <twoDimVertex x="95.250" y="25.080"/>
-            <twoDimVertex x="95.250" y="26.985"/>
-            <twoDimVertex x="91.821" y="26.985"/>
-            <twoDimVertex x="91.821" y="35.113"/>
-            <twoDimVertex x="95.250" y="35.113"/>
-            <twoDimVertex x="95.250" y="45.870"/>
-            <twoDimVertex x="93.046" y="50.447"/>
+            <twoDimVertex x="88.900" y="25.080"/>
+            <twoDimVertex x="88.900" y="26.985"/>
+            <twoDimVertex x="85.471" y="26.985"/>
+            <twoDimVertex x="85.471" y="35.113"/>
+            <twoDimVertex x="88.900" y="35.113"/>
+            <twoDimVertex x="88.900" y="42.812"/>
+            <twoDimVertex x="86.696" y="47.389"/>
             <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>

--- a/geometry/hybrid/hybridDaughter_unified.gdml
+++ b/geometry/hybrid/hybridDaughter_unified.gdml
@@ -532,7 +532,7 @@
             <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
-        <cone aunit="deg" deltaphi="30" lunit="mm" name="Coll6A_Cylinder_solid1" rmax1="55.314" rmax2="57.982" rmin1="45" rmin2="50" startphi="-30" z="70"/>
+        <cone aunit="deg" deltaphi="360" lunit="mm" name="Coll6A_Cylinder_solid1" rmax1="55.31" rmax2="56.29" rmin1="0" rmin2="0" startphi="0" z="70"/>
         <subtraction name="Coll6A_solid_1">
             <first ref="Coll6A_solid1"/>
             <second ref="Coll6A_Cylinder_solid1"/>
@@ -554,7 +554,7 @@
             <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
-        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6A_Cylinder_solid2" rmax1="58.471" rmax2="61.143" rmin1="45" rmin2="50" startphi="5" z="70"/>
+        <cone aunit="deg" deltaphi="360" lunit="mm" name="Coll6A_Cylinder_solid2" rmax1="56.46" rmax2="57.44" rmin1="0" rmin2="0" startphi="0" z="70"/>
         <subtraction name="Coll6A_solid_2">
             <first ref="Coll6A_solid2"/>
             <second ref="Coll6A_Cylinder_solid2"/>

--- a/geometry/hybrid/hybridDaughter_unified.gdml
+++ b/geometry/hybrid/hybridDaughter_unified.gdml
@@ -578,7 +578,7 @@
             <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
-        <cone aunit="deg" deltaphi="35" lunit="mm" name="Coll6B_Cylinder_solid1" rmax1="59.911" rmax2="65.411" rmin1="50" rmin2="52" startphi="330" z="71"/>
+        <cone aunit="deg" deltaphi="360" lunit="mm" name="Coll6B_Cylinder_solid1" rmax1="80.00" rmax2="81.47" rmin1="0" rmin2="0" startphi="0" z="70"/>
         <subtraction name="Coll6B_solid_1">
             <first ref="Coll6B_solid1"/>
             <second ref="Coll6B_Cylinder_solid1"/>
@@ -601,7 +601,7 @@
             <section zOrder="1" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
             <section zOrder="2" zPosition="69.850" xOffset="0" yOffset="0" scalingFactor="1"/>
         </xtru>
-        <cone aunit="deg" deltaphi="50" lunit="mm" name="Coll6B_Cylinder_solid2" rmax1="66.411" rmax2="71.912" rmin1="55" rmin2="56" startphi="-15" z="71"/>
+        <cone aunit="deg" deltaphi="360" lunit="mm" name="Coll6B_Cylinder_solid2" rmax1="81.73" rmax2="83.20" rmin1="0" rmin2="0" startphi="0" z="70"/>
         <subtraction name="Coll6B_solid_2">
             <first ref="Coll6B_solid2"/>
             <second ref="Coll6B_Cylinder_solid2"/>

--- a/geometry/upstream/upstreamTorusRegion.gdml
+++ b/geometry/upstream/upstreamTorusRegion.gdml
@@ -78,8 +78,8 @@
 
 
 <!-- Dimensions for Collimator 4   -->    
-    <constant name="PCOLL2_R1_U" value ="40"/>
-    <constant name="PCOLL2_R1_D" value ="40"/>
+    <constant name="PCOLL2_R1_U" value ="26"/>
+    <constant name="PCOLL2_R1_D" value ="26"/>
     <constant name="PCOLL2_R4_U" value ="250"/>
     <constant name="PCOLL2_R4_D" value ="250"/>
 


### PR DESCRIPTION
Collimator 6A Changes:
 1. Set taper angle to 0.80 degree (from original 2.18degree).
 2. Shorten the outer dimension by 0.25 inches.
 3. Close the gap and overlap by 4.0mm
![image](https://github.com/JeffersonLab/remoll/assets/10902216/c1e7051a-17f1-4c10-999e-028b408abb31)

This image is the `<xtru>` solid part of 6A. The final solid is obtained by subtracting a cone. In the image solid lines show the Collimator 6A before and dashed line show after the change. The larger radius circular arcs show the original and changed outer extent.  The  smaller radius arcs show the IR of subtracting cone for US and DS piece. To accomodate the smaller angle the `<xtru>` geometry is extended inward.

Collimator 6B Changes:
 1. Change taper to 1.20 degree.
 2. Change IR to 80.00mm  from 59.91mm.
 
![image](https://github.com/JeffersonLab/remoll/assets/10902216/662cbbd0-49df-402a-924f-e6f84a70d38b)

The two circle show the initial and final position of IR for the US face of US piece of 6B.

Collimator 4 Changes:
 1. The IR of collimator 4 is changed from 40mm to 26mm.