### PR TITLE
Update load_magnetic_fieldmaps.mac

### DIFF
--- a/macros/load_magnetic_fieldmaps.mac
+++ b/macros/load_magnetic_fieldmaps.mac
@@ -5,4 +5,4 @@
 #   /control/execute macros/load_magnetic_fieldmaps.mac
 
 /remoll/addfield map_directory/V2U.1a.50cm.parallel.txt
-/remoll/addfield map_directory/V2DSg.9.75cm.parallel.txt
+/remoll/addfield map_directory/subcoil_2_3_3mm_full.txt


### PR DESCRIPTION
Update load magnetic field map macro to point to the most recent downstream field map that is downloaded by cmake