### PR TITLE
Update MD tile GDML files: assign indiviual tile IDs, shortened R1 tile…

### DIFF
--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg10_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg10_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg10_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg10_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111010"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111010"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg10_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111020"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111020"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg10_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111030"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111030"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg10_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111040"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111040"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg10_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111051"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111051"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg10_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111053"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>
+			<auxiliary auxtype="DetNo" auxvalue="111053"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg10_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111052"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="111052"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg10_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg10_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111060"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111060"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg11_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg11_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg11_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg11_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-            <!--<auxiliary auxtype="DetNo" auxvalue="111110"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+            <auxiliary auxtype="DetNo" auxvalue="111110"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg11_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111120"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111120"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg11_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111130"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111130"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg11_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111140"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111140"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg11_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111151"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111151"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg11_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111153"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>
+			<auxiliary auxtype="DetNo" auxvalue="111153"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg11_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111152"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="111152"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg11_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg11_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111160"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111160"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg12_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg12_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg12_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg12_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111210"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111210"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg12_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111220"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111220"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg12_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111230"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111230"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg12_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111240"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111240"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg12_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111251"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111251"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg12_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111253"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>
+			<auxiliary auxtype="DetNo" auxvalue="111253"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg12_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111252"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="111252"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg12_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg12_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111260"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111260"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg13_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg13_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg13_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg13_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111310"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111310"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg13_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111320"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111320"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg13_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111330"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111330"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg13_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111340"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111340"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg13_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111351"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111351"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg13_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111353"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>
+			<auxiliary auxtype="DetNo" auxvalue="111353"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg13_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111352"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="111352"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg13_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg13_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111360"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111360"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg14_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg14_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg14_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg14_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111410"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111410"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg14_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-            <!--<auxiliary auxtype="DetNo" auxvalue="111420"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+            <auxiliary auxtype="DetNo" auxvalue="111420"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg14_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111430"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111430"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg14_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111440"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111440"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg14_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111451"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111451"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg14_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111453"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111453"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg14_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111452"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="111452"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg14_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg14_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="111460"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="111460"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg1_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg1_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg1_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg1_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110110"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110110"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg1_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110120"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110120"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg1_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110130"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110130"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg1_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110140"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110140"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg1_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110151"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110151"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg1_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110153"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>
+			<auxiliary auxtype="DetNo" auxvalue="110153"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg1_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110152"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="110152"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg1_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg1_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110160"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110160"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg2_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg2_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg2_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg2_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110210"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110210"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg2_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110220"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110220"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg2_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110230"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110230"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg2_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110240"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110240"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg2_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110251"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110251"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg2_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110253"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>
+			<auxiliary auxtype="DetNo" auxvalue="110253"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg2_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110252"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="110252"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg2_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg2_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110260"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110260"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg3_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg3_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg3_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg3_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110310"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110310"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg3_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110320"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110320"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg3_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110330"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110330"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg3_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110340"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110340"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg3_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110351"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110351"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg3_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110353"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>
+			<auxiliary auxtype="DetNo" auxvalue="110353"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg3_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110352"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="110352"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg3_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg3_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110360"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110360"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R1-BF-Quartz.gdml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
- 
-	<solids>
-		<arb8 name = "BFSeg4_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
- 
+ <!-- <solids>
+     <arb8 name = "BFSeg4_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
+ </solids>-->
+
+    <solids>
+        <arb8 name="BFSeg4_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
+   
 	<structure>
 		<volume name="BFSeg4_R1-BF-Quartz">
 			<materialref ref="Quartz"/>
 			<solidref ref="BFSeg4_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110410"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110410"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg4_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110420"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110420"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg4_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110430"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110430"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg4_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110440"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110440"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg4_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110451"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>            
