### PR TITLE
Update the rotation angle for the main detector in the GDML

### DIFF
--- a/geometry/detector/ThinQuartz/DetectorArray/DetectorArray.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/DetectorArray.gdml
@@ -15,1122 +15,1122 @@
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg1_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="996.22" y="-80" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99763410272428" y="0" z="-270"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="0.0000" y="-2.9976" z="90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg1_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="996.22" y="80" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.99763410272428" y="0" z="90"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="0.0000" y="-2.9976" z="90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg1_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="1005.17-1" y="0" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99763410272428" y="0" z="90"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="0.0000" y="-2.9976" z="90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg1_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="883.6" y="0" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.99708537519869" y="0" z="90"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="0.0000" y="-2.9971" z="90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg1_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="808.24" y="0" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.00224758033941" y="0" z="90"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="0.0000" y="-3.0022" z="90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg1_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="762.49" y="0" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00224758033953" y="0" z="90"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="0.0000" y="-3.0022" z="90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg1_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="731.72" y="0" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.99230923889332" y="0" z="90"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="0.0000" y="-2.9923" z="90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg1_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="1101.41" y="0" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99973858911886" y="0" z="90"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="0.0000" y="-2.9997" z="90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg1_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="971.24" y="221.69" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00106394456493" y="0" z="77.1363693023937"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="0.6687" y="-2.9257" z="77.1193" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg1_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="962.16-1*cos(atan2(301.68,962.16))" y="301.68-1*sin(atan2(301.68,962.16))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00102144041703" y="0" z="77.1363693023936"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="0.6687" y="-2.9256" z="77.1193" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg1_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="997.77-1*cos(atan2(145.69,997.77))" y="145.69-1*sin(atan2(145.69,997.77))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.0012502338421" y="0" z="77.1363693023936"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="0.6688" y="-2.9259" z="77.1193" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg1_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="868.15" y="198.16" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.00122527969865" y="0" z="77.1394584060375"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="0.6686" y="-2.9259" z="77.1224" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg1_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="794.66" y="181.38" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99487897748325" y="0" z="77.1398647098126"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="0.6672" y="-2.9197" z="77.1229" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg1_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="750.16" y="171.22" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99496225842162" y="0" z="77.1399764002307"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="0.6672" y="-2.9198" z="77.1230" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg1_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="720.16" y="164.37" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.0036511046504" y="0" z="77.1380297370479"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="0.6692" y="-2.9282" z="77.1209" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg1_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="1080.58" y="246.66" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99985199406693" y="0" z="77.1396680098295"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="0.6683" y="-2.9245" z="77.1226" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg2_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="932.27" y="360.16" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99756475056213" y="0" z="64.2869393190475"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="1.3015" y="-2.7005" z="64.2563" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg2_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="862.85" y="504.32" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.99748194539466" y="0" z="64.2869393190475"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="1.3015" y="-2.7004" z="64.2563" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg2_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="905.63-1*cos(atan2(436.12,905.63))" y="436.12-1*sin(atan2(436.12,905.63))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99756475056213" y="0" z="64.2869393190475"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="1.3015" y="-2.7005" z="64.2563" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg2_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="796.09" y="383.37" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.99718324709623" y="0" z="64.2843011655183"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="1.3015" y="-2.7001" z="64.2536" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg2_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="728.2" y="350.68" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.0020792280983" y="0" z="64.2859204923853"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="1.3035" y="-2.7046" z="64.2551" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg2_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="686.98" y="330.83" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00224197032247" y="0" z="64.2867348616001"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="1.3035" y="-2.7047" z="64.2560" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg2_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="659.26" y="317.48" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.99215903683614" y="0" z="64.28552100451"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="1.2992" y="-2.6956" z="64.2550" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg2_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="992.34" y="477.88" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99985791843856" y="0" z="64.2864429654171"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="1.3025" y="-2.7026" z="64.2557" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg2_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="778.87" y="621.14" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00125096943197" y="0" z="51.4296691432744"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="1.8723" y="-2.3461" z="51.3913" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg2_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="735.98-1*cos(atan2(689.27,735.98))" y="689.27-1*sin(atan2(689.27,735.98))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00110158279097" y="0" z="51.41960449999"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="1.8726" y="-2.3456" z="51.3813" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg2_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="835.75-1*cos(atan2(564.18,835.75))" y="564.18-1*sin(atan2(564.18,835.75))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00125095792547" y="0" z="51.4252035776925"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="1.8724" y="-2.3459" z="51.3869" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg2_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="696.2" y="555.21" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.00117179784088" y="0" z="51.4254732646494"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="1.8724" y="-2.3459" z="51.3871" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg2_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="637.27" y="508.21" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99489119518104" y="0" z="51.4254350380914"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="1.8685" y="-2.3410" z="51.3873" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg2_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="601.58" y="479.75" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99541711274725" y="0" z="51.4256749419164"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="1.8688" y="-2.3414" z="51.3875" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg2_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="577.53" y="460.56" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00363667055131" y="0" z="51.425963014265"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="1.8739" y="-2.3478" z="51.3876" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg2_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="866.55" y="691.07" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99981480575516" y="0" z="51.4255418585876"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="1.8715" y="-2.3448" z="51.3872" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg3_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="683.69" y="728.99" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99745726760163" y="0" z="38.5703308567256"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.3444" y="-1.8683" z="38.5321" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg3_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="558.59" y="828.75" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.99757625130764" y="0" z="38.5747964223075"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.3443" y="-1.8686" z="38.5366" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg3_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="626.72-1*cos(atan2(785.87,626.72))" y="785.87-1*sin(atan2(785.87,626.72))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99757625130764" y="0" z="38.5747964223075"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.3443" y="-1.8686" z="38.5366" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg3_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="550.92" y="690.82" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.99721832550766" y="0" z="38.5728495018984"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.3441" y="-1.8683" z="38.5346" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg3_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="503.94" y="631.9" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.002276786191" y="0" z="38.5722072982198"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="2.3481" y="-1.8714" z="38.5339" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg3_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="475.41" y="596.14" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00227678985119" y="0" z="38.5723292704693"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="2.3481" y="-1.8714" z="38.5340" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg3_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="456.23" y="572.08" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.99219327349989" y="0" z="38.5713864601968"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.3402" y="-1.8651" z="38.5333" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg3_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="686.73" y="861.11" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99981480575516" y="0" z="38.571361294392"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.3462" y="-1.8698" z="38.5331" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg3_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="432.24" y="897.56" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00120918624295" y="0" z="25.7066077069091"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="2.7046" y="-1.3013" z="25.6759" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg3_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="364.04-1*cos(atan2(940.34,364.04))" y="940.34-1*sin(atan2(940.34,364.04))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00120918624295" y="0" z="25.7130606809524"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="2.7045" y="-1.3016" z="25.6823" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg3_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="508.2-1*cos(atan2(870.92,508.2))" y="870.92-1*sin(atan2(870.92,508.2))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00120919843714" y="0" z="25.7130606809524"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="2.7045" y="-1.3016" z="25.6823" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg3_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="386.36" y="802.29" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.00107722903831" y="0" z="25.7121081286902"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="2.7044" y="-1.3015" z="25.6814" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg3_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="353.66" y="734.38" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.9949274163605" y="0" z="25.7113625977412"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.6989" y="-1.2988" z="25.6808" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg3_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="333.86" y="693.25" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99492742409938" y="0" z="25.711876407795"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.6989" y="-1.2989" z="25.6813" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg3_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="320.51" y="665.53" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00414335225381" y="0" z="25.7114245133361"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="2.7072" y="-1.3028" z="25.6806" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg3_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="480.9" y="998.62" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99985791528861" y="0" z="25.7115715952134"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.7033" y="-1.3010" z="25.6809" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg4_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="299.69" y="953.44" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99760573194198" y="0" z="12.8566480785278"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.9226" y="-0.6667" z="12.8396" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg4_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="143.7" y="989.04" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.99741967693589" y="0" z="12.8636306976064"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.9223" y="-0.6670" z="12.8466" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg4_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="223.69-1*cos(atan2(979.96,223.69))" y="979.96-1*sin(atan2(979.96,223.69))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99760573194198" y="0" z="12.8550545545998"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.9226" y="-0.6666" z="12.8380" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg4_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="196.63" y="861.44" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.9969297088006" y="0" z="12.8579191418416"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.9219" y="-0.6666" z="12.8409" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg4_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="179.86" y="787.97" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.00211414891051" y="0" z="12.8601352901874"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="2.9269" y="-0.6679" z="12.8431" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg4_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="169.68" y="743.37" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00247986696855" y="0" z="12.8569029663613"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="2.9273" y="-0.6678" z="12.8398" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg4_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="162.83" y="713.38" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.99220764800981" y="0" z="12.8579105472007"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.9173" y="-0.6656" z="12.8410" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg4_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="245.1" y="1073.79" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99985199386394" y="0" z="12.8560351387451"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.9248" y="-0.6672" z="12.8390" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg4_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="0" y="996.22" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00108755974753" y="0" z="0"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.0011" y="0.0000" z="0.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg4_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-80-1*cos(atan2(1005.17,-80))" y="1005.17-1*sin(atan2(1005.17,-80))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00127863009874" y="0" z="0"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.0013" y="0.0000" z="0.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg4_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="80-1*cos(atan2(1005.17,80))" y="1005.17-1*sin(atan2(1005.17,80))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00108755974753" y="0" z="0"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.0011" y="0.0000" z="0.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg4_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="0" y="890.48" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.0011722674036" y="0" z="-0.00268994269818279"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.0012" y="0.0001" z="-0.0027" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg4_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="0.01" y="815.1" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99509535773248" y="0" z="0"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.9951" y="0.0000" z="0.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg4_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="0.01" y="769.45" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99509537795284" y="0" z="0"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.9951" y="0.0000" z="0.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg4_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="0.01" y="738.69" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00375307004064" y="0" z="-0.00339028280751563"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.0038" y="0.0002" z="-0.0034" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg4_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="0" y="1108.37" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99973858172374" y="0" z="0"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.9997" y="0.0000" z="0.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg5_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="-143.67" y="989.05" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99760573194198" y="0" z="-12.8566480785279"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.9226" y="0.6667" z="-12.8396" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg5_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="-299.65" y="953.45" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.99760573194198" y="0" z="-12.8550545545998"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.9226" y="0.6666" z="-12.8380" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg5_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-223.65-1*cos(atan2(979.97,-223.650))" y="979.97-1*sin(atan2(979.97,-223.650))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99746213827367" y="0" z="-12.8550545545998"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.9225" y="0.6666" z="-12.8381" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg5_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="-196.6" y="861.45" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.99723355481482" y="0" z="-12.8579191418416"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.9222" y="0.6667" z="-12.8409" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg5_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="-179.83" y="787.98" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.00219761751585" y="0" z="-12.8571954237482"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="2.9271" y="0.6678" z="-12.8401" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg5_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="-169.66" y="743.38" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00211415855684" y="0" z="-12.8537822553654"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="2.9270" y="0.6676" z="-12.8367" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg5_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="-162.81" y="713.38" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.99220764540017" y="0" z="-12.8553596674151"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.9173" y="0.6655" z="-12.8384" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg5_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="-245.07" y="1073.8" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99985199787107" y="0" z="-12.8560351387451"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.9248" y="0.6672" z="-12.8390" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg5_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="-432.24" y="897.56" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00112628845284" y="0" z="-25.7161682809677"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="2.7043" y="1.3017" z="-25.6854" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg5_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-508.2-1*cos(atan2(870.92,-508.2))" y="870.92-1*sin(atan2(870.92,-508.2))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00112628845284" y="0" z="-25.7161682809677"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="2.7043" y="1.3017" z="-25.6854" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg5_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-364.05-1*cos(atan2(940.34,-364.05))" y="940.34-1*sin(atan2(940.34,-364.05))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00129843586788" y="0" z="-25.7195129551217"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="2.7044" y="1.3020" z="-25.6888" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg5_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="-386.36" y="802.3" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.00117730181794" y="0" z="-25.7156988344817"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="2.7044" y="1.3017" z="-25.6850" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg5_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="-353.65" y="734.39" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99508979340774" y="0" z="-25.7153879225717"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.6989" y="1.2991" z="-25.6848" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg5_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="-333.84" y="693.26" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99492741822156" y="0" z="-25.7161490738739"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.6988" y="1.2991" z="-25.6855" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg5_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="-320.49" y="665.54" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00360229565095" y="0" z="-25.71447899549"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="2.7066" y="1.3027" z="-25.6837" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg5_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="-480.9" y="998.61" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99997462941771" y="0" z="-25.7145131578614"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.7033" y="1.3012" z="-25.6838" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg6_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="-558.56" y="828.77" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99757626091407" y="0" z="-38.5647311053794"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.3446" y="1.8682" z="-38.5265" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg6_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="-683.66" y="729.01" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.99757625130764" y="0" z="-38.5747964223074"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.3443" y="1.8686" z="-38.5366" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg6_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-626.69-1*cos(atan2(785.89,-626.69))" y="785.89-1*sin(atan2(785.89,-626.69))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99757625130764" y="0" z="-38.5703308567256"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.3445" y="1.8684" z="-38.5321" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg6_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="-550.9" y="690.84" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.99718443772954" y="0" z="-38.5707464403004"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.3441" y="1.8682" z="-38.5325" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg6_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="-503.91" y="631.92" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.00227678619113" y="0" z="-38.5703270874121"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="2.3481" y="1.8713" z="-38.5320" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg6_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="-475.39" y="596.15" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00227678676049" y="0" z="-38.5698267347991"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="2.3482" y="1.8713" z="-38.5315" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg6_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="-456.21" y="572.1" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.99219327349989" y="0" z="-38.5713864601968"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.3402" y="1.8651" z="-38.5333" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg6_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="-686.7" y="861.14" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99981481142005" y="0" z="-38.5696383727872"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.3462" y="1.8698" z="-38.5313" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg6_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="-778.87" y="621.14" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00107132519304" y="0" z="-51.4252035776925"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="1.8723" y="2.3458" z="-51.3869" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg6_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-835.74-1*cos(atan2(564.17,-835.74))" y="564.17-1*sin(atan2(564.17,-835.74))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00122070860362" y="0" z="-51.4296691432744"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="1.8722" y="2.3461" z="-51.3913" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg6_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-735.99-1*cos(atan2(689.27,-735.99))" y="689.27-1*sin(atan2(689.27,-735.99))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00107132519304" y="0" z="-51.4296691432743"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="1.8721" y="2.3460" z="-51.3913" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg6_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="-696.2" y="555.21" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.00113787626666" y="0" z="-51.4309306419304"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="1.8721" y="2.3460" z="-51.3926" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg6_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="-637.26" y="508.22" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99512450981639" y="0" z="-51.4296729125879"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="1.8684" y="2.3413" z="-51.3915" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg6_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="-601.57" y="479.76" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99512451038444" y="0" z="-51.4301732652009"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="1.8684" y="2.3413" z="-51.3920" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg6_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="-577.52" y="460.58" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00363666277063" y="0" z="-51.4307272403967"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="1.8737" y="2.3480" z="-51.3923" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg6_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="-866.56" y="691.07" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99981481142005" y="0" z="-51.4303616272128"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="1.8713" y="2.3450" z="-51.3921" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg7_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="-862.84" y="504.35" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99748194539466" y="0" z="-64.2869393190477"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="1.3015" y="2.7004" z="-64.2563" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg7_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="-932.26" y="360.19" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.9976538845308" y="0" z="-64.2804870448784"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="1.3018" y="2.7004" z="-64.2498" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg7_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-905.61-1*cos(atan2(436.15,-905.61))" y="436.15-1*sin(atan2(436.15,-905.61))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.9976538845308" y="0" z="-64.2869393190476"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="1.3015" y="2.7006" z="-64.2563" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg7_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="-796.08" y="383.4" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.99709039828762" y="0" z="-64.2830448738053"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="1.3015" y="2.7000" z="-64.2524" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg7_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="-728.19" y="350.7" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.00241718339704" y="0" z="-64.2818951926889"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="1.3038" y="2.7048" z="-64.2511" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg7_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="-686.97" y="330.85" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00257997184032" y="0" z="-64.2838509261261"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="1.3038" y="2.7050" z="-64.2531" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg7_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="-659.25" y="317.5" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.99189951536471" y="0" z="-64.2840499900813"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="1.2992" y="2.6953" z="-64.2535" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg7_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="-992.32" y="477.91" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99974950369418" y="0" z="-64.2835014161884"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="1.3026" y="2.7024" z="-64.2528" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg7_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="-971.24" y="221.69" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00129273781463" y="0" z="-77.1449454454002"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="0.6683" y="2.9260" z="-77.1279" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg7_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-997.76-1*cos(atan2(145.69,-997.76))" y="145.69-1*sin(atan2(145.69,-997.76))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00125022152464" y="0" z="-77.1449454454001"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="0.6683" y="2.9260" z="-77.1279" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg7_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-962.16-1*cos(atan2(301.68,-962.16))" y="301.68-1*sin(atan2(301.68,-962.16))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00125022152464" y="0" z="-77.1433519214721"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="0.6684" y="2.9259" z="-77.1263" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg7_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="-868.15" y="198.17" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.00127297079991" y="0" z="-77.1447033650763"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="0.6683" y="2.9260" z="-77.1276" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg7_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="-794.66" y="181.4" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99532711631145" y="0" z="-77.145744511552"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="0.6670" y="2.9202" z="-77.1287" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg7_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="-750.16" y="171.24" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.9954103878198" y="0" z="-77.1462177446346"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="0.6669" y="2.9203" z="-77.1292" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg7_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="-720.16" y="164.39" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00423660604274" y="0" z="-77.1413349912903"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="0.6692" y="2.9288" z="-77.1242" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg7_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="-1080.58" y="246.65" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99990759573402" y="0" z="-77.1439648612549"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="0.6681" y="2.9246" z="-77.1269" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg8_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="-996.22" y="80.03" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99763410272428" y="0" z="-90"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="0.0000" y="2.9976" z="-90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg8_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="-996.22" y="-79.97" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.99744326354666" y="0" z="-90"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="0.0000" y="2.9974" z="-90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg8_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-1005.17-1*cos(atan2(0.04,-1005.17))" y="0.04-1*sin(atan2(0.04,-1005.17))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99763410272428" y="0" z="-90"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="0.0000" y="2.9976" z="-90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg8_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="-883.6" y="0.03" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.99708537849572" y="0" z="-89.9973100573055"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="0.0001" y="2.9971" z="-89.9973" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg8_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="-808.24" y="0.03" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.00224758449006" y="0" z="-89.9969844326845"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="0.0002" y="3.0022" z="-89.9970" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg8_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="-762.49" y="0.03" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00224758501595" y="0" z="-90"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="0.0000" y="3.0022" z="-90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg8_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="-731.72" y="0.03" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.9917111518538" y="0" z="-90"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="0.0000" y="2.9917" z="-90.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg8_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="-1101.41" y="0.04" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99973859133358" y="0" z="-89.9977963161106"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="0.0001" y="2.9997" z="-89.9978" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg8_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="-971.25" y="-221.66" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00125022152464" y="0" z="-102.856648078528"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="-0.6684" y="2.9259" z="-102.8737" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg8_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-962.17-1*cos(atan2(-301.65,-962.17))" y="-301.65-1*sin(atan2(-301.65,-962.17))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00106394680686" y="0" z="-102.862036367149"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="-0.6686" y="2.9257" z="-102.8791" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg8_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-997.77-1*cos(atan2(-145.66,-997.77))" y="-145.66-1*sin(atan2(-145.66,-997.77))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00125022494929" y="0" z="-102.856648078528"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="-0.6684" y="2.9259" z="-102.8737" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg8_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="-868.16" y="-198.13" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.00127296912344" y="0" z="-102.857919141842"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="-0.6685" y="2.9259" z="-102.8750" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg8_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="-794.67" y="-181.36" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99496225778731" y="0" z="-102.857195423748"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="-0.6670" y="2.9198" z="-102.8742" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg8_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="-750.17" y="-171.2" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99532710357597" y="0" z="-102.860023599769"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="-0.6672" y="2.9201" z="-102.8770" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg8_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="-720.17" y="-164.35" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00365109205349" y="0" z="-102.85866500871"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="-0.6690" y="2.9283" z="-102.8758" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg8_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="-1080.59" y="-246.62" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99985199386394" y="0" z="-102.858183582847"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="-0.6682" y="2.9246" z="-102.8752" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg9_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="-932.29" y="-360.13" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99756474288783" y="0" z="-115.713060680952"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="-1.3015" y="2.7005" z="-115.7437" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg9_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="-862.87" y="-504.29" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.99756475506728" y="0" z="-115.716168280968"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="-1.3016" y="2.7004" z="-115.7468" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg9_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-905.64-1*cos(atan2(-436.09,-905.64))" y="-436.09-1*sin(atan2(-436.09,-905.64))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99756474288783" y="0" z="-115.706607706909"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="-1.3012" y="2.7007" z="-115.7373" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg9_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="-796.11" y="-383.35" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.99718324993159" y="0" z="-115.71210812869"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="-1.3013" y="2.7002" z="-115.7428" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg9_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="-728.21" y="-350.65" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.00224196954869" y="0" z="-115.711362597741"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="-1.3035" y="2.7048" z="-115.7421" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg9_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="-686.99" y="-330.81" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00224197032247" y="0" z="-115.711876407795"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="-1.3035" y="2.7047" z="-115.7426" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg9_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="-659.27" y="-317.46" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.99215901358134" y="0" z="-115.712895402685"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="-1.2991" y="2.6956" z="-115.7435" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg9_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="-992.36" y="-477.85" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99985791528861" y="0" z="-115.712527665644"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="-1.3025" y="2.7026" z="-115.7433" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg9_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="-778.89" y="-621.11" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00125096921121" y="0" z="-128.574796422307"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="-1.8724" y="2.3459" z="-128.6131" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg9_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-736.01-1*cos(atan2(-689.24,-736.01))" y="-689.24-1*sin(atan2(-689.24,-736.01))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00122071822172" y="0" z="-128.570330856726"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="-1.8722" y="2.3461" z="-128.6087" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg9_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-835.77-1*cos(atan2(-564.15,-835.77))" y="-564.15-1*sin(atan2(-564.15,-835.77))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.0012207182216" y="0" z="-128.570330856726"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="-1.8722" y="2.3461" z="-128.6087" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg9_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="-696.22" y="-555.18" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.00130540202344" y="0" z="-128.572849501898"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="-1.8724" y="2.3461" z="-128.6112" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg9_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="-637.29" y="-508.19" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99512451020864" y="0" z="-128.57220729822"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="-1.8685" y="2.3412" z="-128.6104" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg9_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="-601.6" y="-479.73" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99512450982552" y="0" z="-128.571822482625"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="-1.8685" y="2.3413" z="-128.6100" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg9_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="-577.54" y="-460.54" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00326233860396" y="0" z="-128.571386460197"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="-1.8736" y="2.3476" z="-128.6098" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg9_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="-866.58" y="-691.04" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99981480575516" y="0" z="-128.571012343115"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="-1.8714" y="2.3449" z="-128.6093" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg10_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="-683.71" y="-728.97" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99745726760163" y="0" z="-141.429669143274"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="-2.3444" y="1.8683" z="-141.4679" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg10_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="-558.62" y="-828.73" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.99757626624382" y="0" z="-141.425203577693"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="-2.3443" y="1.8686" z="-141.4634" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg10_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-626.75-1*cos(atan2(-785.84,-626.75))" y="-785.84-1*sin(atan2(-785.84,-626.75))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99745726760163" y="0" z="-141.424070264651"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="-2.3442" y="1.8685" z="-141.4623" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg10_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="-550.94" y="-690.8" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.9970848950645" y="0" z="-141.425473264649"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="-2.3439" y="1.8683" z="-141.4637" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg10_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="-503.96" y="-631.88" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.00227678658426" y="0" z="-141.425435038091"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="-2.3480" y="1.8715" z="-141.4638" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg10_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="-475.43" y="-596.12" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00227678985119" y="0" z="-141.427670729531"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="-2.3481" y="1.8714" z="-141.4660" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg10_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="-456.25" y="-572.06" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.99219328386572" y="0" z="-141.426499643632"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="-2.3402" y="1.8652" z="-141.4646" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg10_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="-686.76" y="-861.09" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99981480639075" y="0" z="-141.425541858588"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="-2.3461" y="1.8700" z="-141.4638" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg10_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="-432.27" y="-897.55" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00112628845284" y="0" z="-154.286939319048"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="-2.7044" y="1.3016" z="-154.3177" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg10_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="-364.08-1*cos(atan2(-940.32,-364.08))" y="-940.32-1*sin(atan2(-940.32,-364.08))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00120918624295" y="0" z="-154.286939319048"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="-2.7045" y="1.3016" z="-154.3177" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg10_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-508.23-1*cos(atan2(-870.9,-508.23))" y="-870.9-1*sin(atan2(-870.9,-508.23))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00112628679949" y="0" z="-154.286939319048"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="-2.7044" y="1.3016" z="-154.3177" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg10_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="-386.39" y="-802.28" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.00127027957631" y="0" z="-154.28789187131"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="-2.7046" y="1.3016" z="-154.3186" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg10_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="-353.69" y="-734.37" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99508977792412" y="0" z="-154.287329086263"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="-2.6990" y="1.2990" z="-154.3179" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg10_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="-333.88" y="-693.24" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99508977569805" y="0" z="-154.283850926126"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="-2.6989" y="1.2991" z="-154.3145" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg10_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="-320.53" y="-665.52" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00334178529363" y="0" z="-154.288575486664"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="-2.7064" y="1.3025" z="-154.3193" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg10_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="-480.93" y="-998.6" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99974950490777" y="0" z="-154.288428404787"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="-2.7032" y="1.3009" z="-154.3191" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg11_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="-299.72" y="-953.42" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99760572852145" y="0" z="-167.143351921472"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="-2.9226" y="0.6667" z="-167.1604" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg11_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="-143.73" y="-989.04" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.9975632631192" y="0" z="-167.143351921472"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="-2.9225" y="0.6667" z="-167.1604" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg11_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="-223.72-1*cos(atan2(-979.96,-223.72))" y="-979.96-1*sin(atan2(-979.96,-223.72))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99760573194198" y="0" z="-167.143351921472"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="-2.9226" y="0.6667" z="-167.1604" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg11_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="-196.66" y="-861.43" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.99692970602534" y="0" z="-167.139458406038"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="-2.9219" y="0.6668" z="-167.1565" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg11_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="-179.89" y="-787.97" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.00247986612233" y="0" z="-167.139193516361"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="-2.9273" y="0.6680" z="-167.1563" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg11_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="-169.71" y="-743.37" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00211414876196" y="0" z="-167.139976400231"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="-2.9269" y="0.6679" z="-167.1570" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg11_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="-162.86" y="-713.37" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.9920745328318" y="0" z="-167.14133499129"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="-2.9172" y="0.6656" z="-167.1583" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg11_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="-245.14" y="-1073.79" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99979637796569" y="0" z="-167.13966800983"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="-2.9247" y="0.6674" z="-167.1567" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg11_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="-0.03" y="-996.22" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00127863009874" y="0" z="-180"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="-3.0013" y="0.0000" z="-180.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg11_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="79.97-1*cos(atan2(-1005.17,79.97))" y="-1005.17-1*sin(atan2(-1005.17,79.97))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00127863009874" y="0" z="-180"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="-3.0013" y="0.0000" z="-180.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg11_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="-80.03-1*cos(atan2(-1005.17,-80.03))" y="-1005.17-1*sin(atan2(-1005.17,-80.03))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00127863009874" y="0" z="-180"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="-3.0013" y="0.0000" z="-180.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg11_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="-0.03" y="-890.48" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.00117227416171" y="0" z="-180"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="-3.0012" y="0.0000" z="-180.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg11_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="-0.03" y="-815.1" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99509537328742" y="0" z="-180"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="-2.9951" y="0.0000" z="-180.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg11_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="-0.03" y="-769.45" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99509537328754" y="0" z="-180"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="-2.9951" y="0.0000" z="-180.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg11_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="-0.03" y="-738.69" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00375307004064" y="0" z="-180"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="-3.0038" y="0.0000" z="-180.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg11_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="-0.03" y="-1108.37" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99998846471167" y="0" z="-180"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="-3.0000" y="0.0000" z="-180.0000" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg12_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="143.63" y="-989.05" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99746213533858" y="0" z="-192.848072353728"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="-2.9225" y="-0.6662" z="167.1689" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg12_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="299.62" y="-953.46" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.99764819337144" y="0" z="-192.8550545546"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="-2.9226" y="-0.6666" z="167.1620" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg12_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="223.62-1*cos(atan2(-979.98,223.62))" y="-979.98-1*sin(atan2(-979.98,223.62))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99746213827367" y="0" z="-192.849665070987"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="-2.9225" y="-0.6663" z="167.1673" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg12_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="196.57" y="-861.45" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.99723354693979" y="0" z="-192.85469817488"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="-2.9222" y="-0.6665" z="167.1623" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg12_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="179.81" y="-787.99" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.00219760291102" y="0" z="-192.854255488448"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="-2.9271" y="-0.6676" z="167.1628" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg12_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="169.63" y="-743.38" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00211416193411" y="0" z="-192.856190745833"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="-2.9270" y="-0.6677" z="167.1609" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg12_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="162.78" y="-713.39" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.99234073876644" y="0" z="-192.854605386645"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="-2.9175" y="-0.6654" z="167.1623" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg12_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="245.03" y="-1073.81" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99990759577741" y="0" z="-192.85339642378"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="-2.9249" y="-0.6671" z="167.1636" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg12_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="432.21" y="-897.58" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00112628845284" y="0" z="-205.716168280968"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="-2.7043" y="-1.3017" z="154.3146" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg12_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="508.17-1*cos(atan2(-870.93,508.17))" y="-870.93-1*sin(atan2(-870.93,508.17))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00112628845284" y="0" z="-205.716168280968"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="-2.7043" y="-1.3017" z="154.3146" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg12_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="364.01-1*cos(atan2(-940.35,364.01))" y="-940.35-1*sin(atan2(-940.35,364.01))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00120919392665" y="0" z="-205.713060680952"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="-2.7045" y="-1.3016" z="154.3177" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg12_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="386.33" y="-802.31" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.0013632608332" y="0" z="-205.71210812869"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="-2.7046" y="-1.3017" z="154.3186" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg12_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="353.62" y="-734.4" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99508977792412" y="0" z="-205.712670913737"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="-2.6990" y="-1.2990" z="154.3179" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg12_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="333.82" y="-693.27" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99508977658641" y="0" z="-205.716149073874"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="-2.6989" y="-1.2991" z="154.3145" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg12_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="320.47" y="-665.55" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00388276183127" y="0" z="-205.712895402685"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="-2.7069" y="-1.3028" z="154.3179" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg12_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="480.87" y="-998.63" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99985791843856" y="0" z="-205.712527665644"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="-2.7033" y="-1.3010" z="154.3182" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg13_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="558.54" y="-828.79" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99769524242896" y="0" z="-218.564731105379"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="-2.3447" y="-1.8682" z="141.4735" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg13_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="683.64" y="-729.04" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.99769524242896" y="0" z="-218.564731105379"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="-2.3447" y="-1.8682" z="141.4735" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg13_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="626.67-1*cos(atan2(-785.91,626.67))" y="-785.91-1*sin(atan2(-785.91,626.67))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99754602792094" y="0" z="-218.564731105379"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="-2.3446" y="-1.8681" z="141.4735" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg13_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="550.87" y="-690.86" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.99688373915578" y="0" z="-218.56906935807"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="-2.3440" y="-1.8679" z="141.4691" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg13_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="503.89" y="-631.94" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.00227679824193" y="0" z="-218.566089283562"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="-2.3483" y="-1.8711" z="141.4723" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg13_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="475.37" y="-596.17" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00198352722274" y="0" z="-218.567324024792"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="-2.3480" y="-1.8710" z="141.4710" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg13_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="456.19" y="-572.11" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.99219326952577" y="0" z="-218.566622083143"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="-2.3404" y="-1.8649" z="141.4715" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg13_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="686.67" y="-861.16" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99997060385794" y="0" z="-218.568264485091"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="-2.3464" y="-1.8698" z="141.4700" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg13_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="778.85" y="-621.17" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00110158076619" y="0" z="-231.429669143274"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="-1.8722" y="-2.3460" z="128.6087" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg13_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="835.72-1*cos(atan2(-564.2,835.72))" y="-564.2-1*sin(atan2(-564.2,835.72))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00122070860362" y="0" z="-231.425203577693"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="-1.8724" y="-2.3459" z="128.6131" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg13_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="735.97-1*cos(atan2(-689.29,735.97))" y="-689.29-1*sin(atan2(-689.29,735.97))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00122070860362" y="0" z="-231.425203577693"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="-1.8724" y="-2.3459" z="128.6131" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg13_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="696.18" y="-555.24" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.00130540510166" y="0" z="-231.4292535597"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="-1.8723" y="-2.3461" z="128.6091" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg13_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="637.25" y="-508.24" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99512450972046" y="0" z="-231.427315284211"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="-1.8685" y="-2.3412" z="128.6109" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg13_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="601.56" y="-479.78" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99512450982552" y="0" z="-231.427670729531"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="-1.8685" y="-2.3412" z="128.6105" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg13_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="577.5" y="-460.6" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00363666277075" y="0" z="-231.42384907347"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="-1.8740" y="-2.3478" z="128.6146" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg13_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="866.53" y="-691.1" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99997060487138" y="0" z="-231.428638705608"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="-1.8715" y="-2.3451" z="128.6097" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg14_R5-FF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_L_pos" x="862.82" y="-504.38" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="2.99739914681653" y="0" z="-244.280487044878"/>
+				<rotation unit="deg" name="R5-FF-Quartz_L_rot" x="-1.3017" y="-2.7002" z="115.7502" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg14_R5-FF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_R_pos" x="932.25" y="-360.23" z="-78.98"/>
-				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="2.99739914681665" y="0" z="-244.280487044878"/>
+				<rotation unit="deg" name="R5-FF-Quartz_R_rot" x="-1.3017" y="-2.7002" z="115.7502" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg14_R5-BF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_C_pos" x="905.6-1*cos(atan2(-436.19,905.6))" y="-436.19-1*sin(atan2(-436.19,905.6))" z="78.08"/>
-				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="2.99739914681653" y="0" z="-244.280487044878"/>
+				<rotation unit="deg" name="R5-BF-Quartz_C_rot" x="-1.3017" y="-2.7002" z="115.7502" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg14_R4-FF-Quartz.gdml"/>
 				<position unit="mm" name="R4-FF-Quartz_pos" x="796.07" y="-383.43" z="248.47"/>
