### PR TITLE
Add new optics target, sieve geometry, and blocker

### DIFF
--- a/geometry/positions.xml
+++ b/geometry/positions.xml
@@ -67,8 +67,10 @@
 <position name="n2atmoVirtualPlane_pos" z="31525.00" unit="mm"/>
 
 <!-- Sieve position -->
-<position name="sieveActualCenter_pos" z="-1895.00" x="200" unit="mm"/>
-<position name="sieveVirtualPlane_pos" z="105.00" unit="mm"/>
+<position name="sieveActualCenter_pos" z="-1795.00" x="200" unit="mm"/>
+<position name="sieveVirtualPlane_pos" z="250.00" unit="mm"/>
+<position name="blockerActualCenter_pos" z="-1795.00" x="-200" unit="mm"/>
+
 
 <!-- Showermax virtual plane detector position -->
 <position name="showerMaxVirtualPlane_pos" z="23920.00-90.00" unit="mm"/>

--- a/geometry/target/targetLadder.gdml
+++ b/geometry/target/targetLadder.gdml
@@ -11,7 +11,7 @@
 
 <solids>
   <box name="TargetLadder1_solid" x="200" y="200" z="1300" lunit="mm"/>
-  <box name="TargetLadder2_solid" x="200" y="600" z="1300" lunit="mm"/>
+  <box name="TargetLadder2_solid" x="200" y="700" z="1300" lunit="mm"/>
   <union name="TargetLadder_solid">
     <first ref="TargetLadder1_solid"/>
     <second ref="TargetLadder2_solid"/>
@@ -38,7 +38,7 @@
     <second ref="TargetAlHole_solid"/>
   </subtraction>
 
-  <box name="TargetCFoil_solid" x="25*mm" y="25*mm" z="1*mm"/>
+  <box name="TargetCFoil_solid" x="25*mm" y="25*mm" z="0.254*mm"/>
 
 </solids>
 
@@ -199,7 +199,7 @@
 
     <physvol>
       <volumeref ref="TargetCFoilDS_logical"/>
-      <position z="+60*cm"/>
+      <position z="-62.45*cm"/>
     </physvol>
 
     <auxiliary auxtype="TargetSystem" auxvalue="Optics1"/>
@@ -217,7 +217,7 @@
   
     <physvol>
       <volumeref ref="TargetCFoilDS_logical"/>
-      <position z="-60*cm"/>
+      <position z="+62.45*cm"/>
     </physvol>
 
     <auxiliary auxtype="TargetSystem" auxvalue="Optics2"/>
@@ -234,7 +234,7 @@
   
     <physvol>
       <volumeref ref="TargetCFoilDS_logical"/>
-      <position z="0*cm"/>
+      <position z="+0.0127*cm"/>
     </physvol>
 
     <auxiliary auxtype="TargetSystem" auxvalue="Optics3"/>

--- a/geometry/target/targetLadder.gdml
+++ b/geometry/target/targetLadder.gdml
@@ -121,7 +121,7 @@
   <volume name="TargetAlDummy4pctUS_logical">
     <materialref ref="G4_Al"/>
     <solidref ref="TargetAlDummy4pct_solid"/>
-    <auxiliary auxtype="TargetSamplingVolume" auxvalue="USAl"/>
+    <auxiliary auxtype="TargetSamplingVolume" auxvalue="DSAl"/>
   </volume>
   <volume name="TargetAlDummy2pctDS_logical">
     <materialref ref="G4_Al"/>
@@ -175,36 +175,69 @@
     <solidref ref="TargetCFoil_solid"/>
     <auxiliary auxtype="TargetSamplingVolume" auxvalue="USC"/>
   </volume>
+
+  <volume name="TargetCFoilMS_logical">
+    <materialref ref="G4_C"/>
+    <solidref ref="TargetCFoil_solid"/>
+    <auxiliary auxtype="TargetSamplingVolume" auxvalue="MSC"/>
+  </volume>
+
   <volume name="TargetCFoilDS_logical">
     <materialref ref="G4_C"/>
     <solidref ref="TargetCFoil_solid"/>
     <auxiliary auxtype="TargetSamplingVolume" auxvalue="DSC"/>
   </volume>
