### PR TITLE
Fix overlap issue

### DIFF
--- a/geometry/upstream/sieve.gdml
+++ b/geometry/upstream/sieve.gdml
@@ -104,7 +104,7 @@
   <tube name="sieve_hole_solid"
     rmin="0."
     rmax="sieve_hole_diameter/2"
-    z="sieve_system_thickness+2"
+    z="sieve_system_thickness"
     startphi="0" deltaphi="360.0" aunit="deg"
     />
 


### PR DESCRIPTION
When I ran my simulation with this new develop branch, there were a lot of overlaps detected in the sieve (A screenshot is attached).This is happening because of the nested volume structure that I used to define the sieve holes (the holes are actually nested inside the full solid annulus sieve). In that nested structure, I make the z length of the sieve holes a 1 mm longer than the z thickness of the sieve itself as a cautionary measure on each side. Those overlap problems will go away once you make the two lengths equal. Previously it used to not give any problems but it might be due to the new G4 version (only my guess).

<img width="1395" alt="Screenshot 2024-10-10 at 3 45 53 PM" src="https://github.com/user-attachments/assets/64c0d636-c0b4-4330-b484-08622ee14ae1">
