### PR TITLE
Fix geometry overlap by clipping the upstream face of the DetectorArray mother volume using a subtraction solid

### DIFF
--- a/geometry/detector/ThinQuartz/DetectorArray/DetectorArray.gdml
+++ b/geometry/detector/ThinQuartz/DetectorArray/DetectorArray.gdml
@@ -4,7 +4,18 @@
  
 	<solids>
 		<!--<box lunit="m" name="DetectorArray_solid" x="20.0" y="20.0" z="20.0"/>-->
-        <cone name="DetectorArray_solid" rmin1="700"  rmax1="2100" rmin2="700" rmax2="2100"  z="2500" startphi="0" deltaphi="360" aunit="deg" lunit="mm"/>
+                <!-- <cone name="DetectorArray_solid" rmin1="700"  rmax1="2100" rmin2="700" rmax2="2100"  z="2500" startphi="0" deltaphi="360" aunit="deg" lunit="mm"/>-->
+
+        <cone name="DetectorArray_raw" rmin1="700" rmax1="2100" rmin2="700" rmax2="2100" z="2500" startphi="0" deltaphi="360" aunit="deg" lunit="mm"/>
+
+         <!-- Big box to cut off negative-z side -->
+         <box name="DetectorArray_cutbox" x="5100" y="5100" z="1400" lunit="mm" />
+
+         <subtraction name="DetectorArray_solid">
+           <first  ref="DetectorArray_raw"/>
+           <second ref="DetectorArray_cutbox"/>
+           <position name="CutBox_pos" unit="mm" x="0" y="0" z="-1200"/>
+         </subtraction>
 
 	</solids>
  


### PR DESCRIPTION
This PR fixes the overlap between GEM detector mother volume and Thin quartz mother volume.

After GEM detector implementation ([PR625](https://github.com/JeffersonLab/remoll/pull/625)), the following overlap warnings started to appear in the console outputs;
```
G4GDML: Reading 'mollerMother.gdml' done!
Stripping off GDML names of materials, solids and volumes ...


-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : GeomVol1002
      issued by : G4PVPlacement::CheckOverlaps()
Overlap with volume already placed !
          Overlap is detected for volume GEM_world_log_PV:0 (G4Polycone) with DetectorArray_volume_PV:0 (G4Cons)
          overlap at local point (897.968,699.826,-1228.1) by 2.19 cm  (max of 118 cases)
NOTE: Reached maximum fixed number -1- of overlaps reports for this volume !
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------


-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : GeomVol1002
      issued by : G4PVPlacement::CheckOverlaps()
Overlap with volume already placed !
          Overlap is detected for volume DetectorArray_volume_PV:0 (G4Cons) with GEM_world_log_PV:0 (G4Polycone)
          overlap at local point (-674.779,847.342,1445.1) by 2.19 cm  (max of 39 cases)
NOTE: Reached maximum fixed number -1- of overlaps reports for this volume !
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------
```


To solve this, the upstream face of the DetectorArray mother volume is now clipped using a subtraction solid, removing the region that overlaps with GEM mother volume. Please see the screenshot.

<img width="1479" height="776" alt="Screenshot 2025-11-13 at 2 53 35 PM" src="https://github.com/user-attachments/assets/a2e50f58-ec49-4faa-9268-967b065cdd9a" />

