### PR TITLE
Added solid targets based on docdb 1464v3

### DIFF
--- a/geometry/target/targetLadder.gdml
+++ b/geometry/target/targetLadder.gdml
@@ -17,7 +17,7 @@
     <second ref="TargetLadder2_solid"/>
     <position y="-400" unit="mm"/>
   </union>
-  <box name="TargetPosition_solid" x="70" y="70" z="1300" lunit="mm"/>
+  <box name="TargetPosition_solid" x="50" y="50" z="1300" lunit="mm"/>
 
   <tube name="TargetLH2_solid"
         aunit="deg" lunit="mm" deltaphi="360"
@@ -29,13 +29,24 @@
         aunit="deg" lunit="mm" deltaphi="360"
         rmax="40" rmin="0" z="0.127"/>
 
-  <box name="TargetAlDummy2pct_solid" x="25*mm" y="25*mm" z="0.02*AlX0"/>
+  <!-- see https://moller-docdb.physics.sunysb.edu/DocDB/0014/001464/003/SolidTargets.pdf -->
+
+  <box name="TargetAl_1mm_solid" x="25*mm" y="25*mm" z="1*mm"/>
+  <box name="TargetAl_2mm_solid" x="25*mm" y="25*mm" z="2*mm"/>
+  <box name="TargetAl_6mm_solid" x="25*mm" y="25*mm" z="6*mm"/>
+  <box name="TargetAl_12_5mm_solid" x="25*mm" y="25*mm" z="12.5*mm"/>
+  <box name="TargetC_2mm_solid" x="25*mm" y="25*mm" z="2*mm"/>
+  <box name="TargetC_40mm_solid" x="25*mm" y="25*mm" z="40*mm"/>
+  
+
+  <!-- <box name="TargetAlDummy2pct_solid" x="25*mm" y="25*mm" z="0.02*AlX0"/>
   <box name="TargetAlDummy4pct_solid" x="25*mm" y="25*mm" z="0.04*AlX0"/>
   <box name="TargetAlDummy8pct_solid" x="25*mm" y="25*mm" z="0.08*AlX0"/>
-  <tube name="TargetAlHole_solid" rmin="0" rmax="2*mm" z="0.10*AlX0" deltaphi="360" startphi="0" aunit="deg"/>
-  <subtraction name="TargetAlDummyHole_solid">
-    <first ref="TargetAlDummy4pct_solid"/>
-    <second ref="TargetAlHole_solid"/>
+  <box name="TargetAlDummy10pct_solid" x="25*mm" y="25*mm" z="0.1*AlX0"/> -->
+  <tube name="TargetAlHole_solid" rmin="0" rmax="2*mm" z="2*mm" deltaphi="360" startphi="0" aunit="deg"/>
+  <subtraction name="TargetAlHole">
+    <first ref="TargetAlHole_solid"/>
+    <second ref="TargetAl_2mm_solid"/>
   </subtraction>
 
   <box name="TargetCFoil_solid" x="25*mm" y="25*mm" z="0.254*mm"/>
@@ -50,18 +61,21 @@
     <auxiliary auxtype="TargetSamplingVolume" auxvalue="USAl"/>
     <auxiliary auxtype="Color" auxvalue="white"/>
   </volume>
+
   <volume name="targetLH2_LH2Volume_logical">
     <materialref ref="LiquidHydrogen"/>
     <solidref ref="TargetLH2_LH2Volume_solid"/>
     <auxiliary auxtype="TargetSamplingVolume" auxvalue="LH2"/>
     <auxiliary auxtype="Color" auxvalue="blue"/>
   </volume>
+
   <volume name="targetLH2_AlWindowDS_logical">
     <materialref ref="G4_Al"/>
     <solidref ref="TargetLH2_AlWindow_solid"/>
     <auxiliary auxtype="TargetSamplingVolume" auxvalue="DSAl"/>
     <auxiliary auxtype="Color" auxvalue="white"/>
   </volume>
+
   <volume name="TargetLH2_logical">
     <materialref ref="G4_Galactic"/>
     <solidref ref="TargetLH2_solid"/>
@@ -84,91 +98,131 @@
     <auxiliary auxtype="TargetSystem" auxvalue="LH2"/>
   </volume>
 