+
+
   <volume name="TargetPositionOptics1_logical">
     <materialref ref="G4_Galactic"/>
     <solidref ref="TargetPosition_solid"/>
-    <physvol>
+    <!--<physvol>
       <volumeref ref="TargetCFoilUS_logical"/>
       <position z="-30*cm"/>
-    </physvol>
+    </physvol>-->
+
     <physvol>
       <volumeref ref="TargetCFoilDS_logical"/>
       <position z="+60*cm"/>
     </physvol>
+
     <auxiliary auxtype="TargetSystem" auxvalue="Optics1"/>
   </volume>
+
+
   <volume name="TargetPositionOptics2_logical">
     <materialref ref="G4_Galactic"/>
     <solidref ref="TargetPosition_solid"/>
-    <physvol>
+
+    <!--<physvol>
       <volumeref ref="TargetCFoilUS_logical"/>
       <position z="-60*cm"/>
-    </physvol>
+    </physvol>-->
+  
     <physvol>
       <volumeref ref="TargetCFoilDS_logical"/>
-      <position z="+30*cm"/>
+      <position z="-60*cm"/>
     </physvol>
+
     <auxiliary auxtype="TargetSystem" auxvalue="Optics2"/>
+  </volume>
+
+  <volume name="TargetPositionOptics3_logical">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="TargetPosition_solid"/>
+
+    <!--<physvol>
+      <volumeref ref="TargetCFoilUS_logical"/>
+      <position z="-60*cm"/>
+    </physvol>-->
+  
+    <physvol>
+      <volumeref ref="TargetCFoilDS_logical"/>
+      <position z="0*cm"/>
+    </physvol>
+
+    <auxiliary auxtype="TargetSystem" auxvalue="Optics3"/>
   </volume>
 
   <volume name="TargetLadder_logical">
@@ -253,6 +286,11 @@
     <physvol>
       <volumeref ref="TargetPositionOptics2_logical"/>
       <position y="-63*cm"/>
+    </physvol>
+
+    <physvol>
+      <volumeref ref="TargetPositionOptics3_logical"/>
+      <position y="-70*cm"/>
     </physvol>
 
     <auxiliary auxtype="TargetLadder" auxvalue=""/>

--- a/geometry/upstream/blocker.gdml
+++ b/geometry/upstream/blocker.gdml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gdml
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+<define>
+  <!-- Full blocker system dimensions -->
+  <quantity name="blocker_system_inner_radius" type="length" value="1.043" unit="in"/>
+  <quantity name="blocker_system_outer_radius" type="length" value="3.858" unit="in"/>
+  <quantity name="blocker_system_thickness" type="length" value="3.937" unit="in"/>
+
+</define>
+
+<materials>
+</materials>
+
+
+<solids>
+  <!-- Blocker system solid -->
+  <tube name="blocker_system_solid"
+    rmin="blocker_system_inner_radius"
+    rmax="blocker_system_outer_radius"
+    z="blocker_system_thickness"
+    startphi="0" deltaphi="360.0" aunit="deg"
+    />
+</solids>
+
+<structure>
+  <volume name="blocker_system_logic">
+    <materialref ref="G4_W"/>
+    <solidref ref="blocker_system_solid"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+    <auxiliary auxtype="SensDet" auxvalue="sieveDet"/>
+    <auxiliary auxtype="DetType" auxvalue="secondaries"/>
+    <auxiliary auxtype="DetType" auxvalue="boundaryhits"/>
+    <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
+    <auxiliary auxtype="DetNo" auxvalue="1007"/>
+  </volume>
+</structure>
+
+<setup name="blocker_system_world" version="1.0">
+  <world ref="blocker_system_logic"/>
+</setup>
+
+</gdml>
+
+
+
+

--- a/geometry/upstream/sieve.gdml
+++ b/geometry/upstream/sieve.gdml
@@ -5,35 +5,86 @@
 
 <define>
   <!-- Full sieve system dimensions -->