-				<rotation unit="deg" name="R4-FF-Quartz_rot" x="2.99718325273568" y="0" z="-244.281877637402"/>
+				<rotation unit="deg" name="R4-FF-Quartz_rot" x="-1.3016" y="-2.7000" z="115.7488" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg14_R3-FF-Quartz.gdml"/>
 				<position unit="mm" name="R3-FF-Quartz_pos" x="728.18" y="-350.73" z="525.97"/>
-				<rotation unit="deg" name="R3-FF-Quartz_rot" x="3.00224198718392" y="0" z="-244.281895192689"/>
+				<rotation unit="deg" name="R3-FF-Quartz_rot" x="-1.3038" y="-2.7046" z="115.7489" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg14_R2-FF-Quartz.gdml"/>
 				<position unit="mm" name="R2-FF-Quartz_pos" x="686.96" y="-330.88" z="798.78"/>
-				<rotation unit="deg" name="R2-FF-Quartz_rot" x="3.00207922007917" y="0" z="-244.279578037078"/>
+				<rotation unit="deg" name="R2-FF-Quartz_rot" x="-1.3038" y="-2.7044" z="115.7512" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg14_R1-FF-Quartz.gdml"/>
 				<position unit="mm" name="R1-FF-Quartz_pos" x="659.24" y="-317.53" z="1070.8"/>
