### PR TITLE
Implementation of the accurate GEM drift gap geometry

### DIFF
--- a/geometry/mollerMother.gdml
+++ b/geometry/mollerMother.gdml
@@ -294,16 +294,10 @@
       </physvol>
       
     <!-- Front Tracking Detectors -->
-    <!--    <physvol>
-      <file name="tracking/trackingDaughter.gdml"/>
+    <physvol>
+      <file name="tracking/GEMDetectors.gdml"/>
       <positionref ref="trackingDetectorVirtualPlaneFront1_pos"/>
-    </physvol>-->
-
-    <!-- Back Tracking Detectors -->
-    <!--   <physvol>
-      <file name="tracking/trackingDaughter.gdml"/>
-      <positionref ref="trackingDetectorVirtualPlaneBack1_pos"/>
-    </physvol>-->
+    </physvol>
 
 
       <!-- GEM Rotator -->

--- a/geometry/tracking/GEMDetectors.gdml
+++ b/geometry/tracking/GEMDetectors.gdml
@@ -310,7 +310,7 @@
             <loop for="j" from="0" to="6" step="1">
                 <physvol name="GEM_detector_sector_phys[k+1][j+1]">
                     <volumeref ref="GEM_detector_log[k*7 + j + 1]"/>
-                    <rotation z="(-j)*360./7 + 90" unit="deg"/>
+                    <rotation z="(-j)*360./7 + 90 + GEM_rotation_offset" unit="deg"/>
                     <positionref ref="GEM_trackingPlane_pos[k+1]" unit="m"/>
                 </physvol>
             </loop>