+			<auxiliary auxtype="DetNo" auxvalue="110451"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg4_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110453"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>
+			<auxiliary auxtype="DetNo" auxvalue="110453"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg4_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110452"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="110452"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg4_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg4_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110460"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110460"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg5_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg5_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg5_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg5_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110510"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110510"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg5_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110520"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110520"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg5_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110530"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110530"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg5_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110540"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110540"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg5_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110551"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>            
+			<auxiliary auxtype="DetNo" auxvalue="110551"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg5_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110553"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>            
+			<auxiliary auxtype="DetNo" auxvalue="110553"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg5_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110552"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>            
+			<auxiliary auxtype="DetNo" auxvalue="110552"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg5_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg5_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110560"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110560"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg6_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg6_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg6_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg6_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110610"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110610"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg6_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110620"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110620"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg6_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110630"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110630"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg6_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110640"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110640"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg6_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110651"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>            
+			<auxiliary auxtype="DetNo" auxvalue="110651"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg6_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110653"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>            
+			<auxiliary auxtype="DetNo" auxvalue="110653"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg6_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110652"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="110652"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg6_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg6_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110660"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110660"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg7_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg7_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg7_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg7_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110710"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110710"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg7_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110720"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110720"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg7_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110730"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110730"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg7_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110740"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110740"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg7_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110751"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110751"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg7_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110753"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>
+			<auxiliary auxtype="DetNo" auxvalue="110753"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg7_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110752"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="110752"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg7_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg7_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110760"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110760"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg8_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg8_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg8_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg8_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110810"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110810"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg8_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110820"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>            
+			<auxiliary auxtype="DetNo" auxvalue="110820"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg8_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110830"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110830"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg8_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110840"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110840"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg8_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110851"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110851"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg8_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110853"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>
+			<auxiliary auxtype="DetNo" auxvalue="110853"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg8_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110852"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="110852"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg8_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg8_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110860"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110860"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R1-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R1-BF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "BFSeg9_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "BFSeg9_R1-BF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="BFSeg9_R1-BF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="BFSeg9_R1-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110910"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110910"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R2-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R2-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg9_R2-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110920"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110920"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R3-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R3-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg9_R3-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110930"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110930"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R4-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R4-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg9_R4-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110940"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110940"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R5-BF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R5-BF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg9_R5-BF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110951"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110951"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R5-BF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R5-BF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg9_R5-BF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110953"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050103"/>
+			<auxiliary auxtype="DetNo" auxvalue="110953"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050103"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R5-FF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R5-FF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg9_R5-FF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110952"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050102"/>
+			<auxiliary auxtype="DetNo" auxvalue="110952"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050102"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R6-BF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/BFSeg9_R6-BF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="BFSeg9_R6-BF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="110960"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060101"/>
+			<auxiliary auxtype="DetNo" auxvalue="110960"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060101"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/DetectorArray.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/DetectorArray.gdml
@@ -24,7 +24,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg1_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="1005.17" y="0" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="1005.17-1" y="0" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99763410272428" y="0" z="90"/>
 			</physvol>
 			<physvol>
@@ -59,12 +59,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg1_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="962.16" y="301.68" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="962.16-1*cos(atan2(301.68,962.16))" y="301.68-1*sin(atan2(301.68,962.16))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00102144041703" y="0" z="77.1363693023936"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg1_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="997.77" y="145.69" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="997.77-1*cos(atan2(145.69,997.77))" y="145.69-1*sin(atan2(145.69,997.77))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.0012502338421" y="0" z="77.1363693023936"/>
 			</physvol>
 			<physvol>
@@ -104,7 +104,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg2_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="905.63" y="436.12" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="905.63-1*cos(atan2(436.12,905.63))" y="436.12-1*sin(atan2(436.12,905.63))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99756475056213" y="0" z="64.2869393190475"/>
 			</physvol>
 			<physvol>
@@ -139,12 +139,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg2_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="735.98" y="689.27" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="735.98-1*cos(atan2(689.27,735.98))" y="689.27-1*sin(atan2(689.27,735.98))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00110158279097" y="0" z="51.41960449999"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg2_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="835.75" y="564.18" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="835.75-1*cos(atan2(564.18,835.75))" y="564.18-1*sin(atan2(564.18,835.75))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00125095792547" y="0" z="51.4252035776925"/>
 			</physvol>
 			<physvol>
@@ -184,7 +184,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg3_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="626.72" y="785.87" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="626.72-1*cos(atan2(785.87,626.72))" y="785.87-1*sin(atan2(785.87,626.72))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99757625130764" y="0" z="38.5747964223075"/>
 			</physvol>
 			<physvol>