-				<rotation unit="deg" name="R1-FF-Quartz_rot" x="2.99243842748177" y="0" z="-244.2809955397"/>
+				<rotation unit="deg" name="R1-FF-Quartz_rot" x="-1.2996" y="-2.6958" z="115.7496" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/FFSeg14_R6-FF-Quartz.gdml"/>
 				<position unit="mm" name="R6-FF-Quartz_pos" x="992.31" y="-477.95" z="-364.35"/>
-				<rotation unit="deg" name="R6-FF-Quartz_rot" x="2.99974950850589" y="0" z="-244.283501416188"/>
+				<rotation unit="deg" name="R6-FF-Quartz_rot" x="-1.3026" y="-2.7024" z="115.7472" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg14_R5-FF-Quartz_C.gdml"/>
 				<position unit="mm" name="R5-FF-Quartz_C_pos" x="971.23" y="-221.73" z="-78.11"/>
-				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="3.00125022494929" y="0" z="-257.136369302394"/>
+				<rotation unit="deg" name="R5-FF-Quartz_C_rot" x="-0.6688" y="-2.9259" z="102.8807" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg14_R5-BF-Quartz_R.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_R_pos" x="997.76-1*cos(atan2(-145.73,997.76))" y="-145.73-1*sin(atan2(-145.73,997.76))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="3.00125022494929" y="0" z="-257.137963632851"/>
+				<rotation unit="deg" name="R5-BF-Quartz_R_rot" x="-0.6687" y="-2.9259" z="102.8791" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg14_R5-BF-Quartz_L.gdml"/>
 				<position unit="mm" name="R5-BF-Quartz_L_pos" x="962.15-1*cos(atan2(-301.71,962.15))" y="-301.71-1*sin(atan2(-301.71,962.15))" z="78.95"/>