-  <quantity name="sieve_system_inner_radius" type="length" value="1.390" unit="in"/>
-  <quantity name="sieve_system_outer_radius" type="length" value="3.858" unit="in"/>
-  <quantity name="sieve_system_thickness" type="length" value="4.724" unit="in"/>
+  <quantity name="sieve_system_inner_radius" type="length" value="26.5" unit="mm"/>
+  <quantity name="sieve_system_outer_radius" type="length" value="98" unit="mm"/>
+  <quantity name="sieve_system_thickness" type="length" value="100" unit="mm"/>
 
-  <!-- Sieve sector dimensions -->
-  <quantity name="sieve_sector_inner_radius" type="length" value="1.390" unit="in"/>
-  <quantity name="sieve_sector_outer_radius" type="length" value="3.858" unit="in"/>
-  <!-- Radiation length in W is 0.3504 cm [1], so 40 X_0 is about 15 cm.
-   [1] http://pdg.lbl.gov/2019/AtomicNuclearProperties/HTML/tungsten_W.html
-   -->
-  <quantity name="sieve_sector_thickness" type="length" value="4.724" unit="in"/>
-  <quantity name="sieve_sector_angle" type="angle" value="25.7" unit="deg"/>
+  <quantity name="sieve_hole_diameter" type="length" value="5" unit="mm"/>
+
 
   <!-- Sieve hole dimensions -->
-  <quantity name="sieve_hole1_diameter" type="length" value="0.5" unit="in"/>
-  <quantity name="sieve_hole1_radial_position" type="length" value="1.8" unit="in"/>
-  <quantity name="sieve_hole1_angular_offset_phi" type="angle" value="0" unit="deg"/>
 
-  <quantity name="sieve_hole2_diameter" type="length" value="0.5" unit="in"/>
-  <quantity name="sieve_hole2_radial_position" type="length" value="3.5" unit="in"/>
-  <quantity name="sieve_hole2_angular_offset_phi" type="angle" value="-5" unit="deg"/>
+  <!-- sector 7 -->
+  <quantity name="sieve_hole71_radial_position" type="length" value="44" unit="mm"/>
+  <quantity name="sieve_hole71_angular_offset_phi" type="angle" value="0 + 360/14 - 360/7" unit="deg"/>
 
-  <quantity name="sieve_hole3_diameter" type="length" value="0.5" unit="in"/>
-  <quantity name="sieve_hole3_radial_position" type="length" value="2.6" unit="in"/>
-  <quantity name="sieve_hole3_angular_offset_phi" type="angle" value="2.5" unit="deg"/>
-  <quantity name="sieve_hole3_axis_theta" type="angle" value="2.5" unit="deg"/>
-  <quantity name="sieve_hole3_axis_phi" type="angle" value="0" unit="deg"/>
+  <quantity name="sieve_hole72_radial_position" type="length" value="68" unit="mm"/>
+  <quantity name="sieve_hole72_angular_offset_phi" type="angle" value="8 + 360/14 - 360/7" unit="deg"/>
 