@@ -219,12 +219,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg3_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="364.04" y="940.34" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="364.04-1*cos(atan2(940.34,364.04))" y="940.34-1*sin(atan2(940.34,364.04))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00120918624295" y="0" z="25.7130606809524"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg3_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="508.2" y="870.92" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="508.2-1*cos(atan2(870.92,508.2))" y="870.92-1*sin(atan2(870.92,508.2))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00120919843714" y="0" z="25.7130606809524"/>
 			</physvol>
 			<physvol>
@@ -264,7 +264,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg4_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="223.69" y="979.96" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="223.69-1*cos(atan2(979.96,223.69))" y="979.96-1*sin(atan2(979.96,223.69))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99760573194198" y="0" z="12.8550545545998"/>
 			</physvol>
 			<physvol>
@@ -299,12 +299,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg4_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-80" y="1005.17" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-80-1*cos(atan2(1005.17,-80))" y="1005.17-1*sin(atan2(1005.17,-80))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00127863009874" y="0" z="0"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg4_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="80" y="1005.17" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="80-1*cos(atan2(1005.17,80))" y="1005.17-1*sin(atan2(1005.17,80))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00108755974753" y="0" z="0"/>
 			</physvol>
 			<physvol>
@@ -344,7 +344,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg5_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-223.65" y="979.97" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-223.65-1*cos(atan2(979.97,-223.650))" y="979.97-1*sin(atan2(979.97,-223.650))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99746213827367" y="0" z="-12.8550545545998"/>
 			</physvol>
 			<physvol>
@@ -379,12 +379,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg5_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-508.2" y="870.92" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-508.2-1*cos(atan2(870.92,-508.2))" y="870.92-1*sin(atan2(870.92,-508.2))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00112628845284" y="0" z="-25.7161682809677"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg5_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-364.05" y="940.34" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-364.05-1*cos(atan2(940.34,-364.05))" y="940.34-1*sin(atan2(940.34,-364.05))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00129843586788" y="0" z="-25.7195129551217"/>
 			</physvol>
 			<physvol>
@@ -424,7 +424,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg6_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-626.69" y="785.89" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-626.69-1*cos(atan2(785.89,-626.69))" y="785.89-1*sin(atan2(785.89,-626.69))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99757625130764" y="0" z="-38.5703308567256"/>
 			</physvol>
 			<physvol>
@@ -459,12 +459,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg6_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-835.74" y="564.17" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-835.74-1*cos(atan2(564.17,-835.74))" y="564.17-1*sin(atan2(564.17,-835.74))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00122070860362" y="0" z="-51.4296691432744"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg6_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-735.99" y="689.27" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-735.99-1*cos(atan2(689.27,-735.99))" y="689.27-1*sin(atan2(689.27,-735.99))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00107132519304" y="0" z="-51.4296691432743"/>
 			</physvol>
 			<physvol>
@@ -504,7 +504,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg7_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-905.61" y="436.15" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-905.61-1*cos(atan2(436.15,-905.61))" y="436.15-1*sin(atan2(436.15,-905.61))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.9976538845308" y="0" z="-64.2869393190476"/>
 			</physvol>
 			<physvol>
@@ -539,12 +539,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg7_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-997.76" y="145.69" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-997.76-1*cos(atan2(145.69,-997.76))" y="145.69-1*sin(atan2(145.69,-997.76))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00125022152464" y="0" z="-77.1449454454001"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg7_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-962.16" y="301.68" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-962.16-1*cos(atan2(301.68,-962.16))" y="301.68-1*sin(atan2(301.68,-962.16))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00125022152464" y="0" z="-77.1433519214721"/>
 			</physvol>
 			<physvol>
@@ -584,7 +584,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg8_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-1005.17" y="0.04" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-1005.17-1*cos(atan2(0.04,-1005.17))" y="0.04-1*sin(atan2(0.04,-1005.17))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99763410272428" y="0" z="-90"/>
 			</physvol>
 			<physvol>
@@ -619,12 +619,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg8_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-962.17" y="-301.65" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-962.17-1*cos(atan2(-301.65,-962.17))" y="-301.65-1*sin(atan2(-301.65,-962.17))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00106394680686" y="0" z="-102.862036367149"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg8_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-997.77" y="-145.66" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-997.77-1*cos(atan2(-145.66,-997.77))" y="-145.66-1*sin(atan2(-145.66,-997.77))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00125022494929" y="0" z="-102.856648078528"/>
 			</physvol>
 			<physvol>
