### PR TITLE
Replace undefined G4_Al colour with 'grey' to suppress Geant4 warnings

### DIFF
--- a/geometry/upstream/upstreamToroid.gdml
+++ b/geometry/upstream/upstreamToroid.gdml
@@ -1347,7 +1347,7 @@
 	<volume name="logic_support_front_plate">
 		<materialref ref="G4_Al"/>
 		<solidref ref="solid_support_front_plate"/>
-		<auxiliary auxtype="Color" auxvalue="G4_Al"/>
+		<auxiliary auxtype="Color" auxvalue="grey"/>
 		<auxiliary auxtype="SensDet" auxvalue="enclosureDet"/>
 		<auxiliary auxtype="DetNo" auxvalue="92"/>
 	</volume>
@@ -1355,7 +1355,7 @@
 	<volume name="logic_support_end_plate">
 		<materialref ref="G4_Al"/>
 		<solidref ref="solid_support_end_plate"/>
-		<auxiliary auxtype="Color" auxvalue="G4_Al"/>
+		<auxiliary auxtype="Color" auxvalue="grey"/>
 		<auxiliary auxtype="SensDet" auxvalue="enclosureDet"/>
 		<auxiliary auxtype="DetNo" auxvalue="93"/>
 	</volume>
@@ -1363,7 +1363,7 @@
 	<volume name="logic_support_bar">
 		<materialref ref="G4_Al"/>
 		<solidref ref="solid_support_bar"/>
-		<auxiliary auxtype="Color" auxvalue="G4_Al"/>
+		<auxiliary auxtype="Color" auxvalue="grey"/>
 		<auxiliary auxtype="SensDet" auxvalue="enclosureDet"/>
 		<auxiliary auxtype="DetNo" auxvalue="94"/>
 	</volume>


### PR DESCRIPTION
This PR  suppresses Geant4 visualization warnings. The undefined G4_Al colour is replaced with the standard grey colour in the visualization settings to avoid these warnings.


```
-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : greps0003
      issued by : G4Colour::GetColour
Colour "G4_Al" not found. No action taken.
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------


-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : greps0003
      issued by : G4Colour::GetColour
Colour "G4_Al" not found. No action taken.
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------


-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : greps0003
      issued by : G4Colour::GetColour
Colour "G4_Al" not found. No action taken.
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------
```