-  <volume name="TargetAlDummyHoleUS_logical">
+  <volume name="TargetAl_1_mm_logical">
     <materialref ref="G4_Al"/>
-    <solidref ref="TargetAlDummyHole_solid"/>
-    <auxiliary auxtype="TargetSamplingVolume" auxvalue="USAl"/>
-  </volume>
-  <volume name="TargetAlDummyHoleDS_logical">
-    <materialref ref="G4_Al"/>
-    <solidref ref="TargetAlDummyHole_solid"/>
-    <auxiliary auxtype="TargetSamplingVolume" auxvalue="DSAl"/>
-  </volume>
-  <volume name="TargetPositionAlDummyHoleUS_logical">
-    <materialref ref="G4_Galactic"/>
-    <solidref ref="TargetPosition_solid"/>
-    <physvol>
-      <volumeref ref="TargetAlDummyHoleUS_logical"/>
-      <position z="-125/2*cm"/>
-    </physvol>
-    <auxiliary auxtype="TargetSystem" auxvalue="AlHoleUS"/>
-  </volume>
-  <volume name="TargetPositionAlDummyHoleDS_logical">
-    <materialref ref="G4_Galactic"/>
-    <solidref ref="TargetPosition_solid"/>
-    <physvol>
-      <volumeref ref="TargetAlDummyHoleDS_logical"/>
-      <position z="+125/2*cm"/>
-    </physvol>
-    <auxiliary auxtype="TargetSystem" auxvalue="AlHoleDS"/>
+    <solidref ref="TargetAl_1mm_solid"/>
+    <auxiliary auxtype="TargetSamplingVolume" auxvalue="Al1mm"/>
   </volume>
 
-  <volume name="TargetAlDummy4pctDS_logical">
+  <volume name="TargetAl_2_mm_logical">
     <materialref ref="G4_Al"/>
-    <solidref ref="TargetAlDummy4pct_solid"/>
-    <auxiliary auxtype="TargetSamplingVolume" auxvalue="DSAl"/>
+    <solidref ref="TargetAl_2mm_solid"/>
+    <auxiliary auxtype="TargetSamplingVolume" auxvalue="Al2mm"/>
   </volume>
-  <volume name="TargetAlDummy4pctUS_logical">
+
+  <volume name="TargetAl_6_mm_logical">
     <materialref ref="G4_Al"/>
-    <solidref ref="TargetAlDummy4pct_solid"/>
-    <auxiliary auxtype="TargetSamplingVolume" auxvalue="DSAl"/>
+    <solidref ref="TargetAl_6mm_solid"/>
+    <auxiliary auxtype="TargetSamplingVolume" auxvalue="Al6mm"/>
   </volume>
-  <volume name="TargetAlDummy2pctDS_logical">
+
+  <volume name="TargetAl_12_5_mm_logical">
     <materialref ref="G4_Al"/>
-    <solidref ref="TargetAlDummy2pct_solid"/>
-    <auxiliary auxtype="TargetSamplingVolume" auxvalue="DSAl"/>
+    <solidref ref="TargetAl_12_5mm_solid"/>
+    <auxiliary auxtype="TargetSamplingVolume" auxvalue="Al12_5mm"/>
   </volume>
-  <volume name="TargetAlDummy2pctUS_logical">
+
+  <volume name="TargetAlHole_logical">
     <materialref ref="G4_Al"/>
-    <solidref ref="TargetAlDummy2pct_solid"/>
-    <auxiliary auxtype="TargetSamplingVolume" auxvalue="USAl"/>
+    <solidref ref="TargetAlHole_solid"/>
+    <auxiliary auxtype="TargetSamplingVolume" auxvalue="AlHole"/>
   </volume>
-  <volume name="TargetPositionAlDummy1US_logical">
+
+  <volume name="TargetC_2_mm_logical">
+    <materialref ref="G4_C"/>
+    <solidref ref="TargetC_2mm_solid"/>
+    <auxiliary auxtype="TargetSamplingVolume" auxvalue="C2mm"/>
+  </volume>
+
+  <volume name="TargetC_40_mm_logical">
+    <materialref ref="G4_C"/>
+    <solidref ref="TargetC_40mm_solid"/>
+    <auxiliary auxtype="TargetSamplingVolume" auxvalue="C40mm"/>
+  </volume>
+
+
+
+  <volume name="TargetPositionAlHole_DS_logical">
     <materialref ref="G4_Galactic"/>
     <solidref ref="TargetPosition_solid"/>
     <physvol>