-				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="3.00106396206322" y="0" z="-257.1449454454"/>
+				<rotation unit="deg" name="R5-BF-Quartz_L_rot" x="-0.6683" y="-2.9258" z="102.8721" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg14_R4-BF-Quartz.gdml"/>
 				<position unit="mm" name="R4-BF-Quartz_pos" x="868.14" y="-198.2" z="382.61"/>
-				<rotation unit="deg" name="R4-BF-Quartz_rot" x="3.00127296912344" y="0" z="-257.142080858158"/>
+				<rotation unit="deg" name="R4-BF-Quartz_rot" x="-0.6685" y="-2.9259" z="102.8750" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg14_R3-BF-Quartz.gdml"/>
 				<position unit="mm" name="R3-BF-Quartz_pos" x="794.66" y="-181.42" z="660.12"/>
-				<rotation unit="deg" name="R3-BF-Quartz_rot" x="2.99532710771989" y="0" z="-257.142804576252"/>
+				<rotation unit="deg" name="R3-BF-Quartz_rot" x="-0.6671" y="-2.9202" z="102.8742" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg14_R2-BF-Quartz.gdml"/>
 				<position unit="mm" name="R2-BF-Quartz_pos" x="750.15" y="-171.26" z="932.92"/>
-				<rotation unit="deg" name="R2-BF-Quartz_rot" x="2.99532710856411" y="0" z="-257.143097033639"/>
+				<rotation unit="deg" name="R2-BF-Quartz_rot" x="-0.6671" y="-2.9202" z="102.8739" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg14_R1-BF-Quartz.gdml"/>
 				<position unit="mm" name="R1-BF-Quartz_pos" x="720.15" y="-164.42" z="1204.94"/>