-  <variable name="i" value="1"/>
+  <quantity name="sieve_hole73_radial_position" type="length" value="84.5" unit="mm"/>
+  <quantity name="sieve_hole73_angular_offset_phi" type="angle" value="-8 + 360/14 - 360/7" unit="deg"/>
+
+  <!-- sector 6 -->
+  <quantity name="sieve_hole61_radial_position" type="length" value="39" unit="mm"/>
+  <quantity name="sieve_hole61_angular_offset_phi" type="angle" value="0 - (360/7)*2 + 360/14" unit="deg"/>
+
+  <quantity name="sieve_hole62_radial_position" type="length" value="60" unit="mm"/>
+  <quantity name="sieve_hole62_angular_offset_phi" type="angle" value="8 - (360/7)*2 + 360/14" unit="deg"/>
+
+  <quantity name="sieve_hole63_radial_position" type="length" value="75" unit="mm"/>
+  <quantity name="sieve_hole63_angular_offset_phi" type="angle" value="-8 - (360/7)*2 + 360/14" unit="deg"/>
+
+  <!-- sector 5 -->
+  <quantity name="sieve_hole51_radial_position" type="length" value="56" unit="mm"/>
+  <quantity name="sieve_hole51_angular_offset_phi" type="angle" value="-8 + 360/14 -  (360/7)*3" unit="deg"/>
+
+  <quantity name="sieve_hole52_radial_position" type="length" value="56" unit="mm"/>
+  <quantity name="sieve_hole52_angular_offset_phi" type="angle" value="8 + 360/14 -  (360/7)*3" unit="deg"/>
+
+  <quantity name="sieve_hole53_radial_position" type="length" value="80" unit="mm"/>
+  <quantity name="sieve_hole53_angular_offset_phi" type="angle" value="0 + 360/14 -  (360/7)*3" unit="deg"/>
+
+  <!-- sector 4 -->
+  <quantity name="sieve_hole41_radial_position" type="length" value="50" unit="mm"/>
+  <quantity name="sieve_hole41_angular_offset_phi" type="angle" value="-8 + 360/14 - (360/7)*4" unit="deg"/>
+
+  <quantity name="sieve_hole42_radial_position" type="length" value="60" unit="mm"/>
+  <quantity name="sieve_hole42_angular_offset_phi" type="angle" value="0 + 360/14 - (360/7)*4" unit="deg"/>
+
+  <quantity name="sieve_hole43_radial_position" type="length" value="70" unit="mm"/>
+  <quantity name="sieve_hole43_angular_offset_phi" type="angle" value="8 + 360/14 - (360/7)*4" unit="deg"/>
+
+  <!-- sector 3 -->
+  <quantity name="sieve_hole31_radial_position" type="length" value="39" unit="mm"/>
+  <quantity name="sieve_hole31_angular_offset_phi" type="angle" value="0 + 360/14 - (360/7)*5" unit="deg"/>
+
+  <quantity name="sieve_hole32_radial_position" type="length" value="63" unit="mm"/>
+  <quantity name="sieve_hole32_angular_offset_phi" type="angle" value="8 + 360/14 - (360/7)*5" unit="deg"/>
+
+  <quantity name="sieve_hole33_radial_position" type="length" value="80" unit="mm"/>
+  <quantity name="sieve_hole33_angular_offset_phi" type="angle" value="-8 + 360/14 - (360/7)*5" unit="deg"/>
+
+  <!-- sector 2 -->
+  <quantity name="sieve_hole21_radial_position" type="length" value="50" unit="mm"/>
+  <quantity name="sieve_hole21_angular_offset_phi" type="angle" value="-8 + 360/14 - (360/7)*6" unit="deg"/>
+
+  <quantity name="sieve_hole22_radial_position" type="length" value="56" unit="mm"/>
+  <quantity name="sieve_hole22_angular_offset_phi" type="angle" value="8 + 360/14 - (360/7)*6" unit="deg"/>
+
+ <quantity name="sieve_hole23_radial_position" type="length" value="75" unit="mm"/>
+  <quantity name="sieve_hole23_angular_offset_phi" type="angle" value="0 + 360/14 - (360/7)*6" unit="deg"/>
+
+  <!-- sector 1 -->
+  <quantity name="sieve_hole11_radial_position" type="length" value="35" unit="mm"/>
+  <quantity name="sieve_hole11_angular_offset_phi" type="angle" value="0 + 360/14 - (360/7)*7" unit="deg"/>
+
+  <quantity name="sieve_hole13_radial_position" type="length" value="84.5" unit="mm"/>
+  <quantity name="sieve_hole13_angular_offset_phi" type="angle" value="8 + 360/14 - (360/7)*7" unit="deg"/>
+  
+  <quantity name="sieve_hole12_radial_position" type="length" value="58" unit="mm"/>
+  <quantity name="sieve_hole12_angular_offset_phi" type="angle" value="-8 + 360/14 - (360/7)*7" unit="deg"/>
+
+
 </define>
 
 <materials>
@@ -41,7 +92,7 @@
 
 
 <solids>
-  <!-- Sieve system solid -->
+ 
   <tube name="sieve_system_solid"
     rmin="sieve_system_inner_radius"
     rmax="sieve_system_outer_radius"