-      <volumeref ref="TargetAlDummy4pctUS_logical"/>
-      <position z="-125/2*cm"/>
-    </physvol>
-    <auxiliary auxtype="TargetSystem" auxvalue="AlDummy1US"/>
-  </volume>
-  <volume name="TargetPositionAlDummy1DS_logical">
-    <materialref ref="G4_Galactic"/>
-    <solidref ref="TargetPosition_solid"/>
-    <physvol>
-      <volumeref ref="TargetAlDummy4pctDS_logical"/>
+      <volumeref ref="TargetAlHole_logical"/>
       <position z="+125/2*cm"/>
     </physvol>
-    <auxiliary auxtype="TargetSystem" auxvalue="AlDummy1DS"/>
+    <auxiliary auxtype="TargetSystem" auxvalue="Al_Hole_DS"/>
   </volume>
-  <volume name="TargetPositionAlDummy2US_logical">
+
+  <volume name="TargetPositionAl6mm_DS_logical">
     <materialref ref="G4_Galactic"/>
     <solidref ref="TargetPosition_solid"/>
     <physvol>
-      <volumeref ref="TargetAlDummy2pctUS_logical"/>
-      <position z="-125/2*cm"/>
-    </physvol>
-    <auxiliary auxtype="TargetSystem" auxvalue="AlDummy2US"/>
-  </volume>
-  <volume name="TargetPositionAlDummy2DS_logical">
-    <materialref ref="G4_Galactic"/>
-    <solidref ref="TargetPosition_solid"/>
-    <physvol>
-      <volumeref ref="TargetAlDummy2pctDS_logical"/>
+      <volumeref ref="TargetAl_6_mm_logical"/>
       <position z="+125/2*cm"/>
     </physvol>
-    <auxiliary auxtype="TargetSystem" auxvalue="AlDummy2DS"/>
+    <auxiliary auxtype="TargetSystem" auxvalue="Al_6mm_DS"/>
   </volume>
+
+  <volume name="TargetPositionAl12_5mm_DS_logical">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="TargetPosition_solid"/>
+    <physvol>
+      <volumeref ref="TargetAl_12_5_mm_logical"/>
+      <position z="+125/2*cm"/>
+    </physvol>
+    <auxiliary auxtype="TargetSystem" auxvalue="Al_12_5mm_DS"/>
+  </volume>
+
+  <volume name="TargetPositionC40mm_DS_logical">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="TargetPosition_solid"/>
+    <physvol>
+      <volumeref ref="TargetC_40_mm_logical"/>
+      <position z="+125/2*cm"/>
+    </physvol>
+    <auxiliary auxtype="TargetSystem" auxvalue="C_40mm_DS"/>
+  </volume>
+
+  <volume name="TargetPositionC2mm_US_logical">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="TargetPosition_solid"/>
+    <physvol>
+      <volumeref ref="TargetC_2_mm_logical"/>
+      <position z="-125/2*cm"/>
+    </physvol>
+    <auxiliary auxtype="TargetSystem" auxvalue="C_2mm_US"/>
+  </volume>
+
+  <volume name="TargetPositionAlHole_US_logical">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="TargetPosition_solid"/>
+    <physvol>
+      <volumeref ref="TargetAlHole_logical"/>
+      <position z="-125/2*cm"/>
+    </physvol>
+    <auxiliary auxtype="TargetSystem" auxvalue="Al_Hole_US"/>
+  </volume>
+  
+  <volume name="TargetPositionAl1mm_US_logical">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="TargetPosition_solid"/>
+    <physvol>
+      <volumeref ref="TargetAl_1_mm_logical"/>
+      <position z="-125/2*cm"/>
+    </physvol>
+    <auxiliary auxtype="TargetSystem" auxvalue="Al_1mm_US"/>
+  </volume>
+
+  <volume name="TargetPositionAl2mm_US_logical">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="TargetPosition_solid"/>
+    <physvol>
+      <volumeref ref="TargetAl_1_mm_logical"/>
+      <position z="-125/2*cm"/>
+    </physvol>
+    <auxiliary auxtype="TargetSystem" auxvalue="Al_2mm_US"/>
+  </volume>
+
+  <!-- Optics Targets -->
 
   <volume name="TargetCFoilUS_logical">
     <materialref ref="G4_C"/>
