### PR TITLE
Change targetLH2 material from LiquidHydrogen back to G4_lH2

### DIFF
--- a/geometry/target/targetLadder.gdml
+++ b/geometry/target/targetLadder.gdml
@@ -51,7 +51,7 @@
     <auxiliary auxtype="Color" auxvalue="white"/>
   </volume>
   <volume name="targetLH2_LH2Volume_logical">
-    <materialref ref="LiquidHydrogen"/>
+    <materialref ref="G4_lH2"/>
     <solidref ref="TargetLH2_LH2Volume_solid"/>
     <auxiliary auxtype="TargetSamplingVolume" auxvalue="LH2"/>
     <auxiliary auxtype="Color" auxvalue="blue"/>

--- a/src/remollGenpElastic.cc
+++ b/src/remollGenpElastic.cc
@@ -44,10 +44,10 @@ void remollGenpElastic::SamplePhysics(remollVertex *vert, remollEvent *evt){
 
     auto it = targVols.begin();
     if( targVols.size() > 0 ){
-	while( (*it).first->GetLogicalVolume()->GetMaterial()->GetName() != "LiquidHydrogen" 
+	while( (*it).first->GetLogicalVolume()->GetMaterial()->GetName() != "G4_lH2"
 		&& it != targVols.end() ){ it++; }
 
-	if( (*it).first->GetLogicalVolume()->GetMaterial()->GetName() != "LiquidHydrogen" ){
+	if( (*it).first->GetLogicalVolume()->GetMaterial()->GetName() != "G4_lH2" ){
 	    G4cerr << __FILE__ << " line " << __LINE__ << ": WARNING could not find target" << G4endl;
 	    bypass_target = true;
 	}


### PR DESCRIPTION
This PR reverts target material from LiquidHydrogen back to G4_lH2.
- The target material was changed from G4_lH2 to LiquidHydrogen in  #630 
- While testing latest develop branch, I saw significant decrease in quartz tile rates for physics generators. This issue wasn't present in earlier versions of develop branch (after PR623/624). I ran a quick comparison using 50k Moller events with identical random seeds, and the results show that LiquidHydrogen leads lower rate values.
- More simulations are needed to understand why switching to LiquidHydrogen caused this rate drop. Due to low slurm priority, I can't run full tests right now. So, reverting to G4_lH2 is the safer temporary solution until we can debug the issue.