-				<rotation unit="deg" name="R1-BF-Quartz_rot" x="3.00365109205349" y="0" z="-257.144640332585"/>
+				<rotation unit="deg" name="R1-BF-Quartz_rot" x="-0.6689" y="-2.9283" z="102.8725" />
 			</physvol>
 			<physvol>
 				<file name="detector/ThinQuartz/DetectorArray/BFSeg14_R6-BF-Quartz.gdml"/>
 				<position unit="mm" name="R6-BF-Quartz_pos" x="1080.57" y="-246.69" z="-230.22"/>
-				<rotation unit="deg" name="R6-BF-Quartz_rot" x="2.99985199787107" y="0" z="-257.141816417153"/>
+				<rotation unit="deg" name="R6-BF-Quartz_rot" x="-0.6682" y="-2.9246" z="102.8752" />
 			</physvol>
 			<auxiliary auxtype="Alpha" auxvalue="0.0"/>
 		</volume>

--- a/geometry/rotation-transform.jl
+++ b/geometry/rotation-transform.jl
@@ -1,0 +1,72 @@
+using Printf
+using XML
+using NonlinearSolve
+
+Rz(θ) = [[cos(θ) -sin(θ) 0]; [sin(θ) cos(θ) 0]; [0 0 1]]
+Ry(θ) = [[cos(θ) 0  sin(θ)]; [0 1 0]; [-sin(θ) 0  cos(θ)]]
+Rx(θ) = [[1 0 0]; [0 cos(θ)  -sin(θ)];  [0 sin(θ) cos(θ)]]
+
+function f(u,p)
+    Tm = Rz(-p[3])*Ry(-p[2])*Rx(-p[1])*Rz(u[3])*Ry(u[2])*Rx(u[1])
+    [
+        Tm[1,1] - 1, Tm[1,2] - 0,  Tm[1,3] - 0, 
+        Tm[2,1] - 0, Tm[2,2] - 1,  Tm[2,3] - 0, 
+        Tm[3,1] - 0, Tm[3,2] - 0,  Tm[3,3] - 1, 
+    ]
+end
+
+
+function get_angles(p::Vector{Float64} =  [π/12.5, π/1.4789 , π/2.3])
+    u0 = [0,0,0]
+    prob = NonlinearProblem(f,u0,p)
+    sol = solve(prob, NewtonRaphson())
+    #sol = solve(prob)
+    u = sol.u
+    return u
+end
+
+torad(degree) = degree/180*π
+todeg(radian) = radian*180/π
+todeg(p::Vector{Float64}) = [todeg(p[1]), todeg(p[2]), todeg(p[3])]
+
+function test()
+    pp = [-1,2,0]
+    p =  [π/2,0, π/2]
+    u = get_angles(p);
+    p′ = Rx(p[1])*(Ry(p[2])*(Rz(p[3])*pp))
+    q′ = Rz(u[3])*(Ry(u[2])*(Rx(u[1])*pp))
+    println(todeg(p))
+    println(todeg(u))
+    println(p′)
+    println(q′)
+    @assert p′ - p′ < [0.001,0.001,0.001]
+end
+
+
+
+
+function transform()
+    filename = "/mnt/stg/sft/remoll/develop-remoll/geometry/detector/ThinQuartz/DetectorArray/DetectorArray.gdml"
+    for (i,line) in enumerate(readlines(filename))
+        sl = strip(line)
+        if(startswith(sl,"<rotation"))
+            spc=split(line,'<')[1]
+            parsed = parse(Node,sl)[1]
+            x,y,z = tryparse(Float64,parsed["x"]), tryparse(Float64,parsed["y"]), tryparse(Float64,parsed["z"])
+            tang = get_angles([torad(x),torad(y), torad(z)])
+            xtd,ytd,ztd  = todeg(tang[1]), todeg(tang[2]), todeg(tang[3]) 
+            #println("$(i), $xtd $ytd $ztd")
+            st = @sprintf """%ic %s<rotation unit="deg" name="%s" x="%.4f" y="%.4f" z="%.4f" />""" i spc parsed["name"] xtd ytd ztd
+            #stt = @sprintf """<rotation unit="deg" name="%s" x="%.4f" y="%.4f" z="%.4f" />""" parsed["name"] xtd ytd ztd
+            #println()
+            #println(sl)
+            println(st)
+            #println(stt)
+            #println("$(parsed["name"]) -> ($x, $y, $z) --> ($xtd, $ytd, $ztd)")
+            #println()
+        end
+    end
+end
+
+#test()
+transform()


### PR DESCRIPTION
We want all tiles in the main detector tilt toward to the beam line with a small angle, but currently we are not rotating the tiles  in the correct order. We suppose to rotate the detector with its intended local axis to facing the interaction point, but in the GDML geometry the rotation sequence is fixed. So we change the angle for each axis to make the final rotation in sequence x-y-z the same as sequence z-y-x. Based on the plots I got, it is working properly.
[rotationproblem.pptx](https://github.com/user-attachments/files/22781740/rotationproblem.pptx)