@@ -192,11 +246,6 @@
   <volume name="TargetPositionOptics1_logical">
     <materialref ref="G4_Galactic"/>
     <solidref ref="TargetPosition_solid"/>
-    <!--<physvol>
-      <volumeref ref="TargetCFoilUS_logical"/>
-      <position z="-30*cm"/>
-    </physvol>-->
-
     <physvol>
       <volumeref ref="TargetCFoilDS_logical"/>
       <position z="-62.45*cm"/>
@@ -209,11 +258,6 @@
   <volume name="TargetPositionOptics2_logical">
     <materialref ref="G4_Galactic"/>
     <solidref ref="TargetPosition_solid"/>
-
-    <!--<physvol>
-      <volumeref ref="TargetCFoilUS_logical"/>
-      <position z="-60*cm"/>
-    </physvol>-->
   
     <physvol>
       <volumeref ref="TargetCFoilDS_logical"/>
@@ -226,12 +270,6 @@
   <volume name="TargetPositionOptics3_logical">
     <materialref ref="G4_Galactic"/>
     <solidref ref="TargetPosition_solid"/>
-
-    <!--<physvol>
-      <volumeref ref="TargetCFoilUS_logical"/>
-      <position z="-60*cm"/>
-    </physvol>-->
-  
     <physvol>
       <volumeref ref="TargetCFoilDS_logical"/>
       <position z="+0.0127*cm"/>
@@ -249,48 +287,61 @@
     </physvol>
 
     <physvol>
-      <volumeref ref="TargetPositionAlDummyHoleUS_logical"/>
-      <position y="-14*cm"/>
+      <volumeref ref="TargetPositionAlHole_DS_logical"/>
+      <position y="-10*cm"/>
     </physvol>
 
     <physvol>
-      <volumeref ref="TargetPositionAlDummyHoleDS_logical"/>
-      <position y="-21*cm"/>
+      <volumeref ref="TargetPositionAl6mm_DS_logical"/>
+      <position y="-15*cm"/>
     </physvol>
 
     <physvol>
-      <volumeref ref="TargetPositionAlDummy1US_logical"/>
-      <position y="-28*cm"/>
+      <volumeref ref="TargetPositionAl12_5mm_DS_logical"/>
+      <position y="-20*cm"/>
     </physvol>
 
     <physvol>
-      <volumeref ref="TargetPositionAlDummy1DS_logical"/>
+      <volumeref ref="TargetPositionC40mm_DS_logical"/>
+      <position y="-25*cm"/>
+    </physvol>
+
+    <physvol>
+      <volumeref ref="TargetPositionC2mm_US_logical"/>
+      <position y="-30*cm"/>
+    </physvol>
+
+    <physvol>
+      <volumeref ref="TargetPositionAlHole_US_logical"/>
       <position y="-35*cm"/>
     </physvol>
 
     <physvol>
-      <volumeref ref="TargetPositionAlDummy2US_logical"/>
-      <position y="-42*cm"/>
+      <volumeref ref="TargetPositionAl1mm_US_logical"/>
+      <position y="-40*cm"/>
     </physvol>
 
     <physvol>
-      <volumeref ref="TargetPositionAlDummy2DS_logical"/>
-      <position y="-49*cm"/>
+      <volumeref ref="TargetPositionAl2mm_US_logical"/>
+      <position y="-45*cm"/>
     </physvol>
+
+
+    <!-- There is empty space between here and the next in the real target ladder-->
 
     <physvol>
       <volumeref ref="TargetPositionOptics1_logical"/>
-      <position y="-56*cm"/>
+      <position y="-50*cm"/>
     </physvol>
 
     <physvol>
       <volumeref ref="TargetPositionOptics2_logical"/>