@@ -49,128 +100,210 @@
     startphi="0" deltaphi="360.0" aunit="deg"
     />
 
-  <!-- Sieve sector solid -->
-  <tube name="sieve_sector_solid"
-    rmin="sieve_sector_inner_radius"
-    rmax="sieve_sector_outer_radius"
-    z="sieve_sector_thickness"
-    startphi="-sieve_sector_angle/2" deltaphi="sieve_sector_angle"
+  <!-- Sieve hole solids -->
+  <tube name="sieve_hole_solid"
+    rmin="0."
+    rmax="sieve_hole_diameter/2"
+    z="sieve_system_thickness+2"
+    startphi="0" deltaphi="360.0" aunit="deg"
     />
 
-  <!-- Sieve hole solids -->
-  <tube name="sieve_hole1_solid"
-    rmin="0."
-    rmax="sieve_hole1_diameter/2"
-    z="sieve_sector_thickness"
-    startphi="0" deltaphi="360.0" aunit="deg"
-    />
-  <tube name="sieve_hole2_solid"
-    rmin="0."
-    rmax="sieve_hole2_diameter/2"
-    z="sieve_sector_thickness"
-    startphi="0" deltaphi="360.0" aunit="deg"
-    />
-  <!-- Support for non-zero sieve_hole_axis_theta and sieve_hole_axis_phi
-    requires implementation of solid with cutTube, but this is slower so avoid
-    if not necessary -->
-  <cutTube name="sieve_hole3_solid"
-    rmin="0."
-    rmax="sieve_hole3_diameter/2"
-    z="sieve_sector_thickness/cos(sieve_hole3_axis_theta)"
-    startphi="0" deltaphi="360.0" aunit="deg"
-    lowX="-sin(-sieve_hole3_axis_theta)*cos(-sieve_hole3_axis_phi)"
-    lowY="-sin(-sieve_hole3_axis_theta)*sin(-sieve_hole3_axis_phi)"
-    lowZ="-cos(-sieve_hole3_axis_theta)"
-    highX="sin(-sieve_hole3_axis_theta)*cos(-sieve_hole3_axis_phi)"
-    highY="sin(-sieve_hole3_axis_theta)*sin(-sieve_hole3_axis_phi)"
-    highZ="cos(-sieve_hole3_axis_theta)"
-    />
 </solids>
 
 <structure>
-  <!-- Define the holes as detectors to enable mc-truth analysis where
-    one requires that the track went through a specific sieve hole -->
-  <volume name="sieve_hole1_logic">
+  
+  <volume name="sieve_hole_logic">
     <materialref ref="G4_Galactic"/>
-    <solidref ref="sieve_hole1_solid"/>
+    <solidref ref="sieve_hole_solid"/>
     <auxiliary auxtype="Color" auxvalue="magenta"/>
     <auxiliary auxtype="Alpha" auxvalue="0.1"/>
     <auxiliary auxtype="SensDet" auxvalue="sieveDet"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>
     <auxiliary auxtype="DetType" auxvalue="boundaryhits"/>
     <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
-    <auxiliary auxtype="DetNo" auxvalue="1001"/>
   </volume>
