### PR TITLE
Updated differential vacuum cylinder. 

### DIFF
--- a/geometry/target/subTargetRegion.gdml
+++ b/geometry/target/subTargetRegion.gdml
@@ -79,16 +79,16 @@
           rmin="0" rmax="451" z="concreteThickness+2.0"/>
 	  
     <polycone name = "bellows1USflange_solid" startphi="0" deltaphi="360" aunit="deg" lunit= "mm"> 
-	  <zplane rmin="149.23" rmax="184.15" z="-3427.73+4500" />  
-	  <zplane rmin="149.23" rmax="184.15" z="-3401.69+4500" /> 
-	  <zplane rmin="152.40" rmax="184.15" z="-3401.69+4500" />
-	  <zplane rmin="152.40" rmax="184.15" z="-3399.15+4500" />
+	  <zplane rmin="149.23" rmax="184.15" z="-3269.819+4500" />  
+	  <zplane rmin="149.23" rmax="184.15" z="-3243.779+4500" /> 
+	  <zplane rmin="152.40" rmax="184.15" z="-3243.779+4500" />
+	  <zplane rmin="152.40" rmax="184.15" z="-3241.239+4500" />
     </polycone>
 	  
     <polycone name = "bellows1_solid" startphi="0" deltaphi="360" aunit="deg" lunit= "mm"> 
-	  <zplane rmin="149.23" rmax="152.40" z="-3401.69+4500" />  
-	  <zplane rmin="149.23" rmax="152.40" z="-3343.58+4500" /> 
-	  <zplane rmin="149.23" rmax="190.50" z="-3343.58+4500" />
+	  <zplane rmin="149.23" rmax="152.40" z="-3243.779+4500" />  
+	  <zplane rmin="149.23" rmax="152.40" z="-3185.669+4500" /> 
+	  <zplane rmin="149.23" rmax="190.50" z="-3185.669+4500" />
 	  <zplane rmin="149.23" rmax="190.50" z="-3054.68+4500" />
 	  <zplane rmin="149.23" rmax="152.40" z="-3054.68+4500" />
 	  <zplane rmin="149.23" rmax="152.40" z="-2995.04+4500" />
@@ -203,7 +203,7 @@
 	             <!-- pipe from target exit window to bellow1 -->  
  <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="connecting_pipe_1"> 
       <zplane rmin="196.85/2.0" rmax="203.20/2.0" z="0"/> 
-      <zplane rmin="196.85/2.0" rmax="203.20/2.0" z="0-134.42"/> 
+      <zplane rmin="196.85/2.0" rmax="203.20/2.0" z="0-292.331"/> 
  </polycone>
  <polycone aunit="deg" startphi="0" deltaphi="360" lunit="mm" name="flange_1"> 
       <zplane rmin="190.50/2.0" rmax="368.30/2.0" z="0"/> 
@@ -515,12 +515,12 @@
 	    	 <!-- target exit window to beam pipe connection placement-->	    
     <physvol>
       <volumeref ref="connecting_pipe_volume_1"/>
-      <position name="pipe_pos_1" unit="mm" x="0.0" y="0.0" z="877.01+0.635+6.35+12.7+1.524+134.42"/>
+      <position name="pipe_pos_1" unit="mm" x="0.0" y="0.0" z="877.01+0.635+6.35+12.7+1.524+292.331"/>
     </physvol> 
     
     <physvol>
       <volumeref ref="flange_vol_1"/>
-      <position name="flange_pos_1" unit="mm" x="0.0" y="0.0" z="877.01+0.635+6.35+12.7+1.524+134.42+28.45"/>
+      <position name="flange_pos_1" unit="mm" x="0.0" y="0.0" z="1219.000"/>
     </physvol>	  
    
     </volume>


### PR DESCRIPTION
Updated differential vacuum cylinder. The blue pipe is extended to 1219mm. This now ranges from 864mm to 1219mm. The bellows1 is shrunk for this adjustment.
The pipe before the change
<img width="775" height="606" alt="diff_beam_pipe_before" src="https://github.com/user-attachments/assets/3a49ec9d-a7ca-45c7-a55d-7bb2be1ee551" />
The pipe after the change
<img width="760" height="607" alt="diff_beam_pipe_after" src="https://github.com/user-attachments/assets/108b103e-aec3-4b6f-acc5-f337d317ab8d" />