-      <position y="-63*cm"/>
+      <position y="-55*cm"/>
     </physvol>
 
     <physvol>
       <volumeref ref="TargetPositionOptics3_logical"/>
-      <position y="-70*cm"/>
+      <position y="-60*cm"/>
     </physvol>
 
     <auxiliary auxtype="TargetLadder" auxvalue=""/>

--- a/macros/runexample_Al1mm_US.mac
+++ b/macros/runexample_Al1mm_US.mac
@@ -8,10 +8,10 @@
 /run/initialize
 
 # Set target ladder position
-/control/execute macros/target/AlDummy1US.mac
-#/control/execute macros/target/AlDummy1DS.mac
-#/control/execute macros/target/AlDummy2US.mac
-#/control/execute macros/target/AlDummy2DS.mac
+/control/execute macros/target/Al1mmUS.mac
+#/control/execute macros/target/Al2mmUS.mac
+#/control/execute macros/target/Al6mmDS.mac
+#/control/execute macros/target/Al12_5mmDS.mac
 
 # Load magnetic fields
 /control/execute macros/load_magnetic_fieldmaps.mac

--- a/macros/target/Al12_5mmDS.mac
+++ b/macros/target/Al12_5mmDS.mac
@@ -1,0 +1,3 @@
+/remoll/geometry/absolute_position targetLadder (0,200,0)
+/remoll/target/mother Al_12_5mm_DS
+/remoll/target/volume Al12_5mm

--- a/macros/target/Al1mmUS.mac
+++ b/macros/target/Al1mmUS.mac
@@ -1,0 +1,3 @@
+/remoll/geometry/absolute_position targetLadder (0,400,0)
+/remoll/target/mother Al_1mm_US
+/remoll/target/volume Al1mm

--- a/macros/target/Al2mmUS.mac
+++ b/macros/target/Al2mmUS.mac
@@ -1,0 +1,3 @@
+/remoll/geometry/absolute_position targetLadder (0,450,0)
+/remoll/target/mother Al_2mm_US
+/remoll/target/volume Al2mm

--- a/macros/target/Al6mmDS.mac
+++ b/macros/target/Al6mmDS.mac
@@ -1,0 +1,3 @@
+/remoll/geometry/absolute_position targetLadder (0,150,0)
+/remoll/target/mother Al_6mm_DS
+/remoll/target/volume Al6mm

--- a/macros/target/AlDummy1DS.mac
+++ b/macros/target/AlDummy1DS.mac
@@ -1,3 +1,0 @@
-/remoll/geometry/absolute_position targetLadder (0,350,0)
-/remoll/target/mother AlDummy1DS
-/remoll/target/volume DSAl

--- a/macros/target/AlDummy1US.mac
+++ b/macros/target/AlDummy1US.mac
@@ -1,3 +1,0 @@
-/remoll/geometry/absolute_position targetLadder (0,280,0)
-/remoll/target/mother AlDummy1US
-/remoll/target/volume USAl

--- a/macros/target/AlDummy2DS.mac
+++ b/macros/target/AlDummy2DS.mac
@@ -1,3 +1,0 @@
-/remoll/geometry/absolute_position targetLadder (0,490,0)
-/remoll/target/mother AlDummy2DS
-/remoll/target/volume DSAl

--- a/macros/target/AlDummy2US.mac
+++ b/macros/target/AlDummy2US.mac
@@ -1,3 +1,0 @@
-/remoll/geometry/absolute_position targetLadder (0,420,0)
-/remoll/target/mother AlDummy2US
-/remoll/target/volume USAl

--- a/macros/target/AlDummyHoleDS.mac
+++ b/macros/target/AlDummyHoleDS.mac
@@ -1,3 +1,0 @@
-/remoll/geometry/absolute_position targetLadder (0,210,0)
-/remoll/target/mother AlHoleDS
-/remoll/target/volume DSAl

--- a/macros/target/AlDummyHoleUS.mac
+++ b/macros/target/AlDummyHoleUS.mac
@@ -1,3 +1,0 @@
-/remoll/geometry/absolute_position targetLadder (0,140,0)
-/remoll/target/mother AlHoleUS
-/remoll/target/volume USAl