@@ -664,7 +664,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg9_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-905.64" y="-436.09" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-905.64-1*cos(atan2(-436.09,-905.64))" y="-436.09-1*sin(atan2(-436.09,-905.64))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99756474288783" y="0" z="-115.706607706909"/>
 			</physvol>
 			<physvol>
@@ -699,12 +699,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg9_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-736.01" y="-689.24" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-736.01-1*cos(atan2(-689.24,-736.01))" y="-689.24-1*sin(atan2(-689.24,-736.01))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00122071822172" y="0" z="-128.570330856726"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg9_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-835.77" y="-564.15" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-835.77-1*cos(atan2(-564.15,-835.77))" y="-564.15-1*sin(atan2(-564.15,-835.77))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.0012207182216" y="0" z="-128.570330856726"/>
 			</physvol>
 			<physvol>
@@ -744,7 +744,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg10_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-626.75" y="-785.84" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-626.75-1*cos(atan2(-785.84,-626.75))" y="-785.84-1*sin(atan2(-785.84,-626.75))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99745726760163" y="0" z="-141.424070264651"/>
 			</physvol>
 			<physvol>
@@ -779,12 +779,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg10_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-364.08" y="-940.32" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-364.08-1*cos(atan2(-940.32,-364.08))" y="-940.32-1*sin(atan2(-940.32,-364.08))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00120918624295" y="0" z="-154.286939319048"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg10_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-508.23" y="-870.9" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-508.23-1*cos(atan2(-870.9,-508.23))" y="-870.9-1*sin(atan2(-870.9,-508.23))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00112628679949" y="0" z="-154.286939319048"/>
 			</physvol>
 			<physvol>
@@ -824,7 +824,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg11_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-223.72" y="-979.96" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-223.72-1*cos(atan2(-979.96,-223.72))" y="-979.96-1*sin(atan2(-979.96,-223.72))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99760573194198" y="0" z="-167.143351921472"/>
 			</physvol>
 			<physvol>
@@ -859,12 +859,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg11_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="79.97" y="-1005.17" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="79.97-1*cos(atan2(-1005.17,79.97))" y="-1005.17-1*sin(atan2(-1005.17,79.97))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00127863009874" y="0" z="-180"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg11_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-80.03" y="-1005.17" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-80.03-1*cos(atan2(-1005.17,-80.03))" y="-1005.17-1*sin(atan2(-1005.17,-80.03))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00127863009874" y="0" z="-180"/>
 			</physvol>
 			<physvol>
@@ -904,7 +904,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg12_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="223.62" y="-979.98" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="223.62-1*cos(atan2(-979.98,223.62))" y="-979.98-1*sin(atan2(-979.98,223.62))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99746213827367" y="0" z="-192.849665070987"/>
 			</physvol>
 			<physvol>
@@ -939,12 +939,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg12_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="508.17" y="-870.93" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="508.17-1*cos(atan2(-870.93,508.17))" y="-870.93-1*sin(atan2(-870.93,508.17))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00112628845284" y="0" z="-205.716168280968"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg12_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="364.01" y="-940.35" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="364.01-1*cos(atan2(-940.35,364.01))" y="-940.35-1*sin(atan2(-940.35,364.01))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00120919392665" y="0" z="-205.713060680952"/>
 			</physvol>
 			<physvol>
@@ -984,7 +984,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg13_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="626.67" y="-785.91" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="626.67-1*cos(atan2(-785.91,626.67))" y="-785.91-1*sin(atan2(-785.91,626.67))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99754602792094" y="0" z="-218.564731105379"/>
 			</physvol>
 			<physvol>
@@ -1019,12 +1019,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg13_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="835.72" y="-564.2" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="835.72-1*cos(atan2(-564.2,835.72))" y="-564.2-1*sin(atan2(-564.2,835.72))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00122070860362" y="0" z="-231.425203577693"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg13_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="735.97" y="-689.29" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="735.97-1*cos(atan2(-689.29,735.97))" y="-689.29-1*sin(atan2(-689.29,735.97))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00122070860362" y="0" z="-231.425203577693"/>
 			</physvol>
 			<physvol>