--- a/geometry/tracking/GEMDetectors.gdml
+++ b/geometry/tracking/GEMDetectors.gdml
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gdml 
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+            xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+<define>
+    <!--Starts at 19.509 ends at 20.9662 -->
+    <position name="GEM_trackingPlane_pos_0" z="0.0" unit="m"/>
+    <position name="GEM_trackingPlane_pos_1" z="0.450" unit="m"/>
+    <position name="GEM_trackingPlane_pos_2" z="0.450 + 0.5633" unit="m"/>
+    <position name="GEM_trackingPlane_pos_3" z="2*0.450 + 0.5633" unit="m"/>
+    <quantity name="GEM_rotation" value="360./7" unit="deg"/>
+    <!-- One could change this to do half rotation of gems-->
+    <quantity name="GEM_rotation_offset" value="0*(360./21)" unit="deg"/>
+    <variable name="j" value="0"/>
+    <variable name="k" value="0"/>
+</define>
+
+<materials>
+ <material name="ArCO2" state="gas">
+        <T unit="K" value="293.15"/>
+        <D unit="g/cm3" value="0.0018"/>
+        <fraction n="0.75" ref="G4_Ar"/>
+        <fraction n="0.25" ref="G4_CARBON_DIOXIDE"/>
+    </material>
+</materials>
+
+
+<solids>
+    <xtru name="GEM_detector_solid" lunit="mm">
+        <twoDimVertex x="-207" y="1120"/>
+        <twoDimVertex x="-223" y="1117"/>
+        <twoDimVertex x="-237" y="1109"/>
+        <twoDimVertex x="-247" y="1096"/>
+        <twoDimVertex x="-252" y="1081"/>
+        <twoDimVertex x="-160" y="680"/>
+        <twoDimVertex x="-154" y="664"/>
+        <twoDimVertex x="-145" y="651"/>
+        <twoDimVertex x="-132" y="641"/>
+        <twoDimVertex x="-117" y="635"/>
+        <twoDimVertex x="-60" y="637"/>
+        <twoDimVertex x="-20" y="640"/>
+        <twoDimVertex x="20" y="640"/>
+        <twoDimVertex x="60" y="637"/>
+        <twoDimVertex x="117" y="635"/>
+        <twoDimVertex x="132" y="641"/>
+        <twoDimVertex x="145" y="651"/>
+        <twoDimVertex x="154" y="664"/>
+        <twoDimVertex x="251" y="1065"/>
+        <twoDimVertex x="252" y="1081"/>
+        <twoDimVertex x="247" y="1096"/>
+        <twoDimVertex x="237" y="1109"/>
+        <twoDimVertex x="223" y="1117"/>
+        <twoDimVertex x="207" y="1120"/>
+        <section zOrder="0" zPosition="0" xOffset="0" yOffset="0" scalingFactor="1"/>
+        <section zOrder="1" zPosition="3" xOffset="0" yOffset="0" scalingFactor="1"/>
+    </xtru>
+    <polycone name="GEM_world_solid"
+                        aunit="deg" startphi="0" deltaphi="360"
+                        lunit="mm">
+        <zplane rmin="635" rmax="1150.0" z="0.0"/>
+        <zplane rmin="635" rmax="1150.0" z="1467.0"/>
+    </polycone>
+</solids>
+
+
+<structure>  
+
+    <!--
+        The relevant detector numbers should be 19221 to 19248, but I might have to add a "+1"
+    -->
+    <!-- <loop for="i" from="0" to="27" step="1">
+        <volume name="GEM_detector_log_[i+1]">
+            <materialref ref="ArCO2"/>
+            <solidref ref="GEM_detector_solid"/>
+            <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+            <auxiliary auxtype="DetNo" auxvalue="detector_numbers[i+1]"/>
+            <auxiliary auxtype="Color" auxvalue="green"/>
+        </volume>
+    </loop> -->
+
+    <volume name="GEM_detector_log_0">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="300"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_1">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="301"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_2">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="302"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_3">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="303"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_4">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="304"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_5">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="305"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_6">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="306"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_7">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="307"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_8">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="308"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_9">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="309"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_10">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="310"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_11">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="311"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_12">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="312"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_13">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="313"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_14">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="314"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_15">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="315"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_16">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="316"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_17">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="317"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_18">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="318"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_19">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="319"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_20">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="320"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_21">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="321"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_22">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="322"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_23">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="323"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_24">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="324"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_25">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="325"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_26">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="326"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_detector_log_27">
+        <materialref ref="ArCO2"/>
+        <solidref ref="GEM_detector_solid"/>
+        <auxiliary auxtype="SensDet" auxvalue="GEMSD" />
+        <auxiliary auxtype="DetNo" auxvalue="327"/>
+        <auxiliary auxtype="Color" auxvalue="green"/>
+    </volume>
+
+    <volume name="GEM_world_log">
+        <materialref ref="G4_AIR"/>
+        <solidref ref="GEM_world_solid"/>
+        <loop for="k" from="0" to="3" step="1">
+            <loop for="j" from="0" to="6" step="1">
+                <physvol name="GEM_detector_sector_phys[k+1][j+1]">
+                    <volumeref ref="GEM_detector_log[k*7 + j + 1]"/>
+                    <rotation z="(-j)*360./7 + 90" unit="deg"/>
+                    <positionref ref="GEM_trackingPlane_pos[k+1]" unit="m"/>
+                </physvol>
+            </loop>
+        </loop>
+        <auxiliary auxtype="Alpha" auxvalue="0.0"/>
+    </volume>
+ </structure>
+
+
+    
+
+<setup name="Default" version="1.0">
+    <world ref="GEM_world_log"/>
+</setup>
+
+</gdml>


### PR DESCRIPTION
Added 28 new detectors in geometry/tracking/GEMDetectors.gdml

I used detector ID's 300-327 as they weren't taken.

<img width="953" height="527" alt="image" src="https://github.com/user-attachments/assets/f20822e5-5671-47d7-b62e-a7e515bba971" />

Detector 300 is the most upstream detector at phi=0, the next 6 progress clockwise. Detector 307 is the second most upstream at phi=0, then the same scheme repeats. 

I modified mollerMother.gdml as well to include these detectors. 