--- a/macros/target/AlHoleDS.mac
+++ b/macros/target/AlHoleDS.mac
@@ -1,0 +1,3 @@
+/remoll/geometry/absolute_position targetLadder (0,100,0)
+/remoll/target/mother Al_Hole_DS
+/remoll/target/volume AlHole

--- a/macros/target/AlHoleUS.mac
+++ b/macros/target/AlHoleUS.mac
@@ -1,3 +1,3 @@
-/remoll/geometry/absolute_position targetLadder (0,140,0)
-/remoll/target/mother AlHoleUS
-/remoll/target/volume USAl
+/remoll/geometry/absolute_position targetLadder (0,350,0)
+/remoll/target/mother Al_Hole_US
+/remoll/target/volume AlHole

--- a/macros/target/C2mmUS.mac
+++ b/macros/target/C2mmUS.mac
@@ -1,0 +1,3 @@
+/remoll/geometry/absolute_position targetLadder (0,300,0)
+/remoll/target/mother C_2mm_US
+/remoll/target/volume C2mm

--- a/macros/target/C40mmDS.mac
+++ b/macros/target/C40mmDS.mac
@@ -1,0 +1,3 @@
+/remoll/geometry/absolute_position targetLadder (0,250,0)
+/remoll/target/mother C_40mm_DS
+/remoll/target/volume C40mm

--- a/macros/target/Optics1.mac
+++ b/macros/target/Optics1.mac
@@ -1,3 +1,3 @@
 /remoll/geometry/absolute_position targetLadder (0,500,0)
 /remoll/target/mother Optics1
-/remoll/target/volume DSC
+/remoll/target/volume USC

--- a/macros/target/Optics1.mac
+++ b/macros/target/Optics1.mac
@@ -1,3 +1,3 @@
-/remoll/geometry/absolute_position targetLadder (0,560,0)
+/remoll/geometry/absolute_position targetLadder (0,500,0)
 /remoll/target/mother Optics1
 /remoll/target/volume DSC

--- a/macros/target/Optics2.mac
+++ b/macros/target/Optics2.mac
@@ -1,3 +1,3 @@
-/remoll/geometry/absolute_position targetLadder (0,630,0)
+/remoll/geometry/absolute_position targetLadder (0,550,0)
 /remoll/target/mother Optics2
 /remoll/target/volume DSC

--- a/macros/target/Optics3.mac
+++ b/macros/target/Optics3.mac
@@ -1,3 +1,3 @@
-/remoll/geometry/absolute_position targetLadder (0,700,0)
+/remoll/geometry/absolute_position targetLadder (0,600,0)
 /remoll/target/mother Optics3
 /remoll/target/volume DSC

--- a/macros/target/Optics3.mac
+++ b/macros/target/Optics3.mac
@@ -1,3 +1,3 @@
 /remoll/geometry/absolute_position targetLadder (0,600,0)
 /remoll/target/mother Optics3
-/remoll/target/volume DSC
+/remoll/target/volume MSC


### PR DESCRIPTION
1. Changed target ladder to add in the thick carbon targets and aluminum targets 
2. Add in new target macros for running with each of the newly added targets
3. Remove the old target macros based on the previously implemented targets
4. Rename one of the runexample macros that used the old targets and modify it to use the new targets

[DocDB 1464 discussing the solid targets](https://moller-docdb.physics.sunysb.edu/cgi-bin/DocDBTest/private/ShowDocument?docid=1464)
[DocDB 1537 showing slides about the implementation of the solid targets](https://moller-docdb.physics.sunysb.edu/cgi-bin/DocDBTest/private/ShowDocument?docid=1537)

targets, as implemented are now:

1. DS 2mm hole
2. DS Al 6 mm thick
3. DS Al 12.5 mm thick 
4. DS C 40 mm thick
5. US C 2 mm thick
6. US 2mm hole
7. US Al 1 mm thick
8. US Al 2mm thick
9. Optics 1 (US C 254 um thick)
10. Optics 2 (DS C 254 um thick)
11. Optics 3 (MS C 254 um thick)

currently there is no "empty" target.