@@ -1064,7 +1064,7 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg14_R5-BF-Quartz_C.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_C_pos" x="905.6" y="-436.19" z="78.08"/>
+				<position unit="mm" name="R5-BF-Quartz_C_pos" x="905.6-1*cos(atan2(-436.19,905.6))" y="-436.19-1*sin(atan2(-436.19,905.6))" z="78.08"/>
 				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99739914681653" y="0" z="-244.280487044878"/>
 			</physvol>
 			<physvol>
@@ -1099,12 +1099,12 @@
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg14_R5-BF-Quartz_R.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_R_pos" x="997.76" y="-145.73" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_R_pos" x="997.76-1*cos(atan2(-145.73,997.76))" y="-145.73-1*sin(atan2(-145.73,997.76))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00125022494929" y="0" z="-257.137963632851"/>
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg14_R5-BF-Quartz_L.gdml"/>
-				<position unit="mm" name="R5-BF-Quartz_L_pos" x="962.15" y="-301.71" z="78.95"/>
+				<position unit="mm" name="R5-BF-Quartz_L_pos" x="962.15-1*cos(atan2(-301.71,962.15))" y="-301.71-1*sin(atan2(-301.71,962.15))" z="78.95"/>
 				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00106396206322" y="0" z="-257.1449454454"/>
 			</physvol>
 			<physvol>

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R1-FF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg10_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "FFSeg10_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="FFSeg10_R1-FF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="FFSeg10_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151010"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151010"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg10_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151020"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151020"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg10_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151030"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151030"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg10_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151040"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151040"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg10_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151052"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050202"/>
+			<auxiliary auxtype="DetNo" auxvalue="151052"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050202"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg10_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151051"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151051"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg10_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151053"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050203"/>
+			<auxiliary auxtype="DetNo" auxvalue="151053"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050203"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg10_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg10_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151060"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151060"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R1-FF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg11_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "FFSeg11_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="FFSeg11_R1-FF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="FFSeg11_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151110"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010001"/>
+			<auxiliary auxtype="DetNo" auxvalue="151110"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg11_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151120"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020001"/>
+			<auxiliary auxtype="DetNo" auxvalue="151120"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg11_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151130"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030001"/>
+			<auxiliary auxtype="DetNo" auxvalue="151130"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg11_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151140"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040001"/>
+			<auxiliary auxtype="DetNo" auxvalue="151140"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg11_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151152"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050002"/>
+			<auxiliary auxtype="DetNo" auxvalue="151152"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050002"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg11_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151151"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050001"/>
+			<auxiliary auxtype="DetNo" auxvalue="151151"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg11_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151153"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050003"/>
+			<auxiliary auxtype="DetNo" auxvalue="151153"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050003"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg11_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg11_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151160"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060001"/>
+			<auxiliary auxtype="DetNo" auxvalue="151160"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R1-FF-Quartz.gdml
@@ -2,18 +2,22 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg12_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
- 
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "FFSeg12_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
+    
 	<structure>
 		<volume name="FFSeg12_R1-FF-Quartz">
 			<materialref ref="Quartz"/>
 			<solidref ref="FFSeg12_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151210"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151210"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg12_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151220"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151220"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg12_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151230"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151230"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg12_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151240"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151240"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg12_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151252"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050202"/>