-  <volume name="sieve_hole2_logic">
-    <materialref ref="G4_Galactic"/>
-    <solidref ref="sieve_hole2_solid"/>
-    <auxiliary auxtype="Color" auxvalue="magenta"/>
-    <auxiliary auxtype="Alpha" auxvalue="0.1"/>
-    <auxiliary auxtype="SensDet" auxvalue="sieveDet"/>
-    <auxiliary auxtype="DetType" auxvalue="secondaries"/>
-    <auxiliary auxtype="DetType" auxvalue="boundaryhits"/>
-    <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
-    <auxiliary auxtype="DetNo" auxvalue="1002"/>
-  </volume>
-  <volume name="sieve_hole3_logic">
-    <materialref ref="G4_Galactic"/>
-    <solidref ref="sieve_hole3_solid"/>
-    <auxiliary auxtype="Color" auxvalue="magenta"/>
-    <auxiliary auxtype="Alpha" auxvalue="0.1"/>
-    <auxiliary auxtype="SensDet" auxvalue="sieveDet"/>
-    <auxiliary auxtype="DetType" auxvalue="secondaries"/>
-    <auxiliary auxtype="DetType" auxvalue="boundaryhits"/>
-    <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
-    <auxiliary auxtype="DetNo" auxvalue="1003"/>
-  </volume>
-
-  <!-- Place the holes inside the sector volume -->
-  <volume name="sieve_sector_logic">
-    <materialref ref="G4_W"/>
-    <solidref ref="sieve_sector_solid"/>
-    <physvol name="sieve_hole1_physical">
-      <volumeref ref="sieve_hole1_logic"/>
-      <position x="sieve_hole1_radial_position"/>
-    </physvol>
-
-    <physvol name="sieve_hole2_physical">
-      <volumeref ref="sieve_hole2_logic"/>
-      <position
-        x="sieve_hole2_radial_position*cos(sieve_hole2_angular_offset_phi)"
-        y="sieve_hole2_radial_position*sin(sieve_hole2_angular_offset_phi)"
-        />
-    </physvol>
-
-    <physvol name="sieve_hole3_physical">
-      <volumeref ref="sieve_hole3_logic"/>
-      <position
-        x="sieve_hole3_radial_position*cos(sieve_hole3_angular_offset_phi)"
-        y="sieve_hole3_radial_position*sin(sieve_hole3_angular_offset_phi)"
-        />
-      <rotation
-        y="-(sieve_hole3_axis_theta)"
-        />
-    </physvol>
-  </volume>
-
-  <!-- Place the sector volumes around the ring -->
+  
   <volume name="sieve_system_logic">
-    <materialref ref="G4_Galactic"/>
+    <materialref ref="CW90"/>
     <solidref ref="sieve_system_solid"/>
-    <auxiliary auxtype="Alpha" auxvalue="0.1"/>
+    <auxiliary auxtype="Alpha" auxvalue="0.8"/>
     <auxiliary auxtype="SensDet" auxvalue="sieveDet"/>
     <auxiliary auxtype="DetType" auxvalue="secondaries"/>
     <auxiliary auxtype="DetType" auxvalue="boundaryhits"/>
     <auxiliary auxtype="DetType" auxvalue="lowenergyneutral"/>