+			<auxiliary auxtype="DetNo" auxvalue="151252"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050202"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg12_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151251"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151251"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg12_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151253"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050203"/>
+			<auxiliary auxtype="DetNo" auxvalue="151253"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050203"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg12_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg12_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151260"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151260"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R1-FF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg13_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "FFSeg13_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="FFSeg13_R1-FF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="FFSeg13_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151310"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010001"/>
+			<auxiliary auxtype="DetNo" auxvalue="151310"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg13_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151320"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020001"/>
+			<auxiliary auxtype="DetNo" auxvalue="151320"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg13_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151330"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030001"/>
+			<auxiliary auxtype="DetNo" auxvalue="151330"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg13_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151340"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040001"/>
+			<auxiliary auxtype="DetNo" auxvalue="151340"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg13_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151352"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050002"/>
+			<auxiliary auxtype="DetNo" auxvalue="151352"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050002"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg13_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151351"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050001"/>
+			<auxiliary auxtype="DetNo" auxvalue="151351"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg13_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151353"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050003"/>
+			<auxiliary auxtype="DetNo" auxvalue="151353"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050003"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg13_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg13_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151360"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060001"/>
+			<auxiliary auxtype="DetNo" auxvalue="151360"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R1-FF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg14_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "FFSeg14_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="FFSeg14_R1-FF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="FFSeg14_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151410"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151410"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg14_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151420"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151420"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg14_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151430"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151430"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg14_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151440"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151440"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg14_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151452"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050202"/>
+			<auxiliary auxtype="DetNo" auxvalue="151452"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050202"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg14_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151451"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151451"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg14_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151453"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050203"/>
+			<auxiliary auxtype="DetNo" auxvalue="151453"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050203"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg14_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg14_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="151460"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060201"/>
+			<auxiliary auxtype="DetNo" auxvalue="151460"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R1-FF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg1_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "FFSeg1_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="FFSeg1_R1-FF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="FFSeg1_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150110"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150110"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg1_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150120"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150120"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg1_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150130"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150130"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg1_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150140"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150140"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg1_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150152"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050002"/>
+			<auxiliary auxtype="DetNo" auxvalue="150152"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050002"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg1_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150151"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150151"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg1_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150153"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050003"/>
+			<auxiliary auxtype="DetNo" auxvalue="150153"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050003"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg1_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg1_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150160"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150160"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R1-FF-Quartz.gdml
@@ -2,9 +2,14 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg2_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+ 
+    <solids>
+        <arb8 name="FFSeg2_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
+    
  
 	<structure>
 		<volume name="FFSeg2_R1-FF-Quartz">
@@ -12,8 +17,8 @@
 			<solidref ref="FFSeg2_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150210"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150210"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg2_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150220"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150220"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg2_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150230"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030201"/>
+		    <auxiliary auxtype="DetNo" auxvalue="150230"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg2_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150240"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150240"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg2_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150252"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050202"/>
+			<auxiliary auxtype="DetNo" auxvalue="150252"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050202"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg2_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150251"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150251"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg2_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150253"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050203"/>
+			<auxiliary auxtype="DetNo" auxvalue="150253"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050203"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg2_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg2_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150260"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150260"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R1-FF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg3_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "FFSeg3_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="FFSeg3_R1-FF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="FFSeg3_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150310"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150310"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg3_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150320"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150320"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg3_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150330"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150330"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg3_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150340"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150340"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg3_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150352"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050002"/>
+			<auxiliary auxtype="DetNo" auxvalue="150352"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050002"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg3_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150351"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150351"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg3_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150353"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050003"/>
+			<auxiliary auxtype="DetNo" auxvalue="150353"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050003"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg3_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg3_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150360"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150360"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R1-FF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg4_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "FFSeg4_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="FFSeg4_R1-FF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="FFSeg4_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150410"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150410"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg4_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150420"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150420"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg4_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150430"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150430"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg4_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150440"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150440"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg4_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150452"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050202"/>
+			<auxiliary auxtype="DetNo" auxvalue="150452"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050202"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg4_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150451"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150451"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg4_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150453"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050203"/>
+			<auxiliary auxtype="DetNo" auxvalue="150453"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050203"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg4_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg4_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150460"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150460"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R1-FF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg5_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "FFSeg5_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="FFSeg5_R1-FF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="FFSeg5_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150510"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150510"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg5_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150520"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150520"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg5_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150530"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150530"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg5_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150540"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150540"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg5_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150552"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050002"/>
+			<auxiliary auxtype="DetNo" auxvalue="150552"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050002"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg5_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150551"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150551"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg5_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150553"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050003"/>
+			<auxiliary auxtype="DetNo" auxvalue="150553"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050003"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg5_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg5_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150560"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150560"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R1-FF-Quartz.gdml
@@ -2,9 +2,12 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg6_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    <solids>
+        <arb8 name = "FFSeg6_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="FFSeg6_R1-FF-Quartz">
@@ -12,8 +15,8 @@
 			<solidref ref="FFSeg6_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150610"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150610"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg6_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150620"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150620"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg6_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150630"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150630"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg6_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150640"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150640"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg6_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150652"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050202"/>
+			<auxiliary auxtype="DetNo" auxvalue="150652"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050202"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg6_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150651"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150651"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg6_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150653"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050203"/>
+			<auxiliary auxtype="DetNo" auxvalue="150653"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050203"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg6_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg6_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150660"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150660"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R1-FF-Quartz.gdml
@@ -2,18 +2,22 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg7_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
- 
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "FFSeg7_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
+    
 	<structure>
 		<volume name="FFSeg7_R1-FF-Quartz">
 			<materialref ref="Quartz"/>
 			<solidref ref="FFSeg7_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150710"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150710"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg7_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150720"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150720"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg7_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150730"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150730"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg7_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150740"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150740"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg7_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150752"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150752"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050002"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg7_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150751"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050001"/>            
+			<auxiliary auxtype="DetNo" auxvalue="150751"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg7_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150753"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050003"/>
+			<auxiliary auxtype="DetNo" auxvalue="150753"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050003"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg7_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg7_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150760"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150760"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R1-FF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg8_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "FFSeg8_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="FFSeg8_R1-FF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="FFSeg8_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150810"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150810"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg8_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150820"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150820"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg8_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150830"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150830"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg8_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150840"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150840"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg8_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150852"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050202"/>
+			<auxiliary auxtype="DetNo" auxvalue="150852"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050202"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg8_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150851"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150851"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg8_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150853"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050203"/>
+			<auxiliary auxtype="DetNo" auxvalue="150853"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050203"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg8_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg8_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150860"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060201"/>
+			<auxiliary auxtype="DetNo" auxvalue="150860"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060201"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R1-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R1-FF-Quartz.gdml
@@ -2,9 +2,13 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
  
  
-	<solids>
+	<!--<solids>
 		<arb8 name = "FFSeg9_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="15" v3x="84.5" v3y="15" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="35" v7x="84.5" v7y="35" v8x="84.5" v8y="-15" dz="10" lunit= "mm"/>
-	</solids>
+	</solids>-->
+    
+    <solids>
+        <arb8 name = "FFSeg9_R1-FF-Quartz_solid" v1x="-84.5" v1y="-15" v2x="-84.5" v2y="5" v3x="84.5" v3y="5" v4x="84.5" v4y="-15" v5x="-84.5" v5y="-15" v6x="-84.5" v6y="25" v7x="84.5" v7y="25" v8x="84.5" v8y="-15" dz="10" lunit="mm"/>
+    </solids>
  
 	<structure>
 		<volume name="FFSeg9_R1-FF-Quartz">
@@ -12,8 +16,8 @@
 			<solidref ref="FFSeg9_R1-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150910"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1010001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150910"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1010001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R2-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R2-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg9_R2-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150920"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1020001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150920"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1020001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R3-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R3-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg9_R3-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150930"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1030001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150930"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1030001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R4-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R4-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg9_R4-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150940"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1040001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150940"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1040001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R5-BF-Quartz_C.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R5-BF-Quartz_C.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg9_R5-BF-Quartz_C_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150952"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050002"/>
+			<auxiliary auxtype="DetNo" auxvalue="150952"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050002"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R5-FF-Quartz_L.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R5-FF-Quartz_L.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg9_R5-FF-Quartz_L_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150951"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150951"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050001"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R5-FF-Quartz_R.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R5-FF-Quartz_R.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg9_R5-FF-Quartz_R_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150953"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1050003"/>
+			<auxiliary auxtype="DetNo" auxvalue="150953"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1050003"/>-->
 		</volume>
 	</structure>
  

--- a/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R6-FF-Quartz.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/FFSeg9_R6-FF-Quartz.gdml
@@ -12,8 +12,8 @@
 			<solidref ref="FFSeg9_R6-FF-Quartz_solid"/>
 			<auxiliary auxtype="Color" auxvalue="magenta"/>
 			<auxiliary auxtype="SensDet" auxvalue="mainDetectorSD" />
-			<!--<auxiliary auxtype="DetNo" auxvalue="150960"/>-->
-            <auxiliary auxtype="DetNo" auxvalue="1060001"/>
+			<auxiliary auxtype="DetNo" auxvalue="150960"/>
+            <!--<auxiliary auxtype="DetNo" auxvalue="1060001"/>-->
 		</volume>
 	</structure>
  


### PR DESCRIPTION
This PR includes geometry fixes for the Main detector tiles;
- assigned individual detector ID for each tile
- moved the Ring5 back flush tiles radially inward by 1mm
- shortened Ring1 tiles : More info: https://moller-docdb.physics.sunysb.edu/DocDB/0011/001134/002/Moller_26Feb24_MD_Ring1Ring2.pdf