-    <auxiliary auxtype="DetNo" auxvalue="1000"/>
-    <loop for="i" from="1" to="7" step="1">
-      <physvol name="sieve_sector_physical[i]">
-        <volumeref ref="sieve_sector_logic"/>
-        <rotation unit="deg"
-          z="360.0/14.0+360.0/7.0*(i-1)"
-          />
-      </physvol>
-    </loop>
+
+    <physvol name="sieve_hole71_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole71_radial_position*cos(sieve_hole71_angular_offset_phi)"
+        y="sieve_hole71_radial_position*sin(sieve_hole71_angular_offset_phi)"
+        />
+    </physvol>
+
+    <physvol name="sieve_hole72_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole72_radial_position*cos(sieve_hole72_angular_offset_phi)"
+        y="sieve_hole72_radial_position*sin(sieve_hole72_angular_offset_phi)"
+        />
+
+    </physvol>
+
+ <physvol name="sieve_hole73_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole73_radial_position*cos(sieve_hole73_angular_offset_phi)"
+        y="sieve_hole73_radial_position*sin(sieve_hole73_angular_offset_phi)"
+        />
+    </physvol>
+
+   <physvol name="sieve_hole61_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole61_radial_position*cos(sieve_hole61_angular_offset_phi)"
+        y="sieve_hole61_radial_position*sin(sieve_hole61_angular_offset_phi)"
+        />
+    </physvol>
+
+    <physvol name="sieve_hole62_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole62_radial_position*cos(sieve_hole62_angular_offset_phi)"
+        y="sieve_hole62_radial_position*sin(sieve_hole62_angular_offset_phi)"
+        />
+    </physvol>
+
+   <physvol name="sieve_hole63_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole63_radial_position*cos(sieve_hole63_angular_offset_phi)"
+        y="sieve_hole63_radial_position*sin(sieve_hole63_angular_offset_phi)"
+        />
+    </physvol>
+
+   <physvol name="sieve_hole51_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole51_radial_position*cos(sieve_hole51_angular_offset_phi)"
+        y="sieve_hole51_radial_position*sin(sieve_hole51_angular_offset_phi)"
+        />
+    </physvol>
+
+    <physvol name="sieve_hole52_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole52_radial_position*cos(sieve_hole52_angular_offset_phi)"
+        y="sieve_hole52_radial_position*sin(sieve_hole52_angular_offset_phi)"
+        />
+    </physvol>
+    
+    <physvol name="sieve_hole53_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole53_radial_position*cos(sieve_hole53_angular_offset_phi)"
+        y="sieve_hole53_radial_position*sin(sieve_hole53_angular_offset_phi)"
+        />
+    </physvol>
+
+  <physvol name="sieve_hole41_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole41_radial_position*cos(sieve_hole41_angular_offset_phi)"
+        y="sieve_hole41_radial_position*sin(sieve_hole41_angular_offset_phi)"
+        />
+    </physvol>
+
+    <physvol name="sieve_hole42_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole42_radial_position*cos(sieve_hole42_angular_offset_phi)"
+        y="sieve_hole42_radial_position*sin(sieve_hole42_angular_offset_phi)"
+        />
+    </physvol>
+
+    <physvol name="sieve_hole43_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole43_radial_position*cos(sieve_hole43_angular_offset_phi)"
+        y="sieve_hole43_radial_position*sin(sieve_hole43_angular_offset_phi)"
+        />
+    </physvol>
+
+  <physvol name="sieve_hole31_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole31_radial_position*cos(sieve_hole31_angular_offset_phi)"
+        y="sieve_hole31_radial_position*sin(sieve_hole31_angular_offset_phi)"
+        />
+    </physvol>
+
+    <physvol name="sieve_hole32_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole32_radial_position*cos(sieve_hole32_angular_offset_phi)"
+        y="sieve_hole32_radial_position*sin(sieve_hole32_angular_offset_phi)"
+        />
+    </physvol>
+
+  <physvol name="sieve_hole33_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole33_radial_position*cos(sieve_hole33_angular_offset_phi)"
+        y="sieve_hole33_radial_position*sin(sieve_hole33_angular_offset_phi)"
+        />
+    </physvol>
+
+  <physvol name="sieve_hole21_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole21_radial_position*cos(sieve_hole21_angular_offset_phi)"
+        y="sieve_hole21_radial_position*sin(sieve_hole21_angular_offset_phi)"
+        />
+    </physvol>
+
+
+  <physvol name="sieve_hole22_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole22_radial_position*cos(sieve_hole22_angular_offset_phi)"
+        y="sieve_hole22_radial_position*sin(sieve_hole22_angular_offset_phi)"
+        />
+    </physvol>
+
+    <physvol name="sieve_hole23_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole23_radial_position*cos(sieve_hole23_angular_offset_phi)"
+        y="sieve_hole23_radial_position*sin(sieve_hole23_angular_offset_phi)"
+        />
+    </physvol>
+
+  <physvol name="sieve_hole11_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole11_radial_position*cos(sieve_hole11_angular_offset_phi)"
+        y="sieve_hole11_radial_position*sin(sieve_hole11_angular_offset_phi)"
+        />
+    </physvol>
+
+    <physvol name="sieve_hole12_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole12_radial_position*cos(sieve_hole12_angular_offset_phi)"
+        y="sieve_hole12_radial_position*sin(sieve_hole12_angular_offset_phi)"
+        />
+    </physvol>
+
+    <physvol name="sieve_hole13_physical">
+      <volumeref ref="sieve_hole_logic"/>
+      <position
+        x="sieve_hole13_radial_position*cos(sieve_hole13_angular_offset_phi)"
+        y="sieve_hole13_radial_position*sin(sieve_hole13_angular_offset_phi)"
+        />
+    </physvol>
+
+
+   
   </volume>
 </structure>
 

--- a/geometry/upstream/upstreamTorusRegion.gdml
+++ b/geometry/upstream/upstreamTorusRegion.gdml
@@ -1644,6 +1644,11 @@
         <positionref ref="sieveActualCenter_pos"/>
       </physvol>
 
+      <physvol name="USblocker">
+        <file name= "upstream/blocker.gdml"/>
+        <positionref ref="blockerActualCenter_pos"/>
+      </physvol>
+
       <physvol name="UScoil">
         <file name= "upstream/upstreamToroid.gdml"/>
       </physvol>

--- a/macros/blocker/blockerTest_100.mac
+++ b/macros/blocker/blockerTest_100.mac
@@ -1,0 +1,44 @@
+/remoll/geometry/setfile geometry/mollerMother.gdml
+/remoll/parallel/setfile geometry/mollerParallel.gdml
+
+/remoll/physlist/parallel/enable 
+
+# Enable optical physics
+/remoll/physlist/optical/enable
+
+# This must be explicitly called
+/run/initialize
+
+/remoll/printgeometry true
+
+/control/execute macros/load_magnetic_fieldmaps.mac
+
+# Raster and initial angle stuff
+/remoll/oldras true
+/remoll/rasx 5 mm
+/remoll/rasy 5 mm
+
+#/remoll/evgen/set moller
+#/remoll/evgen/set elastic 
+#/remoll/evgen/set inelastic 
+/remoll/evgen/set pion
+#/remoll/piontype pi+
+#/remoll/evgen/set pion_LUND
+#/remoll/evgen/set inelasticAl
+#/remoll/evgen/set quasielasticAl
+#/remoll/evgen/set elasticAl
+#/remoll/evgen/set external
+
+/remoll/beamene 11 GeV
+/remoll/beamcurr 65 microampere
+
+/control/execute macros/blocker/blocker_in.mac
+
+/remoll/SD/disable_all
+/remoll/SD/enable 29 #DS pion det
+/remoll/SD/enable 1006 #sieve (secondaries)
+/remoll/SD/enable 1007 #blocker
+
+/process/list
+
+/run/beamOn 100

--- a/macros/blocker/blocker_in.mac
+++ b/macros/blocker/blocker_in.mac
@@ -1,0 +1,2 @@
+# Move the blocker 200 mm to beam axis
+/remoll/geometry/relative_position USblocker (200,0,0)

--- a/macros/blocker/blocker_out.mac
+++ b/macros/blocker/blocker_out.mac
@@ -1,0 +1,2 @@
+# Move the blocker 200 mm off axis
+/remoll/geometry/relative_position USblocker (-200,0,0)

--- a/macros/target/Optics2.mac
+++ b/macros/target/Optics2.mac
@@ -1,3 +1,3 @@
 /remoll/geometry/absolute_position targetLadder (0,630,0)
 /remoll/target/mother Optics2
-/remoll/target/volume USC
+/remoll/target/volume DSC

--- a/macros/target/Optics3.mac
+++ b/macros/target/Optics3.mac
@@ -1,0 +1,3 @@
+/remoll/geometry/absolute_position targetLadder (0,700,0)
+/remoll/target/mother Optics3
+/remoll/target/volume DSC


### PR DESCRIPTION
I added an Optics3 target that is a single carbon foil in the center of the z region of the target ladder. I place it 70mm below Optics2 in y on the ladder. I ran a basic simulation with Optics3 and plotted part.vz, and it looks good.

<img width="759" alt="Screen Shot 2024-02-13 at 1 17 30 PM" src="https://github.com/JeffersonLab/remoll/assets/89591378/9cf208bb-8e74-4415-8e03-7e2c8c0e3090">

I've also edited Optics1 and Optics2 to be single carbon foils that sample from the downstream target. This way, we have on target on the upstream end, one target in the middle, and one target on the downstream end. 

Finally, I updated the sieve geometry to be up-to-date with what MIT engineering has and added in the blocker geometry (with macros to insert the